### PR TITLE
Releasing 1.2.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,176 @@
-# git
-**/.gitignore
-**/*.orig
+#==================
+# Eclipse
+#==================
+# Pilfered shamelessly from: https://raw.githubusercontent.com/github/gitignore/master/Global/Eclipse.gitignore
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
 
-# intellij
-.idea/
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+#==================
+# Eclipse Patch
+#==================
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+#==================
+# JetBrains
+#==================
+# Original source: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# => updated to ignore .idea directory entirely
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+#==================
+# Intellij Patch
+#==================
+# Reference: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# Ignoring .idea and *.iml files (https://intellij-support.jetbrains.com/hc/en-us/articles/206544839)
 *.iml
+.idea
 
-# maven
-**/target/*
-**/*.versionsBackup
+#==================
+# Java
+#==================
+# Pilfered shamelessly from: https://github.com/github/gitignore/blob/master/Java.gitignore
+# Compiled class file
+*.class
 
-# eclipse
-**/.settings/*
-**/.classpath
-**/.project
+# Log file
+*.log
 
-# mac
-**/.DS_Store
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+#==================
+# Maven
+#==================
+# Pilfered shamelessly from: https://github.com/github/gitignore/blob/master/Maven.gitignore
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+
+#==================
+# MacOS
+#==================
+# Pilfered shamelessly from: https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unrelased
+### Fixed
+- N/A
+
 ## 1.2.18 - 2017-11-27
 
 ### Changed
@@ -18,15 +22,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Deprecated
 - Methods accepting passphrases as String are deprecated; use char[] instead
-
-## 1.2.17 - 2017-11-02
-
-### Added
-- Support for updating audit retention policy in Audit service
-- Support for archive storage tier, object rename and namespace metadata in Object Storage service
-- Support for fast clones of volumes in Block Storage service
-- Support for backup and restore in Database service
-- Support for sorting and filtering in list APIs in Core Services
 
 ## 1.2.17 - 2017-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Unreleased
-### Fixed
-- N/A
+## 1.2.18 - 2017-11-27
 
 ### Changed
-- N/A
+- Passphrases are now passed as char[] instead of as String
+- Requests are now buffered in memory by default, except by the ObjectStorageClient and ObjectStorageAsyncClient. This allows for better error messages on PUT and POST requests. If you do not want to buffer requests in memory, pass an instance of `com.oracle.bmc.http.DefaultConfigurator.NonBuffering` to the constructor of the client.
 
 ### Added
-- N/A
+- Support for VCN to VCN peering within region
+- Support option for second NIC on X7 bare metal instances
+- Support for user-managed boot volumes
+- Support for creating database from backup in Database service
+- Support for sort and filter in ListLoadBalancers method in Load Balancer Service
+
+### Deprecated
+- Methods accepting passphrases as String are deprecated; use char[] instead
+
+## 1.2.17 - 2017-11-02
+
+### Added
+- Support for updating audit retention policy in Audit service
+- Support for archive storage tier, object rename and namespace metadata in Object Storage service
+- Support for fast clones of volumes in Block Storage service
+- Support for backup and restore in Database service
+- Support for sorting and filtering in list APIs in Core Services
 
 ## 1.2.17 - 2017-11-02
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Oracle Cloud Infrastructure Java SDK
-[![Build Status](https://travis-ci.org/oracle/bmcs-java-sdk.svg?branch=master)](https://travis-ci.org/oracle/bmcs-java-sdk)
+[![Build Status](https://travis-ci.org/oracle/oci-java-sdk.svg?branch=master)](https://travis-ci.org/oracle/oci-java-sdk)
 
 ## About
 

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsyncClient.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.audit;
 
+import java.util.Locale;
 import com.oracle.bmc.audit.internal.http.*;
 import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
@@ -101,7 +102,7 @@ public class AuditAsyncClient implements AuditAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditClient.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.audit;
 
+import java.util.Locale;
 import com.oracle.bmc.audit.internal.http.*;
 import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
@@ -101,7 +102,7 @@ public class AuditClient implements Audit {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/AuditEvent.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/AuditEvent.java
@@ -206,24 +206,28 @@ public class AuditEvent {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AuditEvent o) {
-            return tenantId(o.getTenantId())
-                    .compartmentId(o.getCompartmentId())
-                    .eventId(o.getEventId())
-                    .eventSource(o.getEventSource())
-                    .eventType(o.getEventType())
-                    .eventTime(o.getEventTime())
-                    .principalId(o.getPrincipalId())
-                    .credentialId(o.getCredentialId())
-                    .requestAction(o.getRequestAction())
-                    .requestId(o.getRequestId())
-                    .requestAgent(o.getRequestAgent())
-                    .requestHeaders(o.getRequestHeaders())
-                    .requestOrigin(o.getRequestOrigin())
-                    .requestParameters(o.getRequestParameters())
-                    .requestResource(o.getRequestResource())
-                    .responseHeaders(o.getResponseHeaders())
-                    .responseStatus(o.getResponseStatus())
-                    .responseTime(o.getResponseTime());
+            Builder copiedBuilder =
+                    tenantId(o.getTenantId())
+                            .compartmentId(o.getCompartmentId())
+                            .eventId(o.getEventId())
+                            .eventSource(o.getEventSource())
+                            .eventType(o.getEventType())
+                            .eventTime(o.getEventTime())
+                            .principalId(o.getPrincipalId())
+                            .credentialId(o.getCredentialId())
+                            .requestAction(o.getRequestAction())
+                            .requestId(o.getRequestId())
+                            .requestAgent(o.getRequestAgent())
+                            .requestHeaders(o.getRequestHeaders())
+                            .requestOrigin(o.getRequestOrigin())
+                            .requestParameters(o.getRequestParameters())
+                            .requestResource(o.getRequestResource())
+                            .responseHeaders(o.getResponseHeaders())
+                            .responseStatus(o.getResponseStatus())
+                            .responseTime(o.getResponseTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -32,10 +32,11 @@ public enum Region {
     private static final String DEFAULT_ENDPOINT_FORMAT;
 
     static {
-        InputStream propertyStream =
-                Region.class.getClassLoader().getResourceAsStream("com/oracle/bmc/sdk.properties");
         Properties properties = new Properties();
-        try {
+        try (InputStream propertyStream =
+                Region.class
+                        .getClassLoader()
+                        .getResourceAsStream("com/oracle/bmc/sdk.properties")) {
             properties.load(propertyStream);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to load required properties file", e);

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/BasicAuthenticationDetailsProvider.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/BasicAuthenticationDetailsProvider.java
@@ -32,6 +32,16 @@ public interface BasicAuthenticationDetailsProvider extends AbstractAuthenticati
      * Returns the optional pass phrase for the (encrypted) private key.
      *
      * @return The pass phrase, or null if not applicable
+     *
+     * @deprecated Use getPassphraseCharacters instead
      */
+    @Deprecated
     String getPassPhrase();
+
+    /**
+     * Returns the optional pass phrase for the (encrypted) private key, as a character array.
+     *
+     * @return The pass phrase as character array, or null if not applicable
+     */
+    char[] getPassphraseCharacters();
 }

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider.java
@@ -72,14 +72,16 @@ public class ConfigFileAuthenticationDetailsProvider implements AuthenticationDe
 
         Supplier<InputStream> privateKeySupplier = new SimplePrivateKeySupplier(pemFilePath);
 
-        this.delegate =
+        SimpleAuthenticationDetailsProvider.SimpleAuthenticationDetailsProviderBuilder builder =
                 SimpleAuthenticationDetailsProvider.builder()
                         .fingerprint(fingerprint)
-                        .passPhrase(passPhrase)
                         .privateKeySupplier(privateKeySupplier)
                         .tenantId(tenantId)
-                        .userId(userId)
-                        .build();
+                        .userId(userId);
+        if (passPhrase != null) {
+            builder = builder.passphraseCharacters(passPhrase.toCharArray());
+        }
+        this.delegate = builder.build();
     }
 
     @Override
@@ -97,9 +99,15 @@ public class ConfigFileAuthenticationDetailsProvider implements AuthenticationDe
         return this.delegate.getUserId();
     }
 
+    @Deprecated
     @Override
     public String getPassPhrase() {
         return this.delegate.getPassPhrase();
+    }
+
+    @Override
+    public char[] getPassphraseCharacters() {
+        return this.delegate.getPassphraseCharacters();
     }
 
     @Override

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/SimpleAuthenticationDetailsProvider.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/SimpleAuthenticationDetailsProvider.java
@@ -4,6 +4,7 @@
 package com.oracle.bmc.auth;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import com.google.common.base.Supplier;
 
@@ -27,7 +28,7 @@ public class SimpleAuthenticationDetailsProvider extends CustomerAuthenticationD
     private final String fingerprint;
 
     @Getter(onMethod = @__({@Override}))
-    private final String passPhrase;
+    private final char[] passphraseCharacters;
 
     private final Supplier<InputStream> privateKeySupplier;
 
@@ -36,29 +37,41 @@ public class SimpleAuthenticationDetailsProvider extends CustomerAuthenticationD
         return privateKeySupplier.get();
     }
 
+    @Deprecated
+    @Override
+    public String getPassPhrase() {
+        return passphraseCharacters != null ? new String(passphraseCharacters) : null;
+    }
+
     @Override
     public String toString() {
         // show that there was a passphrase, but not what it was
         return String.format(
-                "SimpleAuthenticationDetailsProvider(tenantId=%s, userId=%s, fingerprint=%s, passPhrase=%s, privateKeySupplier=%s)",
+                "SimpleAuthenticationDetailsProvider(tenantId=%s, userId=%s, fingerprint=%s, passphraseCharacters=%s, privateKeySupplier=%s)",
                 tenantId,
                 userId,
                 fingerprint,
-                passPhrase != null ? "<provided>" : passPhrase,
+                passphraseCharacters != null ? "<provided>" : passphraseCharacters,
                 privateKeySupplier);
     }
 
     public static class SimpleAuthenticationDetailsProviderBuilder {
+
+        // want to provide both passPhrase(String) and passphraseCharacters(char[])
+        public SimpleAuthenticationDetailsProviderBuilder passPhrase(String passPhrase) {
+            return passphraseCharacters(passPhrase != null ? passPhrase.toCharArray() : null);
+        }
+
         // toString overridden as the default lombok builder prints all builder properties
         // including the passphrase.  manually overriding to just show that there was a passphrase
         @Override
         public String toString() {
             return String.format(
-                    "SimpleAuthenticationDetailsProvider.SimpleAuthenticationDetailsProviderBuilder(tenantId=%s, userId=%s, fingerprint=%s, passPhrase=%s, privateKeySupplier=%s)",
+                    "SimpleAuthenticationDetailsProvider.SimpleAuthenticationDetailsProviderBuilder(tenantId=%s, userId=%s, fingerprint=%s, passphraseCharacters=%s, privateKeySupplier=%s)",
                     tenantId,
                     userId,
                     fingerprint,
-                    passPhrase != null ? "<provided>" : passPhrase,
+                    passphraseCharacters != null ? "<provided>" : passphraseCharacters,
                     privateKeySupplier);
         }
     }

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/HeaderUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/HeaderUtils.java
@@ -5,6 +5,7 @@ package com.oracle.bmc.http.internal;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map.Entry;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -31,9 +32,9 @@ public class HeaderUtils {
         }
         // NOTE: this multivaluedmap should be the case-insensitive-key version,
         // but opting to do a simple search instead.
-        String lowerCaseHeaderName = name.toLowerCase();
+        String lowerCaseHeaderName = name.toLowerCase(Locale.ROOT);
         for (Entry<String, List<String>> entry : headers.entrySet()) {
-            if (entry.getKey().toLowerCase().equals(lowerCaseHeaderName)) {
+            if (entry.getKey().toLowerCase(Locale.ROOT).equals(lowerCaseHeaderName)) {
                 return Optional.of(entry.getValue());
             }
         }

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/HttpDateUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/HttpDateUtils.java
@@ -99,7 +99,7 @@ public class HttpDateUtils {
     static Date parse(String headerName, String value) {
         // date and last-modified use 'HTTP-date' format, rfc2616:
         // https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html
-        String lowerCasedHeaderName = headerName.toLowerCase();
+        String lowerCasedHeaderName = headerName.toLowerCase(Locale.ROOT);
         if ("date".equals(lowerCasedHeaderName) || "last-modified".equals(lowerCasedHeaderName)) {
             Date date = tryParse(value, RFC2616_DATE_FORMATS.get());
             if (date == null) {

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
@@ -6,6 +6,7 @@ package com.oracle.bmc.http.internal;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.GenericType;
@@ -159,7 +160,8 @@ public class ResponseHelper {
 
                 T entity = response.readEntity(entityType);
                 String contentType = response.getHeaderString("content-type");
-                if (contentType != null && contentType.toLowerCase().equals("application/json")) {
+                if (contentType != null
+                        && contentType.toLowerCase(Locale.ROOT).equals("application/json")) {
                     // HACK alert, if the entry is a string, and it's mime was
                     // application/json, jackson's provider won't deserialize it since
                     // the default provider takes presidence. Need to explicitly remove

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/RestClientFactoryBuilder.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/RestClientFactoryBuilder.java
@@ -16,6 +16,13 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RestClientFactoryBuilder {
+    public static final DefaultConfigurator DEFAULT_CONFIGURATOR = new DefaultConfigurator();
+
+    /**
+     * This is the client configurator used if a caller passes <code>null</code> to
+     * {@link RestClientFactoryBuilder#clientConfigurator(ClientConfigurator)}.
+     */
+    private ClientConfigurator defaultConfigurator = DEFAULT_CONFIGURATOR;
     private ClientConfigurator clientConfigurator;
 
     /**
@@ -27,7 +34,21 @@ public class RestClientFactoryBuilder {
     }
 
     /**
-     * Sets the ClientConfigurator to use, or null to use the {@link DefaultConfigurator}.
+     * Sets the default ClientConfigurator.
+     * @param defaultConfigurator the {@link ClientConfigurator} used if null is passed to the clientConfigurator method
+     * @return The builder.
+     */
+    public RestClientFactoryBuilder defaultConfigurator(ClientConfigurator defaultConfigurator) {
+        if (defaultConfigurator != null) {
+            defaultConfigurator = defaultConfigurator;
+        } else {
+            defaultConfigurator = DEFAULT_CONFIGURATOR;
+        }
+        return this;
+    }
+
+    /**
+     * Sets the ClientConfigurator to use, or null to use the default client configurator.
      *
      * @param clientConfigurator The client configurator to use.
      * @return The builder.
@@ -45,7 +66,7 @@ public class RestClientFactoryBuilder {
      */
     public RestClientFactory build() {
         ClientConfigurator clientConfigurator =
-                MoreObjects.firstNonNull(this.clientConfigurator, new DefaultConfigurator());
+                MoreObjects.firstNonNull(this.clientConfigurator, defaultConfigurator);
 
         return new RestClientFactory(clientConfigurator);
     }

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/DefaultRequestSignerFactory.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/DefaultRequestSignerFactory.java
@@ -96,7 +96,7 @@ public class DefaultRequestSignerFactory implements RequestSignerFactory {
                 public Optional<RSAPrivateKey> getKey(String keyId) {
                     return new PEMFileRSAPrivateKeySupplier(
                                     authenticationDetailsProvider.getPrivateKey(),
-                                    authenticationDetailsProvider.getPassPhrase())
+                                    authenticationDetailsProvider.getPassphraseCharacters())
                             .getKey(keyId);
                 }
             };
@@ -105,7 +105,7 @@ public class DefaultRequestSignerFactory implements RequestSignerFactory {
         // else parse once now and return a fixed supplier
         return new PEMFileRSAPrivateKeySupplier(
                 authenticationDetailsProvider.getPrivateKey(),
-                authenticationDetailsProvider.getPassPhrase());
+                authenticationDetailsProvider.getPassphraseCharacters());
     }
 
     private static AuthCachingPolicy getAuthCachingPolicy(

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/PEMFileRSAPrivateKeySupplier.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/PEMFileRSAPrivateKeySupplier.java
@@ -54,11 +54,11 @@ public class PEMFileRSAPrivateKeySupplier implements KeySupplier<RSAPrivateKey> 
      *
      * @param inputStream
      *            the path to the RSA private key
-     * @param password
+     * @param passphraseCharacters
      *            the passphrase of the private key, optional
      */
     public PEMFileRSAPrivateKeySupplier(
-            @Nonnull final InputStream inputStream, @Nullable final String password) {
+            @Nonnull final InputStream inputStream, @Nullable final char[] passphraseCharacters) {
         try {
             LOG.debug("Initializing private key");
 
@@ -70,10 +70,10 @@ public class PEMFileRSAPrivateKeySupplier implements KeySupplier<RSAPrivateKey> 
 
                 if (object instanceof PEMEncryptedKeyPair) {
                     Preconditions.checkNotNull(
-                            password, "The provided private key requires a passphrase");
+                            passphraseCharacters, "The provided private key requires a passphrase");
 
                     PEMDecryptorProvider decProv =
-                            new JcePEMDecryptorProviderBuilder().build(password.toCharArray());
+                            new JcePEMDecryptorProviderBuilder().build(passphraseCharacters);
                     try {
                         keyInfo =
                                 ((PEMEncryptedKeyPair) object)

--- a/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/signing/internal/RequestSignerImpl.java
@@ -129,7 +129,7 @@ public class RequestSignerImpl implements RequestSigner {
             String keyId = keyIdSupplier.get();
             Version version = validateVersion(versionName, algorithm);
             final RSAPrivateKey key = getPrivateKey(keyId);
-            final String lowerHttpMethod = httpMethod.toLowerCase();
+            final String lowerHttpMethod = httpMethod.toLowerCase(Locale.ENGLISH);
             final String path = extractPath(uri);
 
             // 1) get the required headers that must be signed
@@ -213,7 +213,7 @@ public class RequestSignerImpl implements RequestSigner {
                 throw new RuntimeException(
                         "Expecting exactly one value for header " + entry.getKey());
             }
-            transformedMap.put(entry.getKey().toLowerCase(), entry.getValue().get(0));
+            transformedMap.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue().get(0));
         }
         return transformedMap;
     }
@@ -282,7 +282,7 @@ public class RequestSignerImpl implements RequestSigner {
                 missingHeaders.put(Constants.CONTENT_TYPE, Constants.JSON_CONTENT_TYPE);
             } else if (!existingHeaders
                     .get(Constants.CONTENT_TYPE)
-                    .toLowerCase()
+                    .toLowerCase(Locale.ROOT)
                     .equals(Constants.JSON_CONTENT_TYPE)) {
                 throw new IllegalArgumentException(
                         "Only 'application/json' supported for content type");

--- a/bmc-common/src/test/java/com/oracle/bmc/io/internal/WrappedFileInputStreamTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/io/internal/WrappedFileInputStreamTest.java
@@ -24,9 +24,9 @@ public class WrappedFileInputStreamTest {
         tmpFile = File.createTempFile("WrappedFileInputStreamTest", null);
         tmpFile.deleteOnExit();
 
-        FileOutputStream fos = new FileOutputStream(tmpFile);
-        fos.write(MESSAGE.getBytes());
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(tmpFile)) {
+            fos.write(MESSAGE.getBytes());
+        }
     }
 
     @After

--- a/bmc-common/src/test/java/com/oracle/bmc/util/StreamUtilsTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/util/StreamUtilsTest.java
@@ -25,8 +25,9 @@ public class StreamUtilsTest {
         File file = File.createTempFile("StreamUtilsTest", null);
         file.deleteOnExit();
 
-        InputStream stream = StreamUtils.toInputStream(file);
-        assertNotNull(stream);
+        try (InputStream stream = StreamUtils.toInputStream(file)) {
+            assertNotNull(stream);
+        }
 
         file.delete();
     }

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
@@ -73,6 +73,18 @@ public interface Blockstorage extends AutoCloseable {
     CreateVolumeBackupResponse createVolumeBackup(CreateVolumeBackupRequest request);
 
     /**
+     * Deletes the specified boot volume. The volume cannot have an active connection to an instance.
+     * To disconnect the boot volume from a connected instance, see
+     * [Disconnecting From a Boot Volume](https://docs.us-phoenix-1.oraclecloud.com/Content/Block/Tasks/deletingbootvolume.htm).
+     * **Warning:** All data on the boot volume will be permanently lost when the boot volume is deleted.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteBootVolumeResponse deleteBootVolume(DeleteBootVolumeRequest request);
+
+    /**
      * Deletes the specified volume. The volume cannot have an active connection to an instance.
      * To disconnect the volume from a connected instance, see
      * [Disconnecting From a Volume](https://docs.us-phoenix-1.oraclecloud.com/Content/Block/Tasks/disconnectingfromavolume.htm).
@@ -93,6 +105,14 @@ public interface Blockstorage extends AutoCloseable {
     DeleteVolumeBackupResponse deleteVolumeBackup(DeleteVolumeBackupRequest request);
 
     /**
+     * Gets information for the specified boot volume.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetBootVolumeResponse getBootVolume(GetBootVolumeRequest request);
+
+    /**
      * Gets information for the specified volume.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -107,6 +127,15 @@ public interface Blockstorage extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetVolumeBackupResponse getVolumeBackup(GetVolumeBackupRequest request);
+
+    /**
+     * Lists the boot volumes in the specified compartment and Availability Domain.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListBootVolumesResponse listBootVolumes(ListBootVolumesRequest request);
 
     /**
      * Lists the volume backups in the specified compartment. You can filter the results by volume.
@@ -125,6 +154,14 @@ public interface Blockstorage extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ListVolumesResponse listVolumes(ListVolumesRequest request);
+
+    /**
+     * Updates the specified boot volume's display name.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateBootVolumeResponse updateBootVolume(UpdateBootVolumeRequest request);
 
     /**
      * Updates the specified volume's display name.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
@@ -88,6 +88,25 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes the specified boot volume. The volume cannot have an active connection to an instance.
+     * To disconnect the boot volume from a connected instance, see
+     * [Disconnecting From a Boot Volume](https://docs.us-phoenix-1.oraclecloud.com/Content/Block/Tasks/deletingbootvolume.htm).
+     * **Warning:** All data on the boot volume will be permanently lost when the boot volume is deleted.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteBootVolumeResponse> deleteBootVolume(
+            DeleteBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteBootVolumeRequest, DeleteBootVolumeResponse>
+                    handler);
+
+    /**
      * Deletes the specified volume. The volume cannot have an active connection to an instance.
      * To disconnect the volume from a connected instance, see
      * [Disconnecting From a Volume](https://docs.us-phoenix-1.oraclecloud.com/Content/Block/Tasks/disconnectingfromavolume.htm).
@@ -123,6 +142,21 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets information for the specified boot volume.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetBootVolumeResponse> getBootVolume(
+            GetBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetBootVolumeRequest, GetBootVolumeResponse>
+                    handler);
+
+    /**
      * Gets information for the specified volume.
      *
      * @param request The request object containing the details to send
@@ -149,6 +183,22 @@ public interface BlockstorageAsync extends AutoCloseable {
     java.util.concurrent.Future<GetVolumeBackupResponse> getVolumeBackup(
             GetVolumeBackupRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetVolumeBackupRequest, GetVolumeBackupResponse>
+                    handler);
+
+    /**
+     * Lists the boot volumes in the specified compartment and Availability Domain.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBootVolumesResponse> listBootVolumes(
+            ListBootVolumesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListBootVolumesRequest, ListBootVolumesResponse>
                     handler);
 
     /**
@@ -182,6 +232,21 @@ public interface BlockstorageAsync extends AutoCloseable {
     java.util.concurrent.Future<ListVolumesResponse> listVolumes(
             ListVolumesRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListVolumesRequest, ListVolumesResponse> handler);
+
+    /**
+     * Updates the specified boot volume's display name.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateBootVolumeResponse> updateBootVolume(
+            UpdateBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateBootVolumeRequest, UpdateBootVolumeResponse>
+                    handler);
 
     /**
      * Updates the specified volume's display name.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -101,7 +102,7 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -164,6 +165,28 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteBootVolumeResponse> deleteBootVolume(
+            DeleteBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteBootVolumeRequest, DeleteBootVolumeResponse>
+                    handler) {
+        LOG.trace("Called async deleteBootVolume");
+        request = DeleteBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBootVolumeResponse>
+                transformer = DeleteBootVolumeConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteVolumeResponse> deleteVolume(
             DeleteVolumeRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeleteVolumeRequest, DeleteVolumeResponse>
@@ -209,6 +232,28 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetBootVolumeResponse> getBootVolume(
+            GetBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetBootVolumeRequest, GetBootVolumeResponse>
+                    handler) {
+        LOG.trace("Called async getBootVolume");
+        request = GetBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeResponse>
+                transformer = GetBootVolumeConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
     public java.util.concurrent.Future<GetVolumeResponse> getVolume(
             GetVolumeRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetVolumeRequest, GetVolumeResponse> handler) {
@@ -240,6 +285,28 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
                 GetVolumeBackupConverter.fromRequest(client, request);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetVolumeBackupResponse>
                 transformer = GetVolumeBackupConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListBootVolumesResponse> listBootVolumes(
+            ListBootVolumesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListBootVolumesRequest, ListBootVolumesResponse>
+                    handler) {
+        LOG.trace("Called async listBootVolumes");
+        request = ListBootVolumesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBootVolumesConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListBootVolumesResponse>
+                transformer = ListBootVolumesConverter.fromResponse();
 
         com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
                 new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
@@ -293,6 +360,28 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
 
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
                 client.get(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateBootVolumeResponse> updateBootVolume(
+            UpdateBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateBootVolumeRequest, UpdateBootVolumeResponse>
+                    handler) {
+        LOG.trace("Called async updateBootVolume");
+        request = UpdateBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBootVolumeResponse>
+                transformer = UpdateBootVolumeConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(ib, request.getUpdateBootVolumeDetails(), request, onSuccess, onError);
         return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -120,7 +121,7 @@ public class BlockstorageClient implements Blockstorage {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -165,6 +166,19 @@ public class BlockstorageClient implements Blockstorage {
     }
 
     @Override
+    public DeleteBootVolumeResponse deleteBootVolume(DeleteBootVolumeRequest request) {
+        LOG.trace("Called deleteBootVolume");
+        request = DeleteBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBootVolumeResponse>
+                transformer = DeleteBootVolumeConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.delete(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
     public DeleteVolumeResponse deleteVolume(DeleteVolumeRequest request) {
         LOG.trace("Called deleteVolume");
         request = DeleteVolumeConverter.interceptRequest(request);
@@ -187,6 +201,19 @@ public class BlockstorageClient implements Blockstorage {
                 transformer = DeleteVolumeBackupConverter.fromResponse();
 
         javax.ws.rs.core.Response response = client.delete(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public GetBootVolumeResponse getBootVolume(GetBootVolumeRequest request) {
+        LOG.trace("Called getBootVolume");
+        request = GetBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeResponse>
+                transformer = GetBootVolumeConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
         return transformer.apply(response);
     }
 
@@ -217,6 +244,19 @@ public class BlockstorageClient implements Blockstorage {
     }
 
     @Override
+    public ListBootVolumesResponse listBootVolumes(ListBootVolumesRequest request) {
+        LOG.trace("Called listBootVolumes");
+        request = ListBootVolumesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBootVolumesConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListBootVolumesResponse>
+                transformer = ListBootVolumesConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
     public ListVolumeBackupsResponse listVolumeBackups(ListVolumeBackupsRequest request) {
         LOG.trace("Called listVolumeBackups");
         request = ListVolumeBackupsConverter.interceptRequest(request);
@@ -239,6 +279,20 @@ public class BlockstorageClient implements Blockstorage {
                 transformer = ListVolumesConverter.fromResponse();
 
         javax.ws.rs.core.Response response = client.get(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public UpdateBootVolumeResponse updateBootVolume(UpdateBootVolumeRequest request) {
+        LOG.trace("Called updateBootVolume");
+        request = UpdateBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBootVolumeResponse>
+                transformer = UpdateBootVolumeConverter.fromResponse();
+
+        javax.ws.rs.core.Response response =
+                client.put(ib, request.getUpdateBootVolumeDetails(), request);
         return transformer.apply(response);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
@@ -25,6 +25,67 @@ public class BlockstorageWaiters {
      * @param targetState The desired state to wait for.
      * @return A new Waiter instance.
      */
+    public com.oracle.bmc.waiter.Waiter<GetBootVolumeRequest, GetBootVolumeResponse> forBootVolume(
+            GetBootVolumeRequest request,
+            com.oracle.bmc.core.model.BootVolume.LifecycleState targetState) {
+        return forBootVolume(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetState);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using the provided configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @param terminationStrategy The {@link TerminationStrategy} to use.
+     * @param delayStrategy The {@link DelayStrategy} to use.
+     * @return A new Waiter instance.
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBootVolumeRequest, GetBootVolumeResponse> forBootVolume(
+            GetBootVolumeRequest request,
+            com.oracle.bmc.core.model.BootVolume.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        return forBootVolume(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    // Helper method to create a new Waiter for BootVolume.
+    private com.oracle.bmc.waiter.Waiter<GetBootVolumeRequest, GetBootVolumeResponse> forBootVolume(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetBootVolumeRequest request,
+            final com.oracle.bmc.core.model.BootVolume.LifecycleState targetState) {
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetBootVolumeRequest, GetBootVolumeResponse>() {
+                            @Override
+                            public GetBootVolumeResponse apply(GetBootVolumeRequest request) {
+                                return client.getBootVolume(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetBootVolumeResponse>() {
+                            @Override
+                            public boolean apply(GetBootVolumeResponse response) {
+                                return response.getBootVolume().getLifecycleState() == targetState;
+                            }
+                        },
+                        targetState
+                                == com.oracle.bmc.core.model.BootVolume.LifecycleState.Terminated),
+                request);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using default configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @return A new Waiter instance.
+     */
     public com.oracle.bmc.waiter.Waiter<GetVolumeRequest, GetVolumeResponse> forVolume(
             GetVolumeRequest request, com.oracle.bmc.core.model.Volume.LifecycleState targetState) {
         return forVolume(

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
@@ -37,6 +37,15 @@ public interface Compute extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Attaches the specified boot volume to the specified instance.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AttachBootVolumeResponse attachBootVolume(AttachBootVolumeRequest request);
+
+    /**
      * Creates a secondary VNIC and attaches it to the specified instance.
      * For more information about secondary VNICs, see
      * [Virtual Network Interface Cards (VNICs)](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingVNICs.htm).
@@ -113,13 +122,11 @@ public interface Compute extends AutoCloseable {
     CreateImageResponse createImage(CreateImageRequest request);
 
     /**
-     * Creates a new serial console connection to the specified instance.
-     * Once the serial console connection has been created and is available,
-     * you connect to the serial console using an SSH client.
+     * Creates a new console connection to the specified instance.
+     * Once the console connection has been created and is available,
+     * you connect to the console using SSH.
      * <p>
-     * The default number of enabled serial console connections per tenancy is 10.
-     * <p>
-     * For more information about serial console access, see [Accessing the Serial Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
+     * For more information about console access, see [Accessing the Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -145,13 +152,25 @@ public interface Compute extends AutoCloseable {
     DeleteImageResponse deleteImage(DeleteImageRequest request);
 
     /**
-     * Deletes the specified serial console connection.
+     * Deletes the specified instance console connection.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
      */
     DeleteInstanceConsoleConnectionResponse deleteInstanceConsoleConnection(
             DeleteInstanceConsoleConnectionRequest request);
+
+    /**
+     * Detaches a boot volume from an instance. You must specify the OCID of the boot volume attachment.
+     * <p>
+     * This is an asynchronous operation. The attachment's `lifecycleState` will change to DETACHING temporarily
+     * until the attachment is completely removed.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DetachBootVolumeResponse detachBootVolume(DetachBootVolumeRequest request);
 
     /**
      * Detaches and deletes the specified secondary VNIC.
@@ -202,6 +221,14 @@ public interface Compute extends AutoCloseable {
     ExportImageResponse exportImage(ExportImageRequest request);
 
     /**
+     * Gets information about the specified boot volume attachment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetBootVolumeAttachmentResponse getBootVolumeAttachment(GetBootVolumeAttachmentRequest request);
+
+    /**
      * Shows the metadata for the specified console history.
      * See {@link #captureConsoleHistory(CaptureConsoleHistoryRequest) captureConsoleHistory}
      * for details about using the console history operations.
@@ -241,7 +268,7 @@ public interface Compute extends AutoCloseable {
     GetInstanceResponse getInstance(GetInstanceRequest request);
 
     /**
-     * Gets the specified serial console connection's information.
+     * Gets the specified instance console connection's information.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -339,6 +366,17 @@ public interface Compute extends AutoCloseable {
     LaunchInstanceResponse launchInstance(LaunchInstanceRequest request);
 
     /**
+     * Lists the boot volume attachments in the specified compartment. You can filter the
+     * list by specifying an instance OCID, boot volume OCID, or both.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListBootVolumeAttachmentsResponse listBootVolumeAttachments(
+            ListBootVolumeAttachmentsRequest request);
+
+    /**
      * Lists the console history metadata for the specified compartment or instance.
      *
      * @param request The request object containing the details to send
@@ -361,9 +399,9 @@ public interface Compute extends AutoCloseable {
     ListImagesResponse listImages(ListImagesRequest request);
 
     /**
-     * Lists the serial console connections for the specified compartment or instance.
+     * Lists the console connections for the specified compartment or instance.
      * <p>
-     * For more information about serial console access, see [Accessing the Serial Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
+     * For more information about console access, see [Accessing the Instance Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -419,6 +457,9 @@ public interface Compute extends AutoCloseable {
     /**
      * Terminates the specified instance. Any attached VNICs and volumes are automatically detached
      * when the instance terminates.
+     * <p>
+     * To preserve the boot volume associated with the instance, specify `true` for `PreserveBootVolumeQueryParam`.
+     * To delete the boot volume when the instance is deleted, specify `false` or do not specify a value for `PreserveBootVolumeQueryParam`.
      * <p>
      * This is an asynchronous operation. The instance's `lifecycleState` will change to TERMINATING temporarily
      * until the instance is completely removed.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
@@ -37,6 +37,22 @@ public interface ComputeAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Attaches the specified boot volume to the specified instance.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AttachBootVolumeResponse> attachBootVolume(
+            AttachBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<AttachBootVolumeRequest, AttachBootVolumeResponse>
+                    handler);
+
+    /**
      * Creates a secondary VNIC and attaches it to the specified instance.
      * For more information about secondary VNICs, see
      * [Virtual Network Interface Cards (VNICs)](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingVNICs.htm).
@@ -140,13 +156,11 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<CreateImageRequest, CreateImageResponse> handler);
 
     /**
-     * Creates a new serial console connection to the specified instance.
-     * Once the serial console connection has been created and is available,
-     * you connect to the serial console using an SSH client.
+     * Creates a new console connection to the specified instance.
+     * Once the console connection has been created and is available,
+     * you connect to the console using SSH.
      * <p>
-     * The default number of enabled serial console connections per tenancy is 10.
-     * <p>
-     * For more information about serial console access, see [Accessing the Serial Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
+     * For more information about console access, see [Accessing the Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -195,7 +209,7 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteImageRequest, DeleteImageResponse> handler);
 
     /**
-     * Deletes the specified serial console connection.
+     * Deletes the specified instance console connection.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -211,6 +225,25 @@ public interface ComputeAsync extends AutoCloseable {
                                     DeleteInstanceConsoleConnectionRequest,
                                     DeleteInstanceConsoleConnectionResponse>
                             handler);
+
+    /**
+     * Detaches a boot volume from an instance. You must specify the OCID of the boot volume attachment.
+     * <p>
+     * This is an asynchronous operation. The attachment's `lifecycleState` will change to DETACHING temporarily
+     * until the attachment is completely removed.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DetachBootVolumeResponse> detachBootVolume(
+            DetachBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DetachBootVolumeRequest, DetachBootVolumeResponse>
+                    handler);
 
     /**
      * Detaches and deletes the specified secondary VNIC.
@@ -280,6 +313,22 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ExportImageRequest, ExportImageResponse> handler);
 
     /**
+     * Gets information about the specified boot volume attachment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetBootVolumeAttachmentResponse> getBootVolumeAttachment(
+            GetBootVolumeAttachmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
+                    handler);
+
+    /**
      * Shows the metadata for the specified console history.
      * See {@link #captureConsoleHistory(CaptureConsoleHistoryRequest, Consumer, Consumer) captureConsoleHistory}
      * for details about using the console history operations.
@@ -346,7 +395,7 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetInstanceRequest, GetInstanceResponse> handler);
 
     /**
-     * Gets the specified serial console connection's information.
+     * Gets the specified instance console connection's information.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -491,6 +540,24 @@ public interface ComputeAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the boot volume attachments in the specified compartment. You can filter the
+     * list by specifying an instance OCID, boot volume OCID, or both.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBootVolumeAttachmentsResponse> listBootVolumeAttachments(
+            ListBootVolumeAttachmentsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListBootVolumeAttachmentsRequest, ListBootVolumeAttachmentsResponse>
+                    handler);
+
+    /**
      * Lists the console history metadata for the specified compartment or instance.
      *
      *
@@ -527,9 +594,9 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListImagesRequest, ListImagesResponse> handler);
 
     /**
-     * Lists the serial console connections for the specified compartment or instance.
+     * Lists the console connections for the specified compartment or instance.
      * <p>
-     * For more information about serial console access, see [Accessing the Serial Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
+     * For more information about console access, see [Accessing the Instance Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -623,6 +690,9 @@ public interface ComputeAsync extends AutoCloseable {
     /**
      * Terminates the specified instance. Any attached VNICs and volumes are automatically detached
      * when the instance terminates.
+     * <p>
+     * To preserve the boot volume associated with the instance, specify `true` for `PreserveBootVolumeQueryParam`.
+     * To delete the boot volume when the instance is deleted, specify `false` or do not specify a value for `PreserveBootVolumeQueryParam`.
      * <p>
      * This is an asynchronous operation. The instance's `lifecycleState` will change to TERMINATING temporarily
      * until the instance is completely removed.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -101,7 +102,7 @@ public class ComputeAsyncClient implements ComputeAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -115,6 +116,28 @@ public class ComputeAsyncClient implements ComputeAsync {
     @Override
     public void close() {
         client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<AttachBootVolumeResponse> attachBootVolume(
+            AttachBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<AttachBootVolumeRequest, AttachBootVolumeResponse>
+                    handler) {
+        LOG.trace("Called async attachBootVolume");
+        request = AttachBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AttachBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AttachBootVolumeResponse>
+                transformer = AttachBootVolumeConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, request.getAttachBootVolumeDetails(), request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 
     @Override
@@ -309,6 +332,28 @@ public class ComputeAsyncClient implements ComputeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DetachBootVolumeResponse> detachBootVolume(
+            DetachBootVolumeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DetachBootVolumeRequest, DetachBootVolumeResponse>
+                    handler) {
+        LOG.trace("Called async detachBootVolume");
+        request = DetachBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DetachBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DetachBootVolumeResponse>
+                transformer = DetachBootVolumeConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
     public java.util.concurrent.Future<DetachVnicResponse> detachVnic(
             DetachVnicRequest request,
             com.oracle.bmc.responses.AsyncHandler<DetachVnicRequest, DetachVnicResponse> handler) {
@@ -370,6 +415,29 @@ public class ComputeAsyncClient implements ComputeAsync {
 
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
                 client.post(ib, request.getExportImageDetails(), request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetBootVolumeAttachmentResponse> getBootVolumeAttachment(
+            GetBootVolumeAttachmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
+                    handler) {
+        LOG.trace("Called async getBootVolumeAttachment");
+        request = GetBootVolumeAttachmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBootVolumeAttachmentConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>
+                transformer = GetBootVolumeAttachmentConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
         return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 
@@ -601,6 +669,30 @@ public class ComputeAsyncClient implements ComputeAsync {
 
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
                 client.post(ib, request.getLaunchInstanceDetails(), request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListBootVolumeAttachmentsResponse> listBootVolumeAttachments(
+            ListBootVolumeAttachmentsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListBootVolumeAttachmentsRequest, ListBootVolumeAttachmentsResponse>
+                    handler) {
+        LOG.trace("Called async listBootVolumeAttachments");
+        request = ListBootVolumeAttachmentsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBootVolumeAttachmentsConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBootVolumeAttachmentsResponse>
+                transformer = ListBootVolumeAttachmentsConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
         return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -120,7 +121,7 @@ public class ComputeClient implements Compute {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -134,6 +135,20 @@ public class ComputeClient implements Compute {
     @Override
     public void close() {
         client.close();
+    }
+
+    @Override
+    public AttachBootVolumeResponse attachBootVolume(AttachBootVolumeRequest request) {
+        LOG.trace("Called attachBootVolume");
+        request = AttachBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AttachBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AttachBootVolumeResponse>
+                transformer = AttachBootVolumeConverter.fromResponse();
+
+        javax.ws.rs.core.Response response =
+                client.post(ib, request.getAttachBootVolumeDetails(), request);
+        return transformer.apply(response);
     }
 
     @Override
@@ -251,6 +266,19 @@ public class ComputeClient implements Compute {
     }
 
     @Override
+    public DetachBootVolumeResponse detachBootVolume(DetachBootVolumeRequest request) {
+        LOG.trace("Called detachBootVolume");
+        request = DetachBootVolumeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DetachBootVolumeConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DetachBootVolumeResponse>
+                transformer = DetachBootVolumeConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.delete(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
     public DetachVnicResponse detachVnic(DetachVnicRequest request) {
         LOG.trace("Called detachVnic");
         request = DetachVnicConverter.interceptRequest(request);
@@ -287,6 +315,20 @@ public class ComputeClient implements Compute {
 
         javax.ws.rs.core.Response response =
                 client.post(ib, request.getExportImageDetails(), request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public GetBootVolumeAttachmentResponse getBootVolumeAttachment(
+            GetBootVolumeAttachmentRequest request) {
+        LOG.trace("Called getBootVolumeAttachment");
+        request = GetBootVolumeAttachmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBootVolumeAttachmentConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>
+                transformer = GetBootVolumeAttachmentConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
         return transformer.apply(response);
     }
 
@@ -423,6 +465,21 @@ public class ComputeClient implements Compute {
 
         javax.ws.rs.core.Response response =
                 client.post(ib, request.getLaunchInstanceDetails(), request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public ListBootVolumeAttachmentsResponse listBootVolumeAttachments(
+            ListBootVolumeAttachmentsRequest request) {
+        LOG.trace("Called listBootVolumeAttachments");
+        request = ListBootVolumeAttachmentsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBootVolumeAttachmentsConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBootVolumeAttachmentsResponse>
+                transformer = ListBootVolumeAttachmentsConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
         return transformer.apply(response);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeWaiters.java
@@ -25,6 +25,75 @@ public class ComputeWaiters {
      * @param targetState The desired state to wait for.
      * @return A new Waiter instance.
      */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
+            forBootVolumeAttachment(
+                    GetBootVolumeAttachmentRequest request,
+                    com.oracle.bmc.core.model.BootVolumeAttachment.LifecycleState targetState) {
+        return forBootVolumeAttachment(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetState);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using the provided configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @param terminationStrategy The {@link TerminationStrategy} to use.
+     * @param delayStrategy The {@link DelayStrategy} to use.
+     * @return A new Waiter instance.
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
+            forBootVolumeAttachment(
+                    GetBootVolumeAttachmentRequest request,
+                    com.oracle.bmc.core.model.BootVolumeAttachment.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        return forBootVolumeAttachment(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    // Helper method to create a new Waiter for BootVolumeAttachment.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
+            forBootVolumeAttachment(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetBootVolumeAttachmentRequest request,
+                    final com.oracle.bmc.core.model.BootVolumeAttachment.LifecycleState
+                            targetState) {
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>() {
+                            @Override
+                            public GetBootVolumeAttachmentResponse apply(
+                                    GetBootVolumeAttachmentRequest request) {
+                                return client.getBootVolumeAttachment(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetBootVolumeAttachmentResponse>() {
+                            @Override
+                            public boolean apply(GetBootVolumeAttachmentResponse response) {
+                                return response.getBootVolumeAttachment().getLifecycleState()
+                                        == targetState;
+                            }
+                        },
+                        false),
+                request);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using default configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @return A new Waiter instance.
+     */
     public com.oracle.bmc.waiter.Waiter<GetConsoleHistoryRequest, GetConsoleHistoryResponse>
             forConsoleHistory(
                     GetConsoleHistoryRequest request,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -37,6 +37,23 @@ public interface VirtualNetwork extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Connects this local peering gateway (LPG) to another one in the same region.
+     * <p>
+     * This operation must be called by the VCN administrator who is designated as
+     * the *requestor* in the peering relationship. The *acceptor* must implement
+     * an Identity and Access Management (IAM) policy that gives the requestor permission
+     * to connect to LPGs in the acceptor's compartment. Without that permission, this
+     * operation will fail. For more information, see
+     * [VCN Peering](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/VCNpeering.htm).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ConnectLocalPeeringGatewaysResponse connectLocalPeeringGateways(
+            ConnectLocalPeeringGatewaysRequest request);
+
+    /**
      * Creates a new virtual Customer-Premises Equipment (CPE) object in the specified compartment. For
      * more information, see [IPSec VPNs](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingIPsec.htm).
      * <p>
@@ -230,6 +247,16 @@ public interface VirtualNetwork extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     CreateInternetGatewayResponse createInternetGateway(CreateInternetGatewayRequest request);
+
+    /**
+     * Creates a new local peering gateway (LPG) for the specified VCN.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateLocalPeeringGatewayResponse createLocalPeeringGateway(
+            CreateLocalPeeringGatewayRequest request);
 
     /**
      * Creates a secondary private IP for the specified VNIC.
@@ -490,6 +517,19 @@ public interface VirtualNetwork extends AutoCloseable {
     DeleteInternetGatewayResponse deleteInternetGateway(DeleteInternetGatewayRequest request);
 
     /**
+     * Deletes the specified local peering gateway (LPG).
+     * <p>
+     * This is an asynchronous operation; the local peering gateway's `lifecycleState` changes to TERMINATING temporarily
+     * until the local peering gateway is completely removed.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteLocalPeeringGatewayResponse deleteLocalPeeringGateway(
+            DeleteLocalPeeringGatewayRequest request);
+
+    /**
      * Unassigns and deletes the specified private IP. You must
      * specify the object's OCID. The private IP address is returned to
      * the subnet's pool of available addresses.
@@ -676,6 +716,14 @@ public interface VirtualNetwork extends AutoCloseable {
     GetInternetGatewayResponse getInternetGateway(GetInternetGatewayRequest request);
 
     /**
+     * Gets the specified local peering gateway's information.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetLocalPeeringGatewayResponse getLocalPeeringGateway(GetLocalPeeringGatewayRequest request);
+
+    /**
      * Gets the specified private IP. You must specify the object's OCID.
      * Alternatively, you can get the object by using
      * {@link #listPrivateIps(ListPrivateIpsRequest) listPrivateIps}
@@ -856,6 +904,17 @@ public interface VirtualNetwork extends AutoCloseable {
     ListInternetGatewaysResponse listInternetGateways(ListInternetGatewaysRequest request);
 
     /**
+     * Lists the local peering gateways (LPGs) for the specified VCN and compartment
+     * (the LPG's compartment).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListLocalPeeringGatewaysResponse listLocalPeeringGateways(
+            ListLocalPeeringGatewaysRequest request);
+
+    /**
      * Lists the {@link PrivateIp} objects based
      * on one of these filters:
      * <p>
@@ -1017,6 +1076,16 @@ public interface VirtualNetwork extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     UpdateInternetGatewayResponse updateInternetGateway(UpdateInternetGatewayRequest request);
+
+    /**
+     * Updates the specified local peering gateway (LPG).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateLocalPeeringGatewayResponse updateLocalPeeringGateway(
+            UpdateLocalPeeringGatewayRequest request);
 
     /**
      * Updates the specified private IP. You must specify the object's OCID.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -37,6 +37,30 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Connects this local peering gateway (LPG) to another one in the same region.
+     * <p>
+     * This operation must be called by the VCN administrator who is designated as
+     * the *requestor* in the peering relationship. The *acceptor* must implement
+     * an Identity and Access Management (IAM) policy that gives the requestor permission
+     * to connect to LPGs in the acceptor's compartment. Without that permission, this
+     * operation will fail. For more information, see
+     * [VCN Peering](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/VCNpeering.htm).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ConnectLocalPeeringGatewaysResponse> connectLocalPeeringGateways(
+            ConnectLocalPeeringGatewaysRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ConnectLocalPeeringGatewaysRequest, ConnectLocalPeeringGatewaysResponse>
+                    handler);
+
+    /**
      * Creates a new virtual Customer-Premises Equipment (CPE) object in the specified compartment. For
      * more information, see [IPSec VPNs](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingIPsec.htm).
      * <p>
@@ -289,6 +313,23 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             CreateInternetGatewayRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             CreateInternetGatewayRequest, CreateInternetGatewayResponse>
+                    handler);
+
+    /**
+     * Creates a new local peering gateway (LPG) for the specified VCN.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateLocalPeeringGatewayResponse> createLocalPeeringGateway(
+            CreateLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateLocalPeeringGatewayRequest, CreateLocalPeeringGatewayResponse>
                     handler);
 
     /**
@@ -653,6 +694,26 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes the specified local peering gateway (LPG).
+     * <p>
+     * This is an asynchronous operation; the local peering gateway's `lifecycleState` changes to TERMINATING temporarily
+     * until the local peering gateway is completely removed.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteLocalPeeringGatewayResponse> deleteLocalPeeringGateway(
+            DeleteLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteLocalPeeringGatewayRequest, DeleteLocalPeeringGatewayResponse>
+                    handler);
+
+    /**
      * Unassigns and deletes the specified private IP. You must
      * specify the object's OCID. The private IP address is returned to
      * the subnet's pool of available addresses.
@@ -974,6 +1035,22 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets the specified local peering gateway's information.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetLocalPeeringGatewayResponse> getLocalPeeringGateway(
+            GetLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>
+                    handler);
+
+    /**
      * Gets the specified private IP. You must specify the object's OCID.
      * Alternatively, you can get the object by using
      * {@link #listPrivateIps(ListPrivateIpsRequest, Consumer, Consumer) listPrivateIps}
@@ -1285,6 +1362,24 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the local peering gateways (LPGs) for the specified VCN and compartment
+     * (the LPG's compartment).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListLocalPeeringGatewaysResponse> listLocalPeeringGateways(
+            ListLocalPeeringGatewaysRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListLocalPeeringGatewaysRequest, ListLocalPeeringGatewaysResponse>
+                    handler);
+
+    /**
      * Lists the {@link PrivateIp} objects based
      * on one of these filters:
      * <p>
@@ -1556,6 +1651,23 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             UpdateInternetGatewayRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateInternetGatewayRequest, UpdateInternetGatewayResponse>
+                    handler);
+
+    /**
+     * Updates the specified local peering gateway (LPG).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateLocalPeeringGatewayResponse> updateLocalPeeringGateway(
+            UpdateLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateLocalPeeringGatewayRequest, UpdateLocalPeeringGatewayResponse>
                     handler);
 
     /**

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -101,7 +102,7 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -115,6 +116,37 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     @Override
     public void close() {
         client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ConnectLocalPeeringGatewaysResponse>
+            connectLocalPeeringGateways(
+                    ConnectLocalPeeringGatewaysRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ConnectLocalPeeringGatewaysRequest,
+                                    ConnectLocalPeeringGatewaysResponse>
+                            handler) {
+        LOG.trace("Called async connectLocalPeeringGateways");
+        request = ConnectLocalPeeringGatewaysConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ConnectLocalPeeringGatewaysConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ConnectLocalPeeringGatewaysResponse>
+                transformer = ConnectLocalPeeringGatewaysConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        request.getConnectLocalPeeringGatewaysDetails(),
+                        request,
+                        onSuccess,
+                        onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 
     @Override
@@ -303,6 +335,35 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
                 client.post(
                         ib, request.getCreateInternetGatewayDetails(), request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateLocalPeeringGatewayResponse> createLocalPeeringGateway(
+            CreateLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateLocalPeeringGatewayRequest, CreateLocalPeeringGatewayResponse>
+                    handler) {
+        LOG.trace("Called async createLocalPeeringGateway");
+        request = CreateLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateLocalPeeringGatewayResponse>
+                transformer = CreateLocalPeeringGatewayConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        request.getCreateLocalPeeringGatewayDetails(),
+                        request,
+                        onSuccess,
+                        onError);
         return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 
@@ -610,6 +671,30 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
                 DeleteInternetGatewayConverter.fromRequest(client, request);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteInternetGatewayResponse>
                 transformer = DeleteInternetGatewayConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteLocalPeeringGatewayResponse> deleteLocalPeeringGateway(
+            DeleteLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteLocalPeeringGatewayRequest, DeleteLocalPeeringGatewayResponse>
+                    handler) {
+        LOG.trace("Called async deleteLocalPeeringGateway");
+        request = DeleteLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteLocalPeeringGatewayResponse>
+                transformer = DeleteLocalPeeringGatewayConverter.fromResponse();
 
         com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
                 new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
@@ -1033,6 +1118,29 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetLocalPeeringGatewayResponse> getLocalPeeringGateway(
+            GetLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>
+                    handler) {
+        LOG.trace("Called async getLocalPeeringGateway");
+        request = GetLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetLocalPeeringGatewayResponse>
+                transformer = GetLocalPeeringGatewayConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
     public java.util.concurrent.Future<GetPrivateIpResponse> getPrivateIp(
             GetPrivateIpRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetPrivateIpRequest, GetPrivateIpResponse>
@@ -1440,6 +1548,29 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListLocalPeeringGatewaysResponse> listLocalPeeringGateways(
+            ListLocalPeeringGatewaysRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListLocalPeeringGatewaysRequest, ListLocalPeeringGatewaysResponse>
+                    handler) {
+        LOG.trace("Called async listLocalPeeringGateways");
+        request = ListLocalPeeringGatewaysConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListLocalPeeringGatewaysConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListLocalPeeringGatewaysResponse>
+                transformer = ListLocalPeeringGatewaysConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
     public java.util.concurrent.Future<ListPrivateIpsResponse> listPrivateIps(
             ListPrivateIpsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListPrivateIpsRequest, ListPrivateIpsResponse>
@@ -1783,6 +1914,35 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
                 client.put(
                         ib, request.getUpdateInternetGatewayDetails(), request, onSuccess, onError);
+        return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateLocalPeeringGatewayResponse> updateLocalPeeringGateway(
+            UpdateLocalPeeringGatewayRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateLocalPeeringGatewayRequest, UpdateLocalPeeringGatewayResponse>
+                    handler) {
+        LOG.trace("Called async updateLocalPeeringGateway");
+        request = UpdateLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateLocalPeeringGatewayResponse>
+                transformer = UpdateLocalPeeringGatewayConverter.fromResponse();
+
+        com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                new com.oracle.bmc.http.internal.SuccessConsumer<>(handler, transformer, request);
+        com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                new com.oracle.bmc.http.internal.ErrorConsumer<>(handler, request);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        request.getUpdateLocalPeeringGatewayDetails(),
+                        request,
+                        onSuccess,
+                        onError);
         return new com.oracle.bmc.util.internal.TransformingFuture<>(responseFuture, transformer);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.core;
 
+import java.util.Locale;
 import com.oracle.bmc.core.internal.http.*;
 import com.oracle.bmc.core.requests.*;
 import com.oracle.bmc.core.responses.*;
@@ -120,7 +121,7 @@ public class VirtualNetworkClient implements VirtualNetwork {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);
@@ -134,6 +135,22 @@ public class VirtualNetworkClient implements VirtualNetwork {
     @Override
     public void close() {
         client.close();
+    }
+
+    @Override
+    public ConnectLocalPeeringGatewaysResponse connectLocalPeeringGateways(
+            ConnectLocalPeeringGatewaysRequest request) {
+        LOG.trace("Called connectLocalPeeringGateways");
+        request = ConnectLocalPeeringGatewaysConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ConnectLocalPeeringGatewaysConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ConnectLocalPeeringGatewaysResponse>
+                transformer = ConnectLocalPeeringGatewaysConverter.fromResponse();
+
+        javax.ws.rs.core.Response response =
+                client.post(ib, request.getConnectLocalPeeringGatewaysDetails(), request);
+        return transformer.apply(response);
     }
 
     @Override
@@ -248,6 +265,22 @@ public class VirtualNetworkClient implements VirtualNetwork {
 
         javax.ws.rs.core.Response response =
                 client.post(ib, request.getCreateInternetGatewayDetails(), request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public CreateLocalPeeringGatewayResponse createLocalPeeringGateway(
+            CreateLocalPeeringGatewayRequest request) {
+        LOG.trace("Called createLocalPeeringGateway");
+        request = CreateLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateLocalPeeringGatewayResponse>
+                transformer = CreateLocalPeeringGatewayConverter.fromResponse();
+
+        javax.ws.rs.core.Response response =
+                client.post(ib, request.getCreateLocalPeeringGatewayDetails(), request);
         return transformer.apply(response);
     }
 
@@ -437,6 +470,21 @@ public class VirtualNetworkClient implements VirtualNetwork {
                 DeleteInternetGatewayConverter.fromRequest(client, request);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteInternetGatewayResponse>
                 transformer = DeleteInternetGatewayConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.delete(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public DeleteLocalPeeringGatewayResponse deleteLocalPeeringGateway(
+            DeleteLocalPeeringGatewayRequest request) {
+        LOG.trace("Called deleteLocalPeeringGateway");
+        request = DeleteLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteLocalPeeringGatewayResponse>
+                transformer = DeleteLocalPeeringGatewayConverter.fromResponse();
 
         javax.ws.rs.core.Response response = client.delete(ib, request);
         return transformer.apply(response);
@@ -684,6 +732,20 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public GetLocalPeeringGatewayResponse getLocalPeeringGateway(
+            GetLocalPeeringGatewayRequest request) {
+        LOG.trace("Called getLocalPeeringGateway");
+        request = GetLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetLocalPeeringGatewayResponse>
+                transformer = GetLocalPeeringGatewayConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
     public GetPrivateIpResponse getPrivateIp(GetPrivateIpRequest request) {
         LOG.trace("Called getPrivateIp");
         request = GetPrivateIpConverter.interceptRequest(request);
@@ -925,6 +987,20 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public ListLocalPeeringGatewaysResponse listLocalPeeringGateways(
+            ListLocalPeeringGatewaysRequest request) {
+        LOG.trace("Called listLocalPeeringGateways");
+        request = ListLocalPeeringGatewaysConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListLocalPeeringGatewaysConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListLocalPeeringGatewaysResponse>
+                transformer = ListLocalPeeringGatewaysConverter.fromResponse();
+
+        javax.ws.rs.core.Response response = client.get(ib, request);
+        return transformer.apply(response);
+    }
+
+    @Override
     public ListPrivateIpsResponse listPrivateIps(ListPrivateIpsRequest request) {
         LOG.trace("Called listPrivateIps");
         request = ListPrivateIpsConverter.interceptRequest(request);
@@ -1127,6 +1203,22 @@ public class VirtualNetworkClient implements VirtualNetwork {
 
         javax.ws.rs.core.Response response =
                 client.put(ib, request.getUpdateInternetGatewayDetails(), request);
+        return transformer.apply(response);
+    }
+
+    @Override
+    public UpdateLocalPeeringGatewayResponse updateLocalPeeringGateway(
+            UpdateLocalPeeringGatewayRequest request) {
+        LOG.trace("Called updateLocalPeeringGateway");
+        request = UpdateLocalPeeringGatewayConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateLocalPeeringGatewayConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateLocalPeeringGatewayResponse>
+                transformer = UpdateLocalPeeringGatewayConverter.fromResponse();
+
+        javax.ws.rs.core.Response response =
+                client.put(ib, request.getUpdateLocalPeeringGatewayDetails(), request);
         return transformer.apply(response);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
@@ -478,6 +478,77 @@ public class VirtualNetworkWaiters {
      * @param targetState The desired state to wait for.
      * @return A new Waiter instance.
      */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>
+            forLocalPeeringGateway(
+                    GetLocalPeeringGatewayRequest request,
+                    com.oracle.bmc.core.model.LocalPeeringGateway.LifecycleState targetState) {
+        return forLocalPeeringGateway(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetState);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using the provided configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @param terminationStrategy The {@link TerminationStrategy} to use.
+     * @param delayStrategy The {@link DelayStrategy} to use.
+     * @return A new Waiter instance.
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>
+            forLocalPeeringGateway(
+                    GetLocalPeeringGatewayRequest request,
+                    com.oracle.bmc.core.model.LocalPeeringGateway.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        return forLocalPeeringGateway(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    // Helper method to create a new Waiter for LocalPeeringGateway.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>
+            forLocalPeeringGateway(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetLocalPeeringGatewayRequest request,
+                    final com.oracle.bmc.core.model.LocalPeeringGateway.LifecycleState
+                            targetState) {
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetLocalPeeringGatewayRequest, GetLocalPeeringGatewayResponse>() {
+                            @Override
+                            public GetLocalPeeringGatewayResponse apply(
+                                    GetLocalPeeringGatewayRequest request) {
+                                return client.getLocalPeeringGateway(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetLocalPeeringGatewayResponse>() {
+                            @Override
+                            public boolean apply(GetLocalPeeringGatewayResponse response) {
+                                return response.getLocalPeeringGateway().getLifecycleState()
+                                        == targetState;
+                            }
+                        },
+                        targetState
+                                == com.oracle.bmc.core.model.LocalPeeringGateway.LifecycleState
+                                        .Terminated),
+                request);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using default configuration.
+     *
+     * @param request The request to send.
+     * @param targetState The desired state to wait for.
+     * @return A new Waiter instance.
+     */
     public com.oracle.bmc.waiter.Waiter<GetRouteTableRequest, GetRouteTableResponse> forRouteTable(
             GetRouteTableRequest request,
             com.oracle.bmc.core.model.RouteTable.LifecycleState targetState) {

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/AttachBootVolumeConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/AttachBootVolumeConverter.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class AttachBootVolumeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static AttachBootVolumeRequest interceptRequest(AttachBootVolumeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, AttachBootVolumeRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getAttachBootVolumeDetails() == null) {
+            throw new NullPointerException("attachBootVolumeDetails is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("bootVolumeAttachments");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, AttachBootVolumeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, AttachBootVolumeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, AttachBootVolumeResponse>() {
+                            @Override
+                            public AttachBootVolumeResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for AttachBootVolumeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BootVolumeAttachment>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BootVolumeAttachment.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BootVolumeAttachment>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                AttachBootVolumeResponse.Builder builder =
+                                        AttachBootVolumeResponse.builder();
+
+                                builder.bootVolumeAttachment(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                AttachBootVolumeResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ConnectLocalPeeringGatewaysConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ConnectLocalPeeringGatewaysConverter.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ConnectLocalPeeringGatewaysConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ConnectLocalPeeringGatewaysRequest interceptRequest(
+            ConnectLocalPeeringGatewaysRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ConnectLocalPeeringGatewaysRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getLocalPeeringGatewayId() == null) {
+            throw new NullPointerException("localPeeringGatewayId is required");
+        }
+
+        if (request.getConnectLocalPeeringGatewaysDetails() == null) {
+            throw new NullPointerException("connectLocalPeeringGatewaysDetails is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("localPeeringGateways")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLocalPeeringGatewayId()))
+                        .path("actions")
+                        .path("connect");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ConnectLocalPeeringGatewaysResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ConnectLocalPeeringGatewaysResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ConnectLocalPeeringGatewaysResponse>() {
+                            @Override
+                            public ConnectLocalPeeringGatewaysResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ConnectLocalPeeringGatewaysResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ConnectLocalPeeringGatewaysResponse.Builder builder =
+                                        ConnectLocalPeeringGatewaysResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ConnectLocalPeeringGatewaysResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateLocalPeeringGatewayConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateLocalPeeringGatewayConverter.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateLocalPeeringGatewayConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateLocalPeeringGatewayRequest interceptRequest(
+            CreateLocalPeeringGatewayRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateLocalPeeringGatewayRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getCreateLocalPeeringGatewayDetails() == null) {
+            throw new NullPointerException("createLocalPeeringGatewayDetails is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("localPeeringGateways");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateLocalPeeringGatewayResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateLocalPeeringGatewayResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateLocalPeeringGatewayResponse>() {
+                            @Override
+                            public CreateLocalPeeringGatewayResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateLocalPeeringGatewayResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LocalPeeringGateway>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LocalPeeringGateway.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<LocalPeeringGateway>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateLocalPeeringGatewayResponse.Builder builder =
+                                        CreateLocalPeeringGatewayResponse.builder();
+
+                                builder.localPeeringGateway(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateLocalPeeringGatewayResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteBootVolumeConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteBootVolumeConverter.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteBootVolumeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteBootVolumeRequest interceptRequest(DeleteBootVolumeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteBootVolumeRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getBootVolumeId() == null) {
+            throw new NullPointerException("bootVolumeId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("bootVolumes")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBootVolumeId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteBootVolumeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBootVolumeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteBootVolumeResponse>() {
+                            @Override
+                            public DeleteBootVolumeResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteBootVolumeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteBootVolumeResponse.Builder builder =
+                                        DeleteBootVolumeResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteBootVolumeResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteLocalPeeringGatewayConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteLocalPeeringGatewayConverter.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteLocalPeeringGatewayConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteLocalPeeringGatewayRequest interceptRequest(
+            DeleteLocalPeeringGatewayRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DeleteLocalPeeringGatewayRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getLocalPeeringGatewayId() == null) {
+            throw new NullPointerException("localPeeringGatewayId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("localPeeringGateways")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLocalPeeringGatewayId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteLocalPeeringGatewayResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteLocalPeeringGatewayResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteLocalPeeringGatewayResponse>() {
+                            @Override
+                            public DeleteLocalPeeringGatewayResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteLocalPeeringGatewayResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteLocalPeeringGatewayResponse.Builder builder =
+                                        DeleteLocalPeeringGatewayResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteLocalPeeringGatewayResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DetachBootVolumeConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DetachBootVolumeConverter.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DetachBootVolumeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DetachBootVolumeRequest interceptRequest(DetachBootVolumeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DetachBootVolumeRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getBootVolumeAttachmentId() == null) {
+            throw new NullPointerException("bootVolumeAttachmentId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("bootVolumeAttachments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBootVolumeAttachmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DetachBootVolumeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DetachBootVolumeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DetachBootVolumeResponse>() {
+                            @Override
+                            public DetachBootVolumeResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DetachBootVolumeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DetachBootVolumeResponse.Builder builder =
+                                        DetachBootVolumeResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DetachBootVolumeResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetBootVolumeAttachmentConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetBootVolumeAttachmentConverter.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetBootVolumeAttachmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetBootVolumeAttachmentRequest interceptRequest(
+            GetBootVolumeAttachmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetBootVolumeAttachmentRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getBootVolumeAttachmentId() == null) {
+            throw new NullPointerException("bootVolumeAttachmentId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("bootVolumeAttachments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBootVolumeAttachmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>() {
+                            @Override
+                            public GetBootVolumeAttachmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetBootVolumeAttachmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BootVolumeAttachment>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BootVolumeAttachment.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BootVolumeAttachment>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetBootVolumeAttachmentResponse.Builder builder =
+                                        GetBootVolumeAttachmentResponse.builder();
+
+                                builder.bootVolumeAttachment(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetBootVolumeAttachmentResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetBootVolumeConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetBootVolumeConverter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetBootVolumeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetBootVolumeRequest interceptRequest(GetBootVolumeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetBootVolumeRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getBootVolumeId() == null) {
+            throw new NullPointerException("bootVolumeId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("bootVolumes")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBootVolumeId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetBootVolumeResponse>() {
+                            @Override
+                            public GetBootVolumeResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for GetBootVolumeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BootVolume>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BootVolume.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BootVolume> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetBootVolumeResponse.Builder builder =
+                                        GetBootVolumeResponse.builder();
+
+                                builder.bootVolume(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetBootVolumeResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetLocalPeeringGatewayConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetLocalPeeringGatewayConverter.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetLocalPeeringGatewayConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetLocalPeeringGatewayRequest interceptRequest(
+            GetLocalPeeringGatewayRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetLocalPeeringGatewayRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getLocalPeeringGatewayId() == null) {
+            throw new NullPointerException("localPeeringGatewayId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("localPeeringGateways")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLocalPeeringGatewayId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetLocalPeeringGatewayResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetLocalPeeringGatewayResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetLocalPeeringGatewayResponse>() {
+                            @Override
+                            public GetLocalPeeringGatewayResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetLocalPeeringGatewayResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LocalPeeringGateway>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LocalPeeringGateway.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<LocalPeeringGateway>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetLocalPeeringGatewayResponse.Builder builder =
+                                        GetLocalPeeringGatewayResponse.builder();
+
+                                builder.localPeeringGateway(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetLocalPeeringGatewayResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListBootVolumeAttachmentsConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListBootVolumeAttachmentsConverter.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListBootVolumeAttachmentsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListBootVolumeAttachmentsRequest interceptRequest(
+            ListBootVolumeAttachmentsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ListBootVolumeAttachmentsRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getAvailabilityDomain() == null) {
+            throw new NullPointerException("availabilityDomain is required");
+        }
+
+        if (request.getCompartmentId() == null) {
+            throw new NullPointerException("compartmentId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("bootVolumeAttachments");
+
+        target =
+                target.queryParam(
+                        "availabilityDomain",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getAvailabilityDomain()));
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getInstanceId() != null) {
+            target =
+                    target.queryParam(
+                            "instanceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstanceId()));
+        }
+
+        if (request.getBootVolumeId() != null) {
+            target =
+                    target.queryParam(
+                            "bootVolumeId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBootVolumeId()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListBootVolumeAttachmentsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBootVolumeAttachmentsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListBootVolumeAttachmentsResponse>() {
+                            @Override
+                            public ListBootVolumeAttachmentsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListBootVolumeAttachmentsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<BootVolumeAttachment>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        BootVolumeAttachment>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<BootVolumeAttachment>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListBootVolumeAttachmentsResponse.Builder builder =
+                                        ListBootVolumeAttachmentsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListBootVolumeAttachmentsResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListBootVolumesConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListBootVolumesConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListBootVolumesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListBootVolumesRequest interceptRequest(ListBootVolumesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListBootVolumesRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getAvailabilityDomain() == null) {
+            throw new NullPointerException("availabilityDomain is required");
+        }
+
+        if (request.getCompartmentId() == null) {
+            throw new NullPointerException("compartmentId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("bootVolumes");
+
+        target =
+                target.queryParam(
+                        "availabilityDomain",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getAvailabilityDomain()));
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListBootVolumesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListBootVolumesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListBootVolumesResponse>() {
+                            @Override
+                            public ListBootVolumesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for ListBootVolumesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<BootVolume>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<BootVolume>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.util.List<BootVolume>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListBootVolumesResponse.Builder builder =
+                                        ListBootVolumesResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListBootVolumesResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListLocalPeeringGatewaysConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListLocalPeeringGatewaysConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListLocalPeeringGatewaysConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListLocalPeeringGatewaysRequest interceptRequest(
+            ListLocalPeeringGatewaysRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ListLocalPeeringGatewaysRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getCompartmentId() == null) {
+            throw new NullPointerException("compartmentId is required");
+        }
+
+        if (request.getVcnId() == null) {
+            throw new NullPointerException("vcnId is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("localPeeringGateways");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        target =
+                target.queryParam(
+                        "vcnId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getVcnId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListLocalPeeringGatewaysResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListLocalPeeringGatewaysResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListLocalPeeringGatewaysResponse>() {
+                            @Override
+                            public ListLocalPeeringGatewaysResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListLocalPeeringGatewaysResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<LocalPeeringGateway>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        LocalPeeringGateway>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<LocalPeeringGateway>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListLocalPeeringGatewaysResponse.Builder builder =
+                                        ListLocalPeeringGatewaysResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListLocalPeeringGatewaysResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/TerminateInstanceConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/TerminateInstanceConverter.java
@@ -37,6 +37,14 @@ public class TerminateInstanceConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getInstanceId()));
 
+        if (request.getPreserveBootVolume() != null) {
+            target =
+                    target.queryParam(
+                            "preserveBootVolume",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPreserveBootVolume()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateBootVolumeConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateBootVolumeConverter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateBootVolumeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateBootVolumeRequest interceptRequest(UpdateBootVolumeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateBootVolumeRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getBootVolumeId() == null) {
+            throw new NullPointerException("bootVolumeId is required");
+        }
+
+        if (request.getUpdateBootVolumeDetails() == null) {
+            throw new NullPointerException("updateBootVolumeDetails is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("bootVolumes")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBootVolumeId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateBootVolumeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBootVolumeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateBootVolumeResponse>() {
+                            @Override
+                            public UpdateBootVolumeResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateBootVolumeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BootVolume>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BootVolume.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BootVolume> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateBootVolumeResponse.Builder builder =
+                                        UpdateBootVolumeResponse.builder();
+
+                                builder.bootVolume(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateBootVolumeResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateLocalPeeringGatewayConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateLocalPeeringGatewayConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateLocalPeeringGatewayConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateLocalPeeringGatewayRequest interceptRequest(
+            UpdateLocalPeeringGatewayRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateLocalPeeringGatewayRequest request) {
+        if (request == null) {
+            throw new NullPointerException("request instance is required");
+        }
+
+        if (request.getLocalPeeringGatewayId() == null) {
+            throw new NullPointerException("localPeeringGatewayId is required");
+        }
+
+        if (request.getUpdateLocalPeeringGatewayDetails() == null) {
+            throw new NullPointerException("updateLocalPeeringGatewayDetails is required");
+        }
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("localPeeringGateways")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLocalPeeringGatewayId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateLocalPeeringGatewayResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateLocalPeeringGatewayResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateLocalPeeringGatewayResponse>() {
+                            @Override
+                            public UpdateLocalPeeringGatewayResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateLocalPeeringGatewayResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LocalPeeringGateway>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LocalPeeringGateway.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<LocalPeeringGateway>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateLocalPeeringGatewayResponse.Builder builder =
+                                        UpdateLocalPeeringGatewayResponse.builder();
+
+                                builder.localPeeringGateway(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateLocalPeeringGatewayResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachBootVolumeDetails.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AttachBootVolumeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AttachBootVolumeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+        private String bootVolumeId;
+
+        public Builder bootVolumeId(String bootVolumeId) {
+            this.bootVolumeId = bootVolumeId;
+            this.__explicitlySet__.add("bootVolumeId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
+        private String instanceId;
+
+        public Builder instanceId(String instanceId) {
+            this.instanceId = instanceId;
+            this.__explicitlySet__.add("instanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AttachBootVolumeDetails build() {
+            AttachBootVolumeDetails __instance__ =
+                    new AttachBootVolumeDetails(bootVolumeId, displayName, instanceId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AttachBootVolumeDetails o) {
+            Builder copiedBuilder =
+                    bootVolumeId(o.getBootVolumeId())
+                            .displayName(o.getDisplayName())
+                            .instanceId(o.getInstanceId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the  boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+    String bootVolumeId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
+    String instanceId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachIScsiVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachIScsiVolumeDetails.java
@@ -68,10 +68,14 @@ public class AttachIScsiVolumeDetails extends AttachVolumeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AttachIScsiVolumeDetails o) {
-            return displayName(o.getDisplayName())
-                    .instanceId(o.getInstanceId())
-                    .volumeId(o.getVolumeId())
-                    .useChap(o.getUseChap());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .instanceId(o.getInstanceId())
+                            .volumeId(o.getVolumeId())
+                            .useChap(o.getUseChap());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachVnicDetails.java
@@ -40,21 +40,35 @@ public class AttachVnicDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nicIndex")
+        private Integer nicIndex;
+
+        public Builder nicIndex(Integer nicIndex) {
+            this.nicIndex = nicIndex;
+            this.__explicitlySet__.add("nicIndex");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AttachVnicDetails build() {
             AttachVnicDetails __instance__ =
-                    new AttachVnicDetails(createVnicDetails, displayName, instanceId);
+                    new AttachVnicDetails(createVnicDetails, displayName, instanceId, nicIndex);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AttachVnicDetails o) {
-            return createVnicDetails(o.getCreateVnicDetails())
-                    .displayName(o.getDisplayName())
-                    .instanceId(o.getInstanceId());
+            Builder copiedBuilder =
+                    createVnicDetails(o.getCreateVnicDetails())
+                            .displayName(o.getDisplayName())
+                            .instanceId(o.getInstanceId())
+                            .nicIndex(o.getNicIndex());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -84,6 +98,17 @@ public class AttachVnicDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
     String instanceId;
+
+    /**
+     * Which physical network interface card (NIC) the VNIC will use. Defaults to 0.
+     * Certain bare metal instance shapes have two active physical NICs (0 and 1). If
+     * you add a secondary VNIC to one of these instances, you can specify which NIC
+     * the VNIC will use. For more information, see
+     * [Virtual Network Interface Cards (VNICs)](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingVNICs.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nicIndex")
+    Integer nicIndex;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * A detachable boot volume device that contains the image used to boot an Compute instance. For more information, see
+ * [Overview of Boot Volumes](https://docs.us-phoenix-1.oraclecloud.com/Content/Block/Concepts/bootvolumes.htm).
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
+ * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
+ * [Getting Started with Policies](https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Concepts/policygetstarted.htm).
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BootVolume.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BootVolume {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+        private String imageId;
+
+        public Builder imageId(String imageId) {
+            this.imageId = imageId;
+            this.__explicitlySet__.add("imageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+        private Long sizeInGBs;
+
+        public Builder sizeInGBs(Long sizeInGBs) {
+            this.sizeInGBs = sizeInGBs;
+            this.__explicitlySet__.add("sizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInMBs")
+        private Long sizeInMBs;
+
+        public Builder sizeInMBs(Long sizeInMBs) {
+            this.sizeInMBs = sizeInMBs;
+            this.__explicitlySet__.add("sizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BootVolume build() {
+            BootVolume __instance__ =
+                    new BootVolume(
+                            availabilityDomain,
+                            compartmentId,
+                            displayName,
+                            id,
+                            imageId,
+                            lifecycleState,
+                            sizeInGBs,
+                            sizeInMBs,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BootVolume o) {
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .imageId(o.getImageId())
+                            .lifecycleState(o.getLifecycleState())
+                            .sizeInGBs(o.getSizeInGBs())
+                            .sizeInMBs(o.getSizeInMBs())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The Availability Domain of the boot volume.
+     * <p>
+     * Example: `Uocm:PHX-AD-1`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    /**
+     * The OCID of the compartment that contains the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The boot volume's Oracle ID (OCID).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The image OCID used to create the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+    String imageId;
+    /**
+     * The current state of a boot volume.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Restoring("RESTORING"),
+        Available("AVAILABLE"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Faulty("FAULTY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of a boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The size of the boot volume in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+    Long sizeInGBs;
+
+    /**
+     * The size of the volume in MBs. The value must be a multiple of 1024.
+     * This field is deprecated. Please use sizeInGBs.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInMBs")
+    Long sizeInMBs;
+
+    /**
+     * The date and time the boot volume was created. Format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeAttachment.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Represents an attachment between a boot volume and an instance.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BootVolumeAttachment.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BootVolumeAttachment {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+        private String bootVolumeId;
+
+        public Builder bootVolumeId(String bootVolumeId) {
+            this.bootVolumeId = bootVolumeId;
+            this.__explicitlySet__.add("bootVolumeId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
+        private String instanceId;
+
+        public Builder instanceId(String instanceId) {
+            this.instanceId = instanceId;
+            this.__explicitlySet__.add("instanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BootVolumeAttachment build() {
+            BootVolumeAttachment __instance__ =
+                    new BootVolumeAttachment(
+                            availabilityDomain,
+                            bootVolumeId,
+                            compartmentId,
+                            displayName,
+                            id,
+                            instanceId,
+                            lifecycleState,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BootVolumeAttachment o) {
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .bootVolumeId(o.getBootVolumeId())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .instanceId(o.getInstanceId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The Availability Domain of an instance.
+     * <p>
+     * Example: `Uocm:PHX-AD-1`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    /**
+     * The OCID of the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+    String bootVolumeId;
+
+    /**
+     * The OCID of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it cannot be changed.
+     * Avoid entering confidential information.
+     * <p>
+     * Example: `My boot volume`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the boot volume attachment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the instance the boot volume is attached to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
+    String instanceId;
+    /**
+     * The current state of the boot volume attachment.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Attaching("ATTACHING"),
+        Attached("ATTACHED"),
+        Detaching("DETACHING"),
+        Detached("DETACHED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the boot volume attachment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the boot volume was created, in the format defined by RFC3339.
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CaptureConsoleHistoryDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CaptureConsoleHistoryDetails.java
@@ -43,7 +43,10 @@ public class CaptureConsoleHistoryDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CaptureConsoleHistoryDetails o) {
-            return displayName(o.getDisplayName()).instanceId(o.getInstanceId());
+            Builder copiedBuilder = displayName(o.getDisplayName()).instanceId(o.getInstanceId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ConnectLocalPeeringGatewaysDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ConnectLocalPeeringGatewaysDetails.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Information about the other local peering gateway (LPG).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConnectLocalPeeringGatewaysDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ConnectLocalPeeringGatewaysDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("peerId")
+        private String peerId;
+
+        public Builder peerId(String peerId) {
+            this.peerId = peerId;
+            this.__explicitlySet__.add("peerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConnectLocalPeeringGatewaysDetails build() {
+            ConnectLocalPeeringGatewaysDetails __instance__ =
+                    new ConnectLocalPeeringGatewaysDetails(peerId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConnectLocalPeeringGatewaysDetails o) {
+            Builder copiedBuilder = peerId(o.getPeerId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the LPG you want to peer with.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerId")
+    String peerId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ConsoleHistory.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ConsoleHistory.java
@@ -99,13 +99,17 @@ public class ConsoleHistory {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ConsoleHistory o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .instanceId(o.getInstanceId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .instanceId(o.getInstanceId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Cpe.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Cpe.java
@@ -79,11 +79,15 @@ public class Cpe {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Cpe o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .ipAddress(o.getIpAddress())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .ipAddress(o.getIpAddress())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCpeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCpeDetails.java
@@ -50,9 +50,13 @@ public class CreateCpeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCpeDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .ipAddress(o.getIpAddress());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .ipAddress(o.getIpAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectDetails.java
@@ -97,15 +97,19 @@ public class CreateCrossConnectDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCrossConnectDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .crossConnectGroupId(o.getCrossConnectGroupId())
-                    .displayName(o.getDisplayName())
-                    .farCrossConnectOrCrossConnectGroupId(
-                            o.getFarCrossConnectOrCrossConnectGroupId())
-                    .locationName(o.getLocationName())
-                    .nearCrossConnectOrCrossConnectGroupId(
-                            o.getNearCrossConnectOrCrossConnectGroupId())
-                    .portSpeedShapeName(o.getPortSpeedShapeName());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .crossConnectGroupId(o.getCrossConnectGroupId())
+                            .displayName(o.getDisplayName())
+                            .farCrossConnectOrCrossConnectGroupId(
+                                    o.getFarCrossConnectOrCrossConnectGroupId())
+                            .locationName(o.getLocationName())
+                            .nearCrossConnectOrCrossConnectGroupId(
+                                    o.getNearCrossConnectOrCrossConnectGroupId())
+                            .portSpeedShapeName(o.getPortSpeedShapeName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectGroupDetails.java
@@ -43,7 +43,11 @@ public class CreateCrossConnectGroupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCrossConnectGroupDetails o) {
-            return compartmentId(o.getCompartmentId()).displayName(o.getDisplayName());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId()).displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDhcpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDhcpDetails.java
@@ -61,10 +61,14 @@ public class CreateDhcpDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDhcpDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .options(o.getOptions())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .options(o.getOptions())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgAttachmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgAttachmentDetails.java
@@ -52,7 +52,11 @@ public class CreateDrgAttachmentDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDrgAttachmentDetails o) {
-            return displayName(o.getDisplayName()).drgId(o.getDrgId()).vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName()).drgId(o.getDrgId()).vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgDetails.java
@@ -40,7 +40,11 @@ public class CreateDrgDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDrgDetails o) {
-            return compartmentId(o.getCompartmentId()).displayName(o.getDisplayName());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId()).displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
@@ -71,11 +71,15 @@ public class CreateIPSecConnectionDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateIPSecConnectionDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .cpeId(o.getCpeId())
-                    .displayName(o.getDisplayName())
-                    .drgId(o.getDrgId())
-                    .staticRoutes(o.getStaticRoutes());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .cpeId(o.getCpeId())
+                            .displayName(o.getDisplayName())
+                            .drgId(o.getDrgId())
+                            .staticRoutes(o.getStaticRoutes());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
@@ -65,10 +65,14 @@ public class CreateImageDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateImageDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .imageSourceDetails(o.getImageSourceDetails())
-                    .instanceId(o.getInstanceId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .imageSourceDetails(o.getImageSourceDetails())
+                            .instanceId(o.getInstanceId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInstanceConsoleConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInstanceConsoleConnectionDetails.java
@@ -4,8 +4,8 @@
 package com.oracle.bmc.core.model;
 
 /**
- * The details for creating a serial console connection.
- * The serial console connection is created in the same compartment as the instance.
+ * The details for creating a instance console connection.
+ * The instance console connection is created in the same compartment as the instance.
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
@@ -48,7 +48,10 @@ public class CreateInstanceConsoleConnectionDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateInstanceConsoleConnectionDetails o) {
-            return instanceId(o.getInstanceId()).publicKey(o.getPublicKey());
+            Builder copiedBuilder = instanceId(o.getInstanceId()).publicKey(o.getPublicKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -60,13 +63,13 @@ public class CreateInstanceConsoleConnectionDetails {
     }
 
     /**
-     * The OCID of the instance to create the serial console connection to.
+     * The OCID of the instance to create the console connection to.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
     String instanceId;
 
     /**
-     * The SSH public key used to authenticate the serial console connection.
+     * The SSH public key used to authenticate the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicKey")
     String publicKey;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInternetGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInternetGatewayDetails.java
@@ -61,10 +61,14 @@ public class CreateInternetGatewayDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateInternetGatewayDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .isEnabled(o.getIsEnabled())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateLocalPeeringGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateLocalPeeringGatewayDetails.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateLocalPeeringGatewayDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateLocalPeeringGatewayDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateLocalPeeringGatewayDetails build() {
+            CreateLocalPeeringGatewayDetails __instance__ =
+                    new CreateLocalPeeringGatewayDetails(compartmentId, displayName, vcnId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateLocalPeeringGatewayDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment containing the local peering gateway (LPG).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the VCN the LPG belongs to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePrivateIpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePrivateIpDetails.java
@@ -61,10 +61,14 @@ public class CreatePrivateIpDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreatePrivateIpDetails o) {
-            return displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .ipAddress(o.getIpAddress())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .ipAddress(o.getIpAddress())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateRouteTableDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateRouteTableDetails.java
@@ -61,10 +61,14 @@ public class CreateRouteTableDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateRouteTableDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .routeRules(o.getRouteRules())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .routeRules(o.getRouteRules())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSecurityListDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSecurityListDetails.java
@@ -76,11 +76,15 @@ public class CreateSecurityListDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateSecurityListDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .egressSecurityRules(o.getEgressSecurityRules())
-                    .ingressSecurityRules(o.getIngressSecurityRules())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .egressSecurityRules(o.getEgressSecurityRules())
+                            .ingressSecurityRules(o.getIngressSecurityRules())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSubnetDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSubnetDetails.java
@@ -125,16 +125,20 @@ public class CreateSubnetDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateSubnetDetails o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .cidrBlock(o.getCidrBlock())
-                    .compartmentId(o.getCompartmentId())
-                    .dhcpOptionsId(o.getDhcpOptionsId())
-                    .displayName(o.getDisplayName())
-                    .dnsLabel(o.getDnsLabel())
-                    .prohibitPublicIpOnVnic(o.getProhibitPublicIpOnVnic())
-                    .routeTableId(o.getRouteTableId())
-                    .securityListIds(o.getSecurityListIds())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .cidrBlock(o.getCidrBlock())
+                            .compartmentId(o.getCompartmentId())
+                            .dhcpOptionsId(o.getDhcpOptionsId())
+                            .displayName(o.getDisplayName())
+                            .dnsLabel(o.getDnsLabel())
+                            .prohibitPublicIpOnVnic(o.getProhibitPublicIpOnVnic())
+                            .routeTableId(o.getRouteTableId())
+                            .securityListIds(o.getSecurityListIds())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
@@ -59,10 +59,14 @@ public class CreateVcnDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateVcnDetails o) {
-            return cidrBlock(o.getCidrBlock())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .dnsLabel(o.getDnsLabel());
+            Builder copiedBuilder =
+                    cidrBlock(o.getCidrBlock())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .dnsLabel(o.getDnsLabel());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
@@ -126,16 +126,20 @@ public class CreateVirtualCircuitDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateVirtualCircuitDetails o) {
-            return bandwidthShapeName(o.getBandwidthShapeName())
-                    .compartmentId(o.getCompartmentId())
-                    .crossConnectMappings(o.getCrossConnectMappings())
-                    .customerBgpAsn(o.getCustomerBgpAsn())
-                    .displayName(o.getDisplayName())
-                    .gatewayId(o.getGatewayId())
-                    .providerName(o.getProviderName())
-                    .providerServiceName(o.getProviderServiceName())
-                    .region(o.getRegion())
-                    .type(o.getType());
+            Builder copiedBuilder =
+                    bandwidthShapeName(o.getBandwidthShapeName())
+                            .compartmentId(o.getCompartmentId())
+                            .crossConnectMappings(o.getCrossConnectMappings())
+                            .customerBgpAsn(o.getCustomerBgpAsn())
+                            .displayName(o.getDisplayName())
+                            .gatewayId(o.getGatewayId())
+                            .providerName(o.getProviderName())
+                            .providerServiceName(o.getProviderServiceName())
+                            .region(o.getRegion())
+                            .type(o.getType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
@@ -92,12 +92,16 @@ public class CreateVnicDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateVnicDetails o) {
-            return assignPublicIp(o.getAssignPublicIp())
-                    .displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .privateIp(o.getPrivateIp())
-                    .skipSourceDestCheck(o.getSkipSourceDestCheck())
-                    .subnetId(o.getSubnetId());
+            Builder copiedBuilder =
+                    assignPublicIp(o.getAssignPublicIp())
+                            .displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .privateIp(o.getPrivateIp())
+                            .skipSourceDestCheck(o.getSkipSourceDestCheck())
+                            .subnetId(o.getSubnetId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeBackupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeBackupDetails.java
@@ -43,7 +43,10 @@ public class CreateVolumeBackupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateVolumeBackupDetails o) {
-            return displayName(o.getDisplayName()).volumeId(o.getVolumeId());
+            Builder copiedBuilder = displayName(o.getDisplayName()).volumeId(o.getVolumeId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
@@ -132,15 +132,19 @@ public class CrossConnect {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnect o) {
-            return compartmentId(o.getCompartmentId())
-                    .crossConnectGroupId(o.getCrossConnectGroupId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .locationName(o.getLocationName())
-                    .portName(o.getPortName())
-                    .portSpeedShapeName(o.getPortSpeedShapeName())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .crossConnectGroupId(o.getCrossConnectGroupId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .locationName(o.getLocationName())
+                            .portName(o.getPortName())
+                            .portSpeedShapeName(o.getPortSpeedShapeName())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
@@ -87,11 +87,15 @@ public class CrossConnectGroup {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnectGroup o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectLocation.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectLocation.java
@@ -45,7 +45,10 @@ public class CrossConnectLocation {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnectLocation o) {
-            return description(o.getDescription()).name(o.getName());
+            Builder copiedBuilder = description(o.getDescription()).name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectMapping.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectMapping.java
@@ -100,11 +100,16 @@ public class CrossConnectMapping {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnectMapping o) {
-            return bgpMd5AuthKey(o.getBgpMd5AuthKey())
-                    .crossConnectOrCrossConnectGroupId(o.getCrossConnectOrCrossConnectGroupId())
-                    .customerBgpPeeringIp(o.getCustomerBgpPeeringIp())
-                    .oracleBgpPeeringIp(o.getOracleBgpPeeringIp())
-                    .vlan(o.getVlan());
+            Builder copiedBuilder =
+                    bgpMd5AuthKey(o.getBgpMd5AuthKey())
+                            .crossConnectOrCrossConnectGroupId(
+                                    o.getCrossConnectOrCrossConnectGroupId())
+                            .customerBgpPeeringIp(o.getCustomerBgpPeeringIp())
+                            .oracleBgpPeeringIp(o.getOracleBgpPeeringIp())
+                            .vlan(o.getVlan());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectPortSpeedShape.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectPortSpeedShape.java
@@ -47,7 +47,10 @@ public class CrossConnectPortSpeedShape {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnectPortSpeedShape o) {
-            return name(o.getName()).portSpeedInGbps(o.getPortSpeedInGbps());
+            Builder copiedBuilder = name(o.getName()).portSpeedInGbps(o.getPortSpeedInGbps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectStatus.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectStatus.java
@@ -65,10 +65,14 @@ public class CrossConnectStatus {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CrossConnectStatus o) {
-            return crossConnectId(o.getCrossConnectId())
-                    .interfaceState(o.getInterfaceState())
-                    .lightLevelIndBm(o.getLightLevelIndBm())
-                    .lightLevelIndicator(o.getLightLevelIndicator());
+            Builder copiedBuilder =
+                    crossConnectId(o.getCrossConnectId())
+                            .interfaceState(o.getInterfaceState())
+                            .lightLevelIndBm(o.getLightLevelIndBm())
+                            .lightLevelIndicator(o.getLightLevelIndicator());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpDnsOption.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpDnsOption.java
@@ -53,7 +53,11 @@ public class DhcpDnsOption extends DhcpOption {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DhcpDnsOption o) {
-            return customDnsServers(o.getCustomDnsServers()).serverType(o.getServerType());
+            Builder copiedBuilder =
+                    customDnsServers(o.getCustomDnsServers()).serverType(o.getServerType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOptions.java
@@ -111,13 +111,17 @@ public class DhcpOptions {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DhcpOptions o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .options(o.getOptions())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .options(o.getOptions())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpSearchDomainOption.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpSearchDomainOption.java
@@ -45,7 +45,10 @@ public class DhcpSearchDomainOption extends DhcpOption {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DhcpSearchDomainOption o) {
-            return searchDomainNames(o.getSearchDomainNames());
+            Builder copiedBuilder = searchDomainNames(o.getSearchDomainNames());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Drg.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Drg.java
@@ -79,11 +79,15 @@ public class Drg {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Drg o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachment.java
@@ -98,13 +98,17 @@ public class DrgAttachment {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DrgAttachment o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .drgId(o.getDrgId())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .drgId(o.getDrgId())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
@@ -88,12 +88,16 @@ public class EgressSecurityRule {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(EgressSecurityRule o) {
-            return destination(o.getDestination())
-                    .icmpOptions(o.getIcmpOptions())
-                    .isStateless(o.getIsStateless())
-                    .protocol(o.getProtocol())
-                    .tcpOptions(o.getTcpOptions())
-                    .udpOptions(o.getUdpOptions());
+            Builder copiedBuilder =
+                    destination(o.getDestination())
+                            .icmpOptions(o.getIcmpOptions())
+                            .isStateless(o.getIsStateless())
+                            .protocol(o.getProtocol())
+                            .tcpOptions(o.getTcpOptions())
+                            .udpOptions(o.getUdpOptions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageTupleDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageTupleDetails.java
@@ -60,9 +60,13 @@ public class ExportImageViaObjectStorageTupleDetails extends ExportImageDetails 
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExportImageViaObjectStorageTupleDetails o) {
-            return bucketName(o.getBucketName())
-                    .namespaceName(o.getNamespaceName())
-                    .objectName(o.getObjectName());
+            Builder copiedBuilder =
+                    bucketName(o.getBucketName())
+                            .namespaceName(o.getNamespaceName())
+                            .objectName(o.getObjectName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
@@ -41,7 +41,10 @@ public class ExportImageViaObjectStorageUriDetails extends ExportImageDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExportImageViaObjectStorageUriDetails o) {
-            return destinationUri(o.getDestinationUri());
+            Builder copiedBuilder = destinationUri(o.getDestinationUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
@@ -57,9 +57,13 @@ public class FastConnectProviderService {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(FastConnectProviderService o) {
-            return description(o.getDescription())
-                    .providerName(o.getProviderName())
-                    .providerServiceName(o.getProviderServiceName());
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .providerName(o.getProviderName())
+                            .providerServiceName(o.getProviderServiceName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
@@ -114,14 +114,18 @@ public class IPSecConnection {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IPSecConnection o) {
-            return compartmentId(o.getCompartmentId())
-                    .cpeId(o.getCpeId())
-                    .displayName(o.getDisplayName())
-                    .drgId(o.getDrgId())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .staticRoutes(o.getStaticRoutes())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .cpeId(o.getCpeId())
+                            .displayName(o.getDisplayName())
+                            .drgId(o.getDrgId())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .staticRoutes(o.getStaticRoutes())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionDeviceConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionDeviceConfig.java
@@ -64,10 +64,14 @@ public class IPSecConnectionDeviceConfig {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IPSecConnectionDeviceConfig o) {
-            return compartmentId(o.getCompartmentId())
-                    .id(o.getId())
-                    .timeCreated(o.getTimeCreated())
-                    .tunnels(o.getTunnels());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .tunnels(o.getTunnels());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionDeviceStatus.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionDeviceStatus.java
@@ -64,10 +64,14 @@ public class IPSecConnectionDeviceStatus {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IPSecConnectionDeviceStatus o) {
-            return compartmentId(o.getCompartmentId())
-                    .id(o.getId())
-                    .timeCreated(o.getTimeCreated())
-                    .tunnels(o.getTunnels());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .tunnels(o.getTunnels());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IScsiVolumeAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IScsiVolumeAttachment.java
@@ -165,19 +165,23 @@ public class IScsiVolumeAttachment extends VolumeAttachment {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IScsiVolumeAttachment o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .instanceId(o.getInstanceId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .volumeId(o.getVolumeId())
-                    .chapSecret(o.getChapSecret())
-                    .chapUsername(o.getChapUsername())
-                    .ipv4(o.getIpv4())
-                    .iqn(o.getIqn())
-                    .port(o.getPort());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .instanceId(o.getInstanceId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .volumeId(o.getVolumeId())
+                            .chapSecret(o.getChapSecret())
+                            .chapUsername(o.getChapUsername())
+                            .ipv4(o.getIpv4())
+                            .iqn(o.getIqn())
+                            .port(o.getPort());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IcmpOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IcmpOptions.java
@@ -50,7 +50,10 @@ public class IcmpOptions {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IcmpOptions o) {
-            return code(o.getCode()).type(o.getType());
+            Builder copiedBuilder = code(o.getCode()).type(o.getType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
@@ -122,15 +122,19 @@ public class Image {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Image o) {
-            return baseImageId(o.getBaseImageId())
-                    .compartmentId(o.getCompartmentId())
-                    .createImageAllowed(o.getCreateImageAllowed())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .operatingSystem(o.getOperatingSystem())
-                    .operatingSystemVersion(o.getOperatingSystemVersion())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    baseImageId(o.getBaseImageId())
+                            .compartmentId(o.getCompartmentId())
+                            .createImageAllowed(o.getCreateImageAllowed())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .operatingSystem(o.getOperatingSystem())
+                            .operatingSystemVersion(o.getOperatingSystemVersion())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceViaObjectStorageTupleDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceViaObjectStorageTupleDetails.java
@@ -60,9 +60,13 @@ public class ImageSourceViaObjectStorageTupleDetails extends ImageSourceDetails 
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ImageSourceViaObjectStorageTupleDetails o) {
-            return bucketName(o.getBucketName())
-                    .namespaceName(o.getNamespaceName())
-                    .objectName(o.getObjectName());
+            Builder copiedBuilder =
+                    bucketName(o.getBucketName())
+                            .namespaceName(o.getNamespaceName())
+                            .objectName(o.getObjectName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceViaObjectStorageUriDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceViaObjectStorageUriDetails.java
@@ -41,7 +41,10 @@ public class ImageSourceViaObjectStorageUriDetails extends ImageSourceDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ImageSourceViaObjectStorageUriDetails o) {
-            return sourceUri(o.getSourceUri());
+            Builder copiedBuilder = sourceUri(o.getSourceUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
@@ -83,12 +83,16 @@ public class IngressSecurityRule {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IngressSecurityRule o) {
-            return icmpOptions(o.getIcmpOptions())
-                    .isStateless(o.getIsStateless())
-                    .protocol(o.getProtocol())
-                    .source(o.getSource())
-                    .tcpOptions(o.getTcpOptions())
-                    .udpOptions(o.getUdpOptions());
+            Builder copiedBuilder =
+                    icmpOptions(o.getIcmpOptions())
+                            .isStateless(o.getIsStateless())
+                            .protocol(o.getProtocol())
+                            .source(o.getSource())
+                            .tcpOptions(o.getTcpOptions())
+                            .udpOptions(o.getUdpOptions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
@@ -121,6 +121,15 @@ public class Instance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+        private InstanceSourceDetails sourceDetails;
+
+        public Builder sourceDetails(InstanceSourceDetails sourceDetails) {
+            this.sourceDetails = sourceDetails;
+            this.__explicitlySet__.add("sourceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -147,6 +156,7 @@ public class Instance {
                             metadata,
                             region,
                             shape,
+                            sourceDetails,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -154,18 +164,23 @@ public class Instance {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Instance o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .extendedMetadata(o.getExtendedMetadata())
-                    .id(o.getId())
-                    .imageId(o.getImageId())
-                    .ipxeScript(o.getIpxeScript())
-                    .lifecycleState(o.getLifecycleState())
-                    .metadata(o.getMetadata())
-                    .region(o.getRegion())
-                    .shape(o.getShape())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .extendedMetadata(o.getExtendedMetadata())
+                            .id(o.getId())
+                            .imageId(o.getImageId())
+                            .ipxeScript(o.getIpxeScript())
+                            .lifecycleState(o.getLifecycleState())
+                            .metadata(o.getMetadata())
+                            .region(o.getRegion())
+                            .shape(o.getShape())
+                            .sourceDetails(o.getSourceDetails())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -219,8 +234,7 @@ public class Instance {
     String id;
 
     /**
-     * The image used to boot the instance. You can enumerate all available images by calling
-     * {@link #listImages(ListImagesRequest) listImages}.
+     * Deprecated. Use `sourceDetails` instead.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("imageId")
@@ -334,6 +348,12 @@ public class Instance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shape")
     String shape;
+
+    /**
+     * Details for creating an instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+    InstanceSourceDetails sourceDetails;
 
     /**
      * The date and time the instance was created, in the format defined by RFC3339.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConsoleConnection.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConsoleConnection.java
@@ -4,11 +4,11 @@
 package com.oracle.bmc.core.model;
 
 /**
- * The `InstanceConsoleConnection` API provides you with serial console access to virtual machine (VM) instances,
+ * The `InstanceConsoleConnection` API provides you with console access to virtual machine (VM) instances,
  * enabling you to troubleshoot malfunctioning instances remotely.
  * <p>
- * For more information about serial console access, see
- * [Accessing the Serial Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
+ * For more information about console access, see
+ * [Accessing the Console](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/serialconsole.htm).
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
@@ -93,12 +93,16 @@ public class InstanceConsoleConnection {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(InstanceConsoleConnection o) {
-            return compartmentId(o.getCompartmentId())
-                    .connectionString(o.getConnectionString())
-                    .fingerprint(o.getFingerprint())
-                    .id(o.getId())
-                    .instanceId(o.getInstanceId())
-                    .lifecycleState(o.getLifecycleState());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .connectionString(o.getConnectionString())
+                            .fingerprint(o.getFingerprint())
+                            .id(o.getId())
+                            .instanceId(o.getInstanceId())
+                            .lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -110,36 +114,36 @@ public class InstanceConsoleConnection {
     }
 
     /**
-     * The OCID of the compartment to contain the serial console connection.
+     * The OCID of the compartment to contain the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The SSH connection string for the serial console connection.
+     * The SSH connection string for the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
     String connectionString;
 
     /**
-     * The SSH public key fingerprint for the serial console connection.
+     * The SSH public key fingerprint for the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fingerprint")
     String fingerprint;
 
     /**
-     * The OCID of the serial console connection.
+     * The OCID of the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The OCID of the instance the serial console connection connects to.
+     * The OCID of the instance the console connection connects to.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceId")
     String instanceId;
     /**
-     * The current state of the serial console connection.
+     * The current state of the console connection.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LifecycleState {
@@ -188,7 +192,7 @@ public class InstanceConsoleConnection {
         }
     };
     /**
-     * The current state of the serial console connection.
+     * The current state of the console connection.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceCredentials.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceCredentials.java
@@ -45,7 +45,10 @@ public class InstanceCredentials {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(InstanceCredentials o) {
-            return password(o.getPassword()).username(o.getUsername());
+            Builder copiedBuilder = password(o.getPassword()).username(o.getUsername());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceDetails.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@lombok.experimental.NonFinal
+@lombok.AllArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType",
+    defaultImpl = InstanceSourceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = InstanceSourceViaImageDetails.class,
+        name = "image"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = InstanceSourceViaBootVolumeDetails.class,
+        name = "bootVolume"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class InstanceSourceDetails {}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaBootVolumeDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceSourceViaBootVolumeDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class InstanceSourceViaBootVolumeDetails extends InstanceSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+        private String bootVolumeId;
+
+        public Builder bootVolumeId(String bootVolumeId) {
+            this.bootVolumeId = bootVolumeId;
+            this.__explicitlySet__.add("bootVolumeId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceSourceViaBootVolumeDetails build() {
+            InstanceSourceViaBootVolumeDetails __instance__ =
+                    new InstanceSourceViaBootVolumeDetails(bootVolumeId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceSourceViaBootVolumeDetails o) {
+            Builder copiedBuilder = bootVolumeId(o.getBootVolumeId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public InstanceSourceViaBootVolumeDetails(String bootVolumeId) {
+        super();
+        this.bootVolumeId = bootVolumeId;
+    }
+
+    /**
+     * The OCID of the boot volume used to boot the instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeId")
+    String bootVolumeId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaImageDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceSourceViaImageDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class InstanceSourceViaImageDetails extends InstanceSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+        private String imageId;
+
+        public Builder imageId(String imageId) {
+            this.imageId = imageId;
+            this.__explicitlySet__.add("imageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceSourceViaImageDetails build() {
+            InstanceSourceViaImageDetails __instance__ = new InstanceSourceViaImageDetails(imageId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceSourceViaImageDetails o) {
+            Builder copiedBuilder = imageId(o.getImageId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public InstanceSourceViaImageDetails(String imageId) {
+        super();
+        this.imageId = imageId;
+    }
+
+    /**
+     * The OCID of the image used to boot the instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+    String imageId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InternetGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InternetGateway.java
@@ -103,13 +103,17 @@ public class InternetGateway {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(InternetGateway o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .isEnabled(o.getIsEnabled())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .isEnabled(o.getIsEnabled())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -103,6 +103,15 @@ public class LaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+        private InstanceSourceDetails sourceDetails;
+
+        public Builder sourceDetails(InstanceSourceDetails sourceDetails) {
+            this.sourceDetails = sourceDetails;
+            this.__explicitlySet__.add("sourceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -128,6 +137,7 @@ public class LaunchInstanceDetails {
                             ipxeScript,
                             metadata,
                             shape,
+                            sourceDetails,
                             subnetId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -135,17 +145,22 @@ public class LaunchInstanceDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LaunchInstanceDetails o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .createVnicDetails(o.getCreateVnicDetails())
-                    .displayName(o.getDisplayName())
-                    .extendedMetadata(o.getExtendedMetadata())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .imageId(o.getImageId())
-                    .ipxeScript(o.getIpxeScript())
-                    .metadata(o.getMetadata())
-                    .shape(o.getShape())
-                    .subnetId(o.getSubnetId());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .createVnicDetails(o.getCreateVnicDetails())
+                            .displayName(o.getDisplayName())
+                            .extendedMetadata(o.getExtendedMetadata())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .imageId(o.getImageId())
+                            .ipxeScript(o.getIpxeScript())
+                            .metadata(o.getMetadata())
+                            .shape(o.getShape())
+                            .sourceDetails(o.getSourceDetails())
+                            .subnetId(o.getSubnetId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -201,7 +216,7 @@ public class LaunchInstanceDetails {
     java.util.Map<String, Object> extendedMetadata;
 
     /**
-     * Deprecated. Instead use `hostnameLabel` in
+     * Deprecated. Instead Use `hostnameLabel` in
      * {@link CreateVnicDetails}.
      * If you provide both, the values must match.
      *
@@ -210,7 +225,9 @@ public class LaunchInstanceDetails {
     String hostnameLabel;
 
     /**
-     * The OCID of the image used to boot the instance.
+     * Deprecated. Use `sourceDetails` with {@link #instanceSourceViaImageDetails(InstanceSourceViaImageDetailsRequest) instanceSourceViaImageDetails}
+     * source type instead. If you specify values for both, the values must match.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("imageId")
     String imageId;
@@ -318,6 +335,12 @@ public class LaunchInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shape")
     String shape;
+
+    /**
+     * Details for creating an instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+    InstanceSourceDetails sourceDetails;
 
     /**
      * Deprecated. Instead use `subnetId` in

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LetterOfAuthority.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LetterOfAuthority.java
@@ -90,12 +90,16 @@ public class LetterOfAuthority {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LetterOfAuthority o) {
-            return circuitType(o.getCircuitType())
-                    .crossConnectId(o.getCrossConnectId())
-                    .facilityLocation(o.getFacilityLocation())
-                    .portName(o.getPortName())
-                    .timeExpires(o.getTimeExpires())
-                    .timeIssued(o.getTimeIssued());
+            Builder copiedBuilder =
+                    circuitType(o.getCircuitType())
+                            .crossConnectId(o.getCrossConnectId())
+                            .facilityLocation(o.getFacilityLocation())
+                            .portName(o.getPortName())
+                            .timeExpires(o.getTimeExpires())
+                            .timeIssued(o.getTimeIssued());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LocalPeeringGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LocalPeeringGateway.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * A local peering gateway (LPG) is an object on a VCN that lets that VCN peer
+ * with another VCN in the same region. *Peering* means that the two VCNs can
+ * communicate using private IP addresses, but without the traffic traversing the
+ * internet or routing through your on-premises network. For more information,
+ * see [VCN Peering](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/VCNpeering.htm).
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
+ * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
+ * [Getting Started with Policies](https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Concepts/policygetstarted.htm).
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LocalPeeringGateway.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class LocalPeeringGateway {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCrossTenancyPeering")
+        private Boolean isCrossTenancyPeering;
+
+        public Builder isCrossTenancyPeering(Boolean isCrossTenancyPeering) {
+            this.isCrossTenancyPeering = isCrossTenancyPeering;
+            this.__explicitlySet__.add("isCrossTenancyPeering");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAdvertisedCidr")
+        private String peerAdvertisedCidr;
+
+        public Builder peerAdvertisedCidr(String peerAdvertisedCidr) {
+            this.peerAdvertisedCidr = peerAdvertisedCidr;
+            this.__explicitlySet__.add("peerAdvertisedCidr");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peeringStatus")
+        private PeeringStatus peeringStatus;
+
+        public Builder peeringStatus(PeeringStatus peeringStatus) {
+            this.peeringStatus = peeringStatus;
+            this.__explicitlySet__.add("peeringStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peeringStatusDetails")
+        private String peeringStatusDetails;
+
+        public Builder peeringStatusDetails(String peeringStatusDetails) {
+            this.peeringStatusDetails = peeringStatusDetails;
+            this.__explicitlySet__.add("peeringStatusDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LocalPeeringGateway build() {
+            LocalPeeringGateway __instance__ =
+                    new LocalPeeringGateway(
+                            compartmentId,
+                            displayName,
+                            id,
+                            isCrossTenancyPeering,
+                            lifecycleState,
+                            peerAdvertisedCidr,
+                            peeringStatus,
+                            peeringStatusDetails,
+                            timeCreated,
+                            vcnId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LocalPeeringGateway o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .isCrossTenancyPeering(o.getIsCrossTenancyPeering())
+                            .lifecycleState(o.getLifecycleState())
+                            .peerAdvertisedCidr(o.getPeerAdvertisedCidr())
+                            .peeringStatus(o.getPeeringStatus())
+                            .peeringStatusDetails(o.getPeeringStatusDetails())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment containing the LPG.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The LPG's Oracle ID (OCID).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Whether the VCN at the other end of the peering is in a different tenancy.
+     * <p>
+     * Example: `false`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCrossTenancyPeering")
+    Boolean isCrossTenancyPeering;
+    /**
+     * The LPG's current lifecycle state.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The LPG's current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The range of IP addresses available on the VCN at the other
+     * end of the peering from this LPG. The value is `null` if the LPG is not peered.
+     * You can use this as the destination CIDR for a route rule to route a subnet's
+     * traffic to this LPG.
+     * <p>
+     * Example: `192.168.0.0/16`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAdvertisedCidr")
+    String peerAdvertisedCidr;
+    /**
+     * Whether the LPG is peered with another LPG. `NEW` means the LPG has not yet been
+     * peered. `PENDING` means the peering is being established. `REVOKED` means the
+     * LPG at the other end of the peering has been deleted.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PeeringStatus {
+        Invalid("INVALID"),
+        New("NEW"),
+        Peered("PEERED"),
+        Pending("PENDING"),
+        Revoked("REVOKED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PeeringStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PeeringStatus v : PeeringStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PeeringStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PeeringStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PeeringStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Whether the LPG is peered with another LPG. `NEW` means the LPG has not yet been
+     * peered. `PENDING` means the peering is being established. `REVOKED` means the
+     * LPG at the other end of the peering has been deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peeringStatus")
+    PeeringStatus peeringStatus;
+
+    /**
+     * Additional information regarding the peering status, if applicable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peeringStatusDetails")
+    String peeringStatusDetails;
+
+    /**
+     * The date and time the LPG was created, in the format defined by RFC3339.
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The OCID of the VCN the LPG belongs to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PortRange.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PortRange.java
@@ -40,7 +40,10 @@ public class PortRange {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PortRange o) {
-            return max(o.getMax()).min(o.getMin());
+            Builder copiedBuilder = max(o.getMax()).min(o.getMin());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
@@ -153,16 +153,20 @@ public class PrivateIp {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PrivateIp o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .id(o.getId())
-                    .ipAddress(o.getIpAddress())
-                    .isPrimary(o.getIsPrimary())
-                    .subnetId(o.getSubnetId())
-                    .timeCreated(o.getTimeCreated())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .id(o.getId())
+                            .ipAddress(o.getIpAddress())
+                            .isPrimary(o.getIsPrimary())
+                            .subnetId(o.getSubnetId())
+                            .timeCreated(o.getTimeCreated())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
@@ -45,7 +45,11 @@ public class RouteRule {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(RouteRule o) {
-            return cidrBlock(o.getCidrBlock()).networkEntityId(o.getNetworkEntityId());
+            Builder copiedBuilder =
+                    cidrBlock(o.getCidrBlock()).networkEntityId(o.getNetworkEntityId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteTable.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteTable.java
@@ -103,13 +103,17 @@ public class RouteTable {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(RouteTable o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .routeRules(o.getRouteRules())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .routeRules(o.getRouteRules())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityList.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityList.java
@@ -120,14 +120,18 @@ public class SecurityList {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SecurityList o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .egressSecurityRules(o.getEgressSecurityRules())
-                    .id(o.getId())
-                    .ingressSecurityRules(o.getIngressSecurityRules())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .egressSecurityRules(o.getEgressSecurityRules())
+                            .id(o.getId())
+                            .ingressSecurityRules(o.getIngressSecurityRules())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
@@ -36,7 +36,10 @@ public class Shape {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Shape o) {
-            return shape(o.getShape());
+            Builder copiedBuilder = shape(o.getShape());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
@@ -195,22 +195,26 @@ public class Subnet {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Subnet o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .cidrBlock(o.getCidrBlock())
-                    .compartmentId(o.getCompartmentId())
-                    .dhcpOptionsId(o.getDhcpOptionsId())
-                    .displayName(o.getDisplayName())
-                    .dnsLabel(o.getDnsLabel())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .prohibitPublicIpOnVnic(o.getProhibitPublicIpOnVnic())
-                    .routeTableId(o.getRouteTableId())
-                    .securityListIds(o.getSecurityListIds())
-                    .subnetDomainName(o.getSubnetDomainName())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnId(o.getVcnId())
-                    .virtualRouterIp(o.getVirtualRouterIp())
-                    .virtualRouterMac(o.getVirtualRouterMac());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .cidrBlock(o.getCidrBlock())
+                            .compartmentId(o.getCompartmentId())
+                            .dhcpOptionsId(o.getDhcpOptionsId())
+                            .displayName(o.getDisplayName())
+                            .dnsLabel(o.getDnsLabel())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .prohibitPublicIpOnVnic(o.getProhibitPublicIpOnVnic())
+                            .routeTableId(o.getRouteTableId())
+                            .securityListIds(o.getSecurityListIds())
+                            .subnetDomainName(o.getSubnetDomainName())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnId(o.getVcnId())
+                            .virtualRouterIp(o.getVirtualRouterIp())
+                            .virtualRouterMac(o.getVirtualRouterMac());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/TcpOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/TcpOptions.java
@@ -45,8 +45,12 @@ public class TcpOptions {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TcpOptions o) {
-            return destinationPortRange(o.getDestinationPortRange())
-                    .sourcePortRange(o.getSourcePortRange());
+            Builder copiedBuilder =
+                    destinationPortRange(o.getDestinationPortRange())
+                            .sourcePortRange(o.getSourcePortRange());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelConfig.java
@@ -52,9 +52,13 @@ public class TunnelConfig {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TunnelConfig o) {
-            return ipAddress(o.getIpAddress())
-                    .sharedSecret(o.getSharedSecret())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    ipAddress(o.getIpAddress())
+                            .sharedSecret(o.getSharedSecret())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelStatus.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelStatus.java
@@ -63,10 +63,14 @@ public class TunnelStatus {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TunnelStatus o) {
-            return ipAddress(o.getIpAddress())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .timeStateModified(o.getTimeStateModified());
+            Builder copiedBuilder =
+                    ipAddress(o.getIpAddress())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeStateModified(o.getTimeStateModified());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UdpOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UdpOptions.java
@@ -45,8 +45,12 @@ public class UdpOptions {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UdpOptions o) {
-            return destinationPortRange(o.getDestinationPortRange())
-                    .sourcePortRange(o.getSourcePortRange());
+            Builder copiedBuilder =
+                    destinationPortRange(o.getDestinationPortRange())
+                            .sourcePortRange(o.getSourcePortRange());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateBootVolumeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateBootVolumeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateBootVolumeDetails build() {
+            UpdateBootVolumeDetails __instance__ = new UpdateBootVolumeDetails(displayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateBootVolumeDetails o) {
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateConsoleHistoryDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateConsoleHistoryDetails.java
@@ -33,7 +33,10 @@ public class UpdateConsoleHistoryDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateConsoleHistoryDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCpeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCpeDetails.java
@@ -31,7 +31,10 @@ public class UpdateCpeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCpeDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectDetails.java
@@ -47,7 +47,10 @@ public class UpdateCrossConnectDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCrossConnectDetails o) {
-            return displayName(o.getDisplayName()).isActive(o.getIsActive());
+            Builder copiedBuilder = displayName(o.getDisplayName()).isActive(o.getIsActive());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectGroupDetails.java
@@ -34,7 +34,10 @@ public class UpdateCrossConnectGroupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCrossConnectGroupDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDhcpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDhcpDetails.java
@@ -42,7 +42,10 @@ public class UpdateDhcpDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateDhcpDetails o) {
-            return displayName(o.getDisplayName()).options(o.getOptions());
+            Builder copiedBuilder = displayName(o.getDisplayName()).options(o.getOptions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgAttachmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgAttachmentDetails.java
@@ -33,7 +33,10 @@ public class UpdateDrgAttachmentDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateDrgAttachmentDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgDetails.java
@@ -31,7 +31,10 @@ public class UpdateDrgDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateDrgDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionDetails.java
@@ -34,7 +34,10 @@ public class UpdateIPSecConnectionDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateIPSecConnectionDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateImageDetails.java
@@ -33,7 +33,10 @@ public class UpdateImageDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateImageDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
@@ -33,7 +33,10 @@ public class UpdateInstanceDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateInstanceDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInternetGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInternetGatewayDetails.java
@@ -43,7 +43,10 @@ public class UpdateInternetGatewayDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateInternetGatewayDetails o) {
-            return displayName(o.getDisplayName()).isEnabled(o.getIsEnabled());
+            Builder copiedBuilder = displayName(o.getDisplayName()).isEnabled(o.getIsEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLocalPeeringGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLocalPeeringGatewayDetails.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateLocalPeeringGatewayDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateLocalPeeringGatewayDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateLocalPeeringGatewayDetails build() {
+            UpdateLocalPeeringGatewayDetails __instance__ =
+                    new UpdateLocalPeeringGatewayDetails(displayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateLocalPeeringGatewayDetails o) {
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdatePrivateIpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdatePrivateIpDetails.java
@@ -52,9 +52,13 @@ public class UpdatePrivateIpDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdatePrivateIpDetails o) {
-            return displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateRouteTableDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateRouteTableDetails.java
@@ -43,7 +43,10 @@ public class UpdateRouteTableDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateRouteTableDetails o) {
-            return displayName(o.getDisplayName()).routeRules(o.getRouteRules());
+            Builder copiedBuilder = displayName(o.getDisplayName()).routeRules(o.getRouteRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSecurityListDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSecurityListDetails.java
@@ -54,9 +54,13 @@ public class UpdateSecurityListDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateSecurityListDetails o) {
-            return displayName(o.getDisplayName())
-                    .egressSecurityRules(o.getEgressSecurityRules())
-                    .ingressSecurityRules(o.getIngressSecurityRules());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .egressSecurityRules(o.getEgressSecurityRules())
+                            .ingressSecurityRules(o.getIngressSecurityRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSubnetDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSubnetDetails.java
@@ -33,7 +33,10 @@ public class UpdateSubnetDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateSubnetDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVcnDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVcnDetails.java
@@ -31,7 +31,10 @@ public class UpdateVcnDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateVcnDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
@@ -96,13 +96,17 @@ public class UpdateVirtualCircuitDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateVirtualCircuitDetails o) {
-            return bandwidthShapeName(o.getBandwidthShapeName())
-                    .crossConnectMappings(o.getCrossConnectMappings())
-                    .customerBgpAsn(o.getCustomerBgpAsn())
-                    .displayName(o.getDisplayName())
-                    .gatewayId(o.getGatewayId())
-                    .providerState(o.getProviderState())
-                    .referenceComment(o.getReferenceComment());
+            Builder copiedBuilder =
+                    bandwidthShapeName(o.getBandwidthShapeName())
+                            .crossConnectMappings(o.getCrossConnectMappings())
+                            .customerBgpAsn(o.getCustomerBgpAsn())
+                            .displayName(o.getDisplayName())
+                            .gatewayId(o.getGatewayId())
+                            .providerState(o.getProviderState())
+                            .referenceComment(o.getReferenceComment());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVnicDetails.java
@@ -52,9 +52,13 @@ public class UpdateVnicDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateVnicDetails o) {
-            return displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .skipSourceDestCheck(o.getSkipSourceDestCheck());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .skipSourceDestCheck(o.getSkipSourceDestCheck());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeBackupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeBackupDetails.java
@@ -33,7 +33,10 @@ public class UpdateVolumeBackupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateVolumeBackupDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
@@ -33,7 +33,10 @@ public class UpdateVolumeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateVolumeDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
@@ -142,17 +142,21 @@ public class Vcn {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Vcn o) {
-            return cidrBlock(o.getCidrBlock())
-                    .compartmentId(o.getCompartmentId())
-                    .defaultDhcpOptionsId(o.getDefaultDhcpOptionsId())
-                    .defaultRouteTableId(o.getDefaultRouteTableId())
-                    .defaultSecurityListId(o.getDefaultSecurityListId())
-                    .displayName(o.getDisplayName())
-                    .dnsLabel(o.getDnsLabel())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated())
-                    .vcnDomainName(o.getVcnDomainName());
+            Builder copiedBuilder =
+                    cidrBlock(o.getCidrBlock())
+                            .compartmentId(o.getCompartmentId())
+                            .defaultDhcpOptionsId(o.getDefaultDhcpOptionsId())
+                            .defaultRouteTableId(o.getDefaultRouteTableId())
+                            .defaultSecurityListId(o.getDefaultSecurityListId())
+                            .displayName(o.getDisplayName())
+                            .dnsLabel(o.getDnsLabel())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .vcnDomainName(o.getVcnDomainName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
@@ -218,23 +218,27 @@ public class VirtualCircuit {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VirtualCircuit o) {
-            return bandwidthShapeName(o.getBandwidthShapeName())
-                    .bgpSessionState(o.getBgpSessionState())
-                    .compartmentId(o.getCompartmentId())
-                    .crossConnectMappings(o.getCrossConnectMappings())
-                    .customerBgpAsn(o.getCustomerBgpAsn())
-                    .displayName(o.getDisplayName())
-                    .gatewayId(o.getGatewayId())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .oracleBgpAsn(o.getOracleBgpAsn())
-                    .providerName(o.getProviderName())
-                    .providerServiceName(o.getProviderServiceName())
-                    .providerState(o.getProviderState())
-                    .referenceComment(o.getReferenceComment())
-                    .region(o.getRegion())
-                    .timeCreated(o.getTimeCreated())
-                    .type(o.getType());
+            Builder copiedBuilder =
+                    bandwidthShapeName(o.getBandwidthShapeName())
+                            .bgpSessionState(o.getBgpSessionState())
+                            .compartmentId(o.getCompartmentId())
+                            .crossConnectMappings(o.getCrossConnectMappings())
+                            .customerBgpAsn(o.getCustomerBgpAsn())
+                            .displayName(o.getDisplayName())
+                            .gatewayId(o.getGatewayId())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .oracleBgpAsn(o.getOracleBgpAsn())
+                            .providerName(o.getProviderName())
+                            .providerServiceName(o.getProviderServiceName())
+                            .providerState(o.getProviderState())
+                            .referenceComment(o.getReferenceComment())
+                            .region(o.getRegion())
+                            .timeCreated(o.getTimeCreated())
+                            .type(o.getType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuitBandwidthShape.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuitBandwidthShape.java
@@ -47,7 +47,10 @@ public class VirtualCircuitBandwidthShape {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VirtualCircuitBandwidthShape o) {
-            return bandwidthInMbps(o.getBandwidthInMbps()).name(o.getName());
+            Builder copiedBuilder = bandwidthInMbps(o.getBandwidthInMbps()).name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Vnic.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Vnic.java
@@ -171,19 +171,23 @@ public class Vnic {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Vnic o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .hostnameLabel(o.getHostnameLabel())
-                    .id(o.getId())
-                    .isPrimary(o.getIsPrimary())
-                    .lifecycleState(o.getLifecycleState())
-                    .macAddress(o.getMacAddress())
-                    .privateIp(o.getPrivateIp())
-                    .publicIp(o.getPublicIp())
-                    .skipSourceDestCheck(o.getSkipSourceDestCheck())
-                    .subnetId(o.getSubnetId())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .id(o.getId())
+                            .isPrimary(o.getIsPrimary())
+                            .lifecycleState(o.getLifecycleState())
+                            .macAddress(o.getMacAddress())
+                            .privateIp(o.getPrivateIp())
+                            .publicIp(o.getPublicIp())
+                            .skipSourceDestCheck(o.getSkipSourceDestCheck())
+                            .subnetId(o.getSubnetId())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VnicAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VnicAttachment.java
@@ -70,6 +70,15 @@ public class VnicAttachment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nicIndex")
+        private Integer nicIndex;
+
+        public Builder nicIndex(Integer nicIndex) {
+            this.nicIndex = nicIndex;
+            this.__explicitlySet__.add("nicIndex");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
         private String subnetId;
 
@@ -118,6 +127,7 @@ public class VnicAttachment {
                             id,
                             instanceId,
                             lifecycleState,
+                            nicIndex,
                             subnetId,
                             timeCreated,
                             vlanTag,
@@ -128,16 +138,21 @@ public class VnicAttachment {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VnicAttachment o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .instanceId(o.getInstanceId())
-                    .lifecycleState(o.getLifecycleState())
-                    .subnetId(o.getSubnetId())
-                    .timeCreated(o.getTimeCreated())
-                    .vlanTag(o.getVlanTag())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .instanceId(o.getInstanceId())
+                            .lifecycleState(o.getLifecycleState())
+                            .nicIndex(o.getNicIndex())
+                            .subnetId(o.getSubnetId())
+                            .timeCreated(o.getTimeCreated())
+                            .vlanTag(o.getVlanTag())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -237,6 +252,17 @@ public class VnicAttachment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * Which physical network interface card (NIC) the VNIC uses.
+     * Certain bare metal instance shapes have two active physical NICs (0 and 1). If
+     * you add a secondary VNIC to one of these instances, you can specify which NIC
+     * the VNIC will use. For more information, see
+     * [Virtual Network Interface Cards (VNICs)](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingVNICs.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nicIndex")
+    Integer nicIndex;
 
     /**
      * The OCID of the VNIC's subnet.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackup.java
@@ -143,17 +143,21 @@ public class VolumeBackup {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VolumeBackup o) {
-            return compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .sizeInGBs(o.getSizeInGBs())
-                    .sizeInMBs(o.getSizeInMBs())
-                    .timeCreated(o.getTimeCreated())
-                    .timeRequestReceived(o.getTimeRequestReceived())
-                    .uniqueSizeInGBs(o.getUniqueSizeInGBs())
-                    .uniqueSizeInMbs(o.getUniqueSizeInMbs())
-                    .volumeId(o.getVolumeId());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .sizeInGBs(o.getSizeInGBs())
+                            .sizeInMBs(o.getSizeInMBs())
+                            .timeCreated(o.getTimeCreated())
+                            .timeRequestReceived(o.getTimeRequestReceived())
+                            .uniqueSizeInGBs(o.getUniqueSizeInGBs())
+                            .uniqueSizeInMbs(o.getUniqueSizeInMbs())
+                            .volumeId(o.getVolumeId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AttachBootVolumeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AttachBootVolumeRequest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AttachBootVolumeRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Attach boot volume request
+     */
+    private AttachBootVolumeDetails attachBootVolumeDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AttachBootVolumeRequest o) {
+            attachBootVolumeDetails(o.getAttachBootVolumeDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            return this;
+        }
+
+        /**
+         * Build the instance of AttachBootVolumeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AttachBootVolumeRequest
+         */
+        public AttachBootVolumeRequest build() {
+            AttachBootVolumeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ConnectLocalPeeringGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ConnectLocalPeeringGatewaysRequest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ConnectLocalPeeringGatewaysRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the local peering gateway.
+     */
+    private String localPeeringGatewayId;
+
+    /**
+     * Details regarding the local peering gateway to connect.
+     */
+    private ConnectLocalPeeringGatewaysDetails connectLocalPeeringGatewaysDetails;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ConnectLocalPeeringGatewaysRequest o) {
+            localPeeringGatewayId(o.getLocalPeeringGatewayId());
+            connectLocalPeeringGatewaysDetails(o.getConnectLocalPeeringGatewaysDetails());
+            return this;
+        }
+
+        /**
+         * Build the instance of ConnectLocalPeeringGatewaysRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ConnectLocalPeeringGatewaysRequest
+         */
+        public ConnectLocalPeeringGatewaysRequest build() {
+            ConnectLocalPeeringGatewaysRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateLocalPeeringGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateLocalPeeringGatewayRequest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateLocalPeeringGatewayRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Details for creating a new local peering gateway.
+     */
+    private CreateLocalPeeringGatewayDetails createLocalPeeringGatewayDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateLocalPeeringGatewayRequest o) {
+            createLocalPeeringGatewayDetails(o.getCreateLocalPeeringGatewayDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateLocalPeeringGatewayRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateLocalPeeringGatewayRequest
+         */
+        public CreateLocalPeeringGatewayRequest build() {
+            CreateLocalPeeringGatewayRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteBootVolumeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteBootVolumeRequest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteBootVolumeRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the boot volume.
+     */
+    private String bootVolumeId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBootVolumeRequest o) {
+            bootVolumeId(o.getBootVolumeId());
+            ifMatch(o.getIfMatch());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteBootVolumeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteBootVolumeRequest
+         */
+        public DeleteBootVolumeRequest build() {
+            DeleteBootVolumeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteLocalPeeringGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteLocalPeeringGatewayRequest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteLocalPeeringGatewayRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the local peering gateway.
+     */
+    private String localPeeringGatewayId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteLocalPeeringGatewayRequest o) {
+            localPeeringGatewayId(o.getLocalPeeringGatewayId());
+            ifMatch(o.getIfMatch());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteLocalPeeringGatewayRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteLocalPeeringGatewayRequest
+         */
+        public DeleteLocalPeeringGatewayRequest build() {
+            DeleteLocalPeeringGatewayRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DetachBootVolumeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DetachBootVolumeRequest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DetachBootVolumeRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the boot volume attachment.
+     */
+    private String bootVolumeAttachmentId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DetachBootVolumeRequest o) {
+            bootVolumeAttachmentId(o.getBootVolumeAttachmentId());
+            ifMatch(o.getIfMatch());
+            return this;
+        }
+
+        /**
+         * Build the instance of DetachBootVolumeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DetachBootVolumeRequest
+         */
+        public DetachBootVolumeRequest build() {
+            DetachBootVolumeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetBootVolumeAttachmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetBootVolumeAttachmentRequest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetBootVolumeAttachmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the boot volume attachment.
+     */
+    private String bootVolumeAttachmentId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBootVolumeAttachmentRequest o) {
+            bootVolumeAttachmentId(o.getBootVolumeAttachmentId());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetBootVolumeAttachmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetBootVolumeAttachmentRequest
+         */
+        public GetBootVolumeAttachmentRequest build() {
+            GetBootVolumeAttachmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetBootVolumeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetBootVolumeRequest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetBootVolumeRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the boot volume.
+     */
+    private String bootVolumeId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBootVolumeRequest o) {
+            bootVolumeId(o.getBootVolumeId());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetBootVolumeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetBootVolumeRequest
+         */
+        public GetBootVolumeRequest build() {
+            GetBootVolumeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetLocalPeeringGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetLocalPeeringGatewayRequest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetLocalPeeringGatewayRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the local peering gateway.
+     */
+    private String localPeeringGatewayId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetLocalPeeringGatewayRequest o) {
+            localPeeringGatewayId(o.getLocalPeeringGatewayId());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetLocalPeeringGatewayRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetLocalPeeringGatewayRequest
+         */
+        public GetLocalPeeringGatewayRequest build() {
+            GetLocalPeeringGatewayRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListBootVolumeAttachmentsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListBootVolumeAttachmentsRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListBootVolumeAttachmentsRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The name of the Availability Domain.
+     * <p>
+     * Example: `Uocm:PHX-AD-1`
+     *
+     */
+    private String availabilityDomain;
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return in a paginated \"List\" call.
+     * <p>
+     * Example: `500`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The OCID of the instance.
+     */
+    private String instanceId;
+
+    /**
+     * The OCID of the boot volume.
+     */
+    private String bootVolumeId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBootVolumeAttachmentsRequest o) {
+            availabilityDomain(o.getAvailabilityDomain());
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            instanceId(o.getInstanceId());
+            bootVolumeId(o.getBootVolumeId());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBootVolumeAttachmentsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBootVolumeAttachmentsRequest
+         */
+        public ListBootVolumeAttachmentsRequest build() {
+            ListBootVolumeAttachmentsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListBootVolumesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListBootVolumesRequest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListBootVolumesRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The name of the Availability Domain.
+     * <p>
+     * Example: `Uocm:PHX-AD-1`
+     *
+     */
+    private String availabilityDomain;
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return in a paginated \"List\" call.
+     * <p>
+     * Example: `500`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBootVolumesRequest o) {
+            availabilityDomain(o.getAvailabilityDomain());
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBootVolumesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBootVolumesRequest
+         */
+        public ListBootVolumesRequest build() {
+            ListBootVolumesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListLocalPeeringGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListLocalPeeringGatewaysRequest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListLocalPeeringGatewaysRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * The OCID of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * The maximum number of items to return in a paginated \"List\" call.
+     * <p>
+     * Example: `500`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListLocalPeeringGatewaysRequest o) {
+            compartmentId(o.getCompartmentId());
+            vcnId(o.getVcnId());
+            limit(o.getLimit());
+            page(o.getPage());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListLocalPeeringGatewaysRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListLocalPeeringGatewaysRequest
+         */
+        public ListLocalPeeringGatewaysRequest build() {
+            ListLocalPeeringGatewaysRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/TerminateInstanceRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/TerminateInstanceRequest.java
@@ -23,6 +23,11 @@ public class TerminateInstanceRequest extends com.oracle.bmc.requests.BmcRequest
      */
     private String ifMatch;
 
+    /**
+     * Specifies whether to delete or preserve the boot volume when terminating an instance.
+     */
+    private Boolean preserveBootVolume;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -46,6 +51,7 @@ public class TerminateInstanceRequest extends com.oracle.bmc.requests.BmcRequest
         public Builder copy(TerminateInstanceRequest o) {
             instanceId(o.getInstanceId());
             ifMatch(o.getIfMatch());
+            preserveBootVolume(o.getPreserveBootVolume());
             return this;
         }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateBootVolumeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateBootVolumeRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateBootVolumeRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the boot volume.
+     */
+    private String bootVolumeId;
+
+    /**
+     * Update boot volume's display name.
+     */
+    private UpdateBootVolumeDetails updateBootVolumeDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBootVolumeRequest o) {
+            bootVolumeId(o.getBootVolumeId());
+            updateBootVolumeDetails(o.getUpdateBootVolumeDetails());
+            ifMatch(o.getIfMatch());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateBootVolumeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateBootVolumeRequest
+         */
+        public UpdateBootVolumeRequest build() {
+            UpdateBootVolumeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateLocalPeeringGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateLocalPeeringGatewayRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateLocalPeeringGatewayRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the local peering gateway.
+     */
+    private String localPeeringGatewayId;
+
+    /**
+     * Details object for updating a local peering gateway.
+     */
+    private UpdateLocalPeeringGatewayDetails updateLocalPeeringGatewayDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLocalPeeringGatewayRequest o) {
+            localPeeringGatewayId(o.getLocalPeeringGatewayId());
+            updateLocalPeeringGatewayDetails(o.getUpdateLocalPeeringGatewayDetails());
+            ifMatch(o.getIfMatch());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateLocalPeeringGatewayRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateLocalPeeringGatewayRequest
+         */
+        public UpdateLocalPeeringGatewayRequest build() {
+            UpdateLocalPeeringGatewayRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/AttachBootVolumeResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/AttachBootVolumeResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AttachBootVolumeResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BootVolumeAttachment instance.
+     */
+    private BootVolumeAttachment bootVolumeAttachment;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AttachBootVolumeResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            bootVolumeAttachment(o.getBootVolumeAttachment());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ConnectLocalPeeringGatewaysResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ConnectLocalPeeringGatewaysResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ConnectLocalPeeringGatewaysResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ConnectLocalPeeringGatewaysResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateLocalPeeringGatewayResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateLocalPeeringGatewayResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateLocalPeeringGatewayResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LocalPeeringGateway instance.
+     */
+    private LocalPeeringGateway localPeeringGateway;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateLocalPeeringGatewayResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            localPeeringGateway(o.getLocalPeeringGateway());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteBootVolumeResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteBootVolumeResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteBootVolumeResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBootVolumeResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteLocalPeeringGatewayResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteLocalPeeringGatewayResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteLocalPeeringGatewayResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteLocalPeeringGatewayResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/DetachBootVolumeResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/DetachBootVolumeResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DetachBootVolumeResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DetachBootVolumeResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetBootVolumeAttachmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetBootVolumeAttachmentResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetBootVolumeAttachmentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BootVolumeAttachment instance.
+     */
+    private BootVolumeAttachment bootVolumeAttachment;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBootVolumeAttachmentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            bootVolumeAttachment(o.getBootVolumeAttachment());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetBootVolumeResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetBootVolumeResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetBootVolumeResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BootVolume instance.
+     */
+    private BootVolume bootVolume;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBootVolumeResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            bootVolume(o.getBootVolume());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetLocalPeeringGatewayResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetLocalPeeringGatewayResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetLocalPeeringGatewayResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LocalPeeringGateway instance.
+     */
+    private LocalPeeringGateway localPeeringGateway;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetLocalPeeringGatewayResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            localPeeringGateway(o.getLocalPeeringGateway());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListBootVolumeAttachmentsResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListBootVolumeAttachmentsResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListBootVolumeAttachmentsResponse {
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of BootVolumeAttachment instances.
+     */
+    private java.util.List<BootVolumeAttachment> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBootVolumeAttachmentsResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListBootVolumesResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListBootVolumesResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListBootVolumesResponse {
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of BootVolume instances.
+     */
+    private java.util.List<BootVolume> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBootVolumesResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListLocalPeeringGatewaysResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListLocalPeeringGatewaysResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListLocalPeeringGatewaysResponse {
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of LocalPeeringGateway instances.
+     */
+    private java.util.List<LocalPeeringGateway> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListLocalPeeringGatewaysResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateBootVolumeResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateBootVolumeResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateBootVolumeResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BootVolume instance.
+     */
+    private BootVolume bootVolume;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBootVolumeResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            bootVolume(o.getBootVolume());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateLocalPeeringGatewayResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateLocalPeeringGatewayResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateLocalPeeringGatewayResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LocalPeeringGateway instance.
+     */
+    private LocalPeeringGateway localPeeringGateway;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLocalPeeringGatewayResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            localPeeringGateway(o.getLocalPeeringGateway());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.database;
 
+import java.util.Locale;
 import com.oracle.bmc.database.internal.http.*;
 import com.oracle.bmc.database.requests.*;
 import com.oracle.bmc.database.responses.*;
@@ -101,7 +102,7 @@ public class DatabaseAsyncClient implements DatabaseAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.database;
 
+import java.util.Locale;
 import com.oracle.bmc.database.internal.http.*;
 import com.oracle.bmc.database.requests.*;
 import com.oracle.bmc.database.responses.*;
@@ -120,7 +121,7 @@ public class DatabaseClient implements Database {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
@@ -73,10 +73,14 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDataGuardAssociationToExistingDbSystemDetails o) {
-            return databaseAdminPassword(o.getDatabaseAdminPassword())
-                    .protectionMode(o.getProtectionMode())
-                    .transportType(o.getTransportType())
-                    .peerDbSystemId(o.getPeerDbSystemId());
+            Builder copiedBuilder =
+                    databaseAdminPassword(o.getDatabaseAdminPassword())
+                            .protectionMode(o.getProtectionMode())
+                            .transportType(o.getTransportType())
+                            .peerDbSystemId(o.getPeerDbSystemId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDatabaseFromBackupDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDatabaseFromBackupDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+        private String adminPassword;
+
+        public Builder adminPassword(String adminPassword) {
+            this.adminPassword = adminPassword;
+            this.__explicitlySet__.add("adminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupId")
+        private String backupId;
+
+        public Builder backupId(String backupId) {
+            this.backupId = backupId;
+            this.__explicitlySet__.add("backupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupTDEPassword")
+        private String backupTDEPassword;
+
+        public Builder backupTDEPassword(String backupTDEPassword) {
+            this.backupTDEPassword = backupTDEPassword;
+            this.__explicitlySet__.add("backupTDEPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDatabaseFromBackupDetails build() {
+            CreateDatabaseFromBackupDetails __instance__ =
+                    new CreateDatabaseFromBackupDetails(adminPassword, backupId, backupTDEPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDatabaseFromBackupDetails o) {
+            Builder copiedBuilder =
+                    adminPassword(o.getAdminPassword())
+                            .backupId(o.getBackupId())
+                            .backupTDEPassword(o.getBackupTDEPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+    String adminPassword;
+
+    /**
+     * The backup OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupId")
+    String backupId;
+
+    /**
+     * The password to open the TDE wallet.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupTDEPassword")
+    String backupTDEPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeDetails.java
@@ -52,9 +52,13 @@ public class CreateDbHomeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDbHomeDetails o) {
-            return database(o.getDatabase())
-                    .dbVersion(o.getDbVersion())
-                    .displayName(o.getDisplayName());
+            Builder copiedBuilder =
+                    database(o.getDatabase())
+                            .dbVersion(o.getDbVersion())
+                            .displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdBase.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@lombok.experimental.NonFinal
+@lombok.AllArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source",
+    defaultImpl = CreateDbHomeWithDbSystemIdBase.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithDbSystemIdFromBackupDetails.class,
+        name = "DB_BACKUP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithDbSystemIdDetails.class,
+        name = "NONE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeWithDbSystemIdBase {
+
+    /**
+     * The OCID of the DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    /**
+     * The user-provided name of the database home.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdDetails.java
@@ -8,35 +8,24 @@ package com.oracle.bmc.database.model;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
     builder = CreateDbHomeWithDbSystemIdDetails.Builder.class
 )
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class CreateDbHomeWithDbSystemIdDetails {
+public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeWithDbSystemIdBase {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("database")
-        private CreateDatabaseDetails database;
-
-        public Builder database(CreateDatabaseDetails database) {
-            this.database = database;
-            this.__explicitlySet__.add("database");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
         private String dbSystemId;
 
         public Builder dbSystemId(String dbSystemId) {
             this.dbSystemId = dbSystemId;
             this.__explicitlySet__.add("dbSystemId");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
-        private String dbVersion;
-
-        public Builder dbVersion(String dbVersion) {
-            this.dbVersion = dbVersion;
-            this.__explicitlySet__.add("dbVersion");
             return this;
         }
 
@@ -49,23 +38,45 @@ public class CreateDbHomeWithDbSystemIdDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseDetails database;
+
+        public Builder database(CreateDatabaseDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDbHomeWithDbSystemIdDetails build() {
             CreateDbHomeWithDbSystemIdDetails __instance__ =
                     new CreateDbHomeWithDbSystemIdDetails(
-                            database, dbSystemId, dbVersion, displayName);
+                            dbSystemId, displayName, database, dbVersion);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDbHomeWithDbSystemIdDetails o) {
-            return database(o.getDatabase())
-                    .dbSystemId(o.getDbSystemId())
-                    .dbVersion(o.getDbVersion())
-                    .displayName(o.getDisplayName());
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .displayName(o.getDisplayName())
+                            .database(o.getDatabase())
+                            .dbVersion(o.getDbVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -76,26 +87,24 @@ public class CreateDbHomeWithDbSystemIdDetails {
         return new Builder();
     }
 
+    public CreateDbHomeWithDbSystemIdDetails(
+            String dbSystemId,
+            String displayName,
+            CreateDatabaseDetails database,
+            String dbVersion) {
+        super(dbSystemId, displayName);
+        this.database = database;
+        this.dbVersion = dbVersion;
+    }
+
     @com.fasterxml.jackson.annotation.JsonProperty("database")
     CreateDatabaseDetails database;
-
-    /**
-     * The OCID of the DB System.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
-    String dbSystemId;
 
     /**
      * A valid Oracle database version. To get a list of supported versions, use the {@link #listDbVersions(ListDbVersionsRequest) listDbVersions} operation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
     String dbVersion;
-
-    /**
-     * The user-provided name of the database home.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
-    String displayName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromBackupDetails.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbHomeWithDbSystemIdFromBackupDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeWithDbSystemIdBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseFromBackupDetails database;
+
+        public Builder database(CreateDatabaseFromBackupDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbHomeWithDbSystemIdFromBackupDetails build() {
+            CreateDbHomeWithDbSystemIdFromBackupDetails __instance__ =
+                    new CreateDbHomeWithDbSystemIdFromBackupDetails(
+                            dbSystemId, displayName, database);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbHomeWithDbSystemIdFromBackupDetails o) {
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .displayName(o.getDisplayName())
+                            .database(o.getDatabase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public CreateDbHomeWithDbSystemIdFromBackupDetails(
+            String dbSystemId, String displayName, CreateDatabaseFromBackupDetails database) {
+        super(dbSystemId, displayName);
+        this.database = database;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("database")
+    CreateDatabaseFromBackupDetails database;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DataGuardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DataGuardAssociation.java
@@ -187,21 +187,25 @@ public class DataGuardAssociation {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DataGuardAssociation o) {
-            return applyLag(o.getApplyLag())
-                    .applyRate(o.getApplyRate())
-                    .databaseId(o.getDatabaseId())
-                    .id(o.getId())
-                    .lifecycleDetails(o.getLifecycleDetails())
-                    .lifecycleState(o.getLifecycleState())
-                    .peerDataGuardAssociationId(o.getPeerDataGuardAssociationId())
-                    .peerDatabaseId(o.getPeerDatabaseId())
-                    .peerDbHomeId(o.getPeerDbHomeId())
-                    .peerDbSystemId(o.getPeerDbSystemId())
-                    .peerRole(o.getPeerRole())
-                    .protectionMode(o.getProtectionMode())
-                    .role(o.getRole())
-                    .timeCreated(o.getTimeCreated())
-                    .transportType(o.getTransportType());
+            Builder copiedBuilder =
+                    applyLag(o.getApplyLag())
+                            .applyRate(o.getApplyRate())
+                            .databaseId(o.getDatabaseId())
+                            .id(o.getId())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .lifecycleState(o.getLifecycleState())
+                            .peerDataGuardAssociationId(o.getPeerDataGuardAssociationId())
+                            .peerDatabaseId(o.getPeerDatabaseId())
+                            .peerDbHomeId(o.getPeerDbHomeId())
+                            .peerDbSystemId(o.getPeerDbSystemId())
+                            .peerRole(o.getPeerRole())
+                            .protectionMode(o.getProtectionMode())
+                            .role(o.getRole())
+                            .timeCreated(o.getTimeCreated())
+                            .transportType(o.getTransportType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHome.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHome.java
@@ -114,14 +114,18 @@ public class DbHome {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbHome o) {
-            return compartmentId(o.getCompartmentId())
-                    .dbSystemId(o.getDbSystemId())
-                    .dbVersion(o.getDbVersion())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .dbSystemId(o.getDbSystemId())
+                            .dbVersion(o.getDbVersion())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHomeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHomeSummary.java
@@ -114,14 +114,18 @@ public class DbHomeSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbHomeSummary o) {
-            return compartmentId(o.getCompartmentId())
-                    .dbSystemId(o.getDbSystemId())
-                    .dbVersion(o.getDbVersion())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .dbSystemId(o.getDbSystemId())
+                            .dbVersion(o.getDbVersion())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
@@ -109,14 +109,18 @@ public class DbNode {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbNode o) {
-            return backupVnicId(o.getBackupVnicId())
-                    .dbSystemId(o.getDbSystemId())
-                    .hostname(o.getHostname())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .softwareStorageSizeInGB(o.getSoftwareStorageSizeInGB())
-                    .timeCreated(o.getTimeCreated())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    backupVnicId(o.getBackupVnicId())
+                            .dbSystemId(o.getDbSystemId())
+                            .hostname(o.getHostname())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .softwareStorageSizeInGB(o.getSoftwareStorageSizeInGB())
+                            .timeCreated(o.getTimeCreated())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
@@ -109,14 +109,18 @@ public class DbNodeSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbNodeSummary o) {
-            return backupVnicId(o.getBackupVnicId())
-                    .dbSystemId(o.getDbSystemId())
-                    .hostname(o.getHostname())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .softwareStorageSizeInGB(o.getSoftwareStorageSizeInGB())
-                    .timeCreated(o.getTimeCreated())
-                    .vnicId(o.getVnicId());
+            Builder copiedBuilder =
+                    backupVnicId(o.getBackupVnicId())
+                            .dbSystemId(o.getDbSystemId())
+                            .hostname(o.getHostname())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .softwareStorageSizeInGB(o.getSoftwareStorageSizeInGB())
+                            .timeCreated(o.getTimeCreated())
+                            .vnicId(o.getVnicId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
@@ -60,9 +60,13 @@ public class DbSystemShapeSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbSystemShapeSummary o) {
-            return availableCoreCount(o.getAvailableCoreCount())
-                    .name(o.getName())
-                    .shape(o.getShape());
+            Builder copiedBuilder =
+                    availableCoreCount(o.getAvailableCoreCount())
+                            .name(o.getName())
+                            .shape(o.getShape());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbVersionSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbVersionSummary.java
@@ -46,7 +46,10 @@ public class DbVersionSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DbVersionSummary o) {
-            return supportsPdb(o.getSupportsPdb()).version(o.getVersion());
+            Builder copiedBuilder = supportsPdb(o.getSupportsPdb()).version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/FailoverDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/FailoverDataGuardAssociationDetails.java
@@ -38,7 +38,10 @@ public class FailoverDataGuardAssociationDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(FailoverDataGuardAssociationDetails o) {
-            return databaseAdminPassword(o.getDatabaseAdminPassword());
+            Builder copiedBuilder = databaseAdminPassword(o.getDatabaseAdminPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemDetails.java
@@ -205,24 +205,28 @@ public class LaunchDbSystemDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LaunchDbSystemDetails o) {
-            return availabilityDomain(o.getAvailabilityDomain())
-                    .backupSubnetId(o.getBackupSubnetId())
-                    .clusterName(o.getClusterName())
-                    .compartmentId(o.getCompartmentId())
-                    .cpuCoreCount(o.getCpuCoreCount())
-                    .dataStoragePercentage(o.getDataStoragePercentage())
-                    .databaseEdition(o.getDatabaseEdition())
-                    .dbHome(o.getDbHome())
-                    .diskRedundancy(o.getDiskRedundancy())
-                    .displayName(o.getDisplayName())
-                    .domain(o.getDomain())
-                    .hostname(o.getHostname())
-                    .initialDataStorageSizeInGB(o.getInitialDataStorageSizeInGB())
-                    .licenseModel(o.getLicenseModel())
-                    .nodeCount(o.getNodeCount())
-                    .shape(o.getShape())
-                    .sshPublicKeys(o.getSshPublicKeys())
-                    .subnetId(o.getSubnetId());
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .backupSubnetId(o.getBackupSubnetId())
+                            .clusterName(o.getClusterName())
+                            .compartmentId(o.getCompartmentId())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .dataStoragePercentage(o.getDataStoragePercentage())
+                            .databaseEdition(o.getDatabaseEdition())
+                            .dbHome(o.getDbHome())
+                            .diskRedundancy(o.getDiskRedundancy())
+                            .displayName(o.getDisplayName())
+                            .domain(o.getDomain())
+                            .hostname(o.getHostname())
+                            .initialDataStorageSizeInGB(o.getInitialDataStorageSizeInGB())
+                            .licenseModel(o.getLicenseModel())
+                            .nodeCount(o.getNodeCount())
+                            .shape(o.getShape())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .subnetId(o.getSubnetId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Patch.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Patch.java
@@ -111,14 +111,18 @@ public class Patch {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Patch o) {
-            return availableActions(o.getAvailableActions())
-                    .description(o.getDescription())
-                    .id(o.getId())
-                    .lastAction(o.getLastAction())
-                    .lifecycleDetails(o.getLifecycleDetails())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeReleased(o.getTimeReleased())
-                    .version(o.getVersion());
+            Builder copiedBuilder =
+                    availableActions(o.getAvailableActions())
+                            .description(o.getDescription())
+                            .id(o.getId())
+                            .lastAction(o.getLastAction())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeReleased(o.getTimeReleased())
+                            .version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchDetails.java
@@ -46,7 +46,10 @@ public class PatchDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PatchDetails o) {
-            return action(o.getAction()).patchId(o.getPatchId());
+            Builder copiedBuilder = action(o.getAction()).patchId(o.getPatchId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchHistoryEntry.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchHistoryEntry.java
@@ -98,13 +98,17 @@ public class PatchHistoryEntry {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PatchHistoryEntry o) {
-            return action(o.getAction())
-                    .id(o.getId())
-                    .lifecycleDetails(o.getLifecycleDetails())
-                    .lifecycleState(o.getLifecycleState())
-                    .patchId(o.getPatchId())
-                    .timeEnded(o.getTimeEnded())
-                    .timeStarted(o.getTimeStarted());
+            Builder copiedBuilder =
+                    action(o.getAction())
+                            .id(o.getId())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .lifecycleState(o.getLifecycleState())
+                            .patchId(o.getPatchId())
+                            .timeEnded(o.getTimeEnded())
+                            .timeStarted(o.getTimeStarted());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchHistoryEntrySummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchHistoryEntrySummary.java
@@ -98,13 +98,17 @@ public class PatchHistoryEntrySummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PatchHistoryEntrySummary o) {
-            return action(o.getAction())
-                    .id(o.getId())
-                    .lifecycleDetails(o.getLifecycleDetails())
-                    .lifecycleState(o.getLifecycleState())
-                    .patchId(o.getPatchId())
-                    .timeEnded(o.getTimeEnded())
-                    .timeStarted(o.getTimeStarted());
+            Builder copiedBuilder =
+                    action(o.getAction())
+                            .id(o.getId())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .lifecycleState(o.getLifecycleState())
+                            .patchId(o.getPatchId())
+                            .timeEnded(o.getTimeEnded())
+                            .timeStarted(o.getTimeStarted());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PatchSummary.java
@@ -111,14 +111,18 @@ public class PatchSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PatchSummary o) {
-            return availableActions(o.getAvailableActions())
-                    .description(o.getDescription())
-                    .id(o.getId())
-                    .lastAction(o.getLastAction())
-                    .lifecycleDetails(o.getLifecycleDetails())
-                    .lifecycleState(o.getLifecycleState())
-                    .timeReleased(o.getTimeReleased())
-                    .version(o.getVersion());
+            Builder copiedBuilder =
+                    availableActions(o.getAvailableActions())
+                            .description(o.getDescription())
+                            .id(o.getId())
+                            .lastAction(o.getLastAction())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeReleased(o.getTimeReleased())
+                            .version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ReinstateDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ReinstateDataGuardAssociationDetails.java
@@ -38,7 +38,10 @@ public class ReinstateDataGuardAssociationDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ReinstateDataGuardAssociationDetails o) {
-            return databaseAdminPassword(o.getDatabaseAdminPassword());
+            Builder copiedBuilder = databaseAdminPassword(o.getDatabaseAdminPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/SwitchoverDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/SwitchoverDataGuardAssociationDetails.java
@@ -38,7 +38,10 @@ public class SwitchoverDataGuardAssociationDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SwitchoverDataGuardAssociationDetails o) {
-            return databaseAdminPassword(o.getDatabaseAdminPassword());
+            Builder copiedBuilder = databaseAdminPassword(o.getDatabaseAdminPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbHomeDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbHomeDetails.java
@@ -37,7 +37,10 @@ public class UpdateDbHomeDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateDbHomeDetails o) {
-            return dbVersion(o.getDbVersion());
+            Builder copiedBuilder = dbVersion(o.getDbVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateDbHomeRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateDbHomeRequest.java
@@ -13,7 +13,7 @@ public class CreateDbHomeRequest extends com.oracle.bmc.requests.BmcRequest {
     /**
      * Request to create a new DB Home.
      */
-    private CreateDbHomeWithDbSystemIdDetails createDbHomeWithDbSystemIdDetails;
+    private CreateDbHomeWithDbSystemIdBase createDbHomeWithDbSystemIdDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case of a timeout or

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsyncClient.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.identity;
 
+import java.util.Locale;
 import com.oracle.bmc.identity.internal.http.*;
 import com.oracle.bmc.identity.requests.*;
 import com.oracle.bmc.identity.responses.*;
@@ -101,7 +102,7 @@ public class IdentityAsyncClient implements IdentityAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityClient.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.identity;
 
+import java.util.Locale;
 import com.oracle.bmc.identity.internal.http.*;
 import com.oracle.bmc.identity.requests.*;
 import com.oracle.bmc.identity.responses.*;
@@ -120,7 +121,7 @@ public class IdentityClient implements Identity {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AddUserToGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AddUserToGroupDetails.java
@@ -42,7 +42,10 @@ public class AddUserToGroupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AddUserToGroupDetails o) {
-            return userId(o.getUserId()).groupId(o.getGroupId());
+            Builder copiedBuilder = userId(o.getUserId()).groupId(o.getGroupId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ApiKey.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/ApiKey.java
@@ -106,13 +106,17 @@ public class ApiKey {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ApiKey o) {
-            return keyId(o.getKeyId())
-                    .keyValue(o.getKeyValue())
-                    .fingerprint(o.getFingerprint())
-                    .userId(o.getUserId())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    keyId(o.getKeyId())
+                            .keyValue(o.getKeyValue())
+                            .fingerprint(o.getFingerprint())
+                            .userId(o.getUserId())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AvailabilityDomain.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/AvailabilityDomain.java
@@ -48,7 +48,10 @@ public class AvailabilityDomain {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AvailabilityDomain o) {
-            return name(o.getName()).compartmentId(o.getCompartmentId());
+            Builder copiedBuilder = name(o.getName()).compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Compartment.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Compartment.java
@@ -112,13 +112,17 @@ public class Compartment {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Compartment o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateApiKeyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateApiKeyDetails.java
@@ -33,7 +33,10 @@ public class CreateApiKeyDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateApiKeyDetails o) {
-            return key(o.getKey());
+            Builder copiedBuilder = key(o.getKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateCompartmentDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateCompartmentDetails.java
@@ -52,9 +52,13 @@ public class CreateCompartmentDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCompartmentDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateCustomerSecretKeyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateCustomerSecretKeyDetails.java
@@ -34,7 +34,10 @@ public class CreateCustomerSecretKeyDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCustomerSecretKeyDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateGroupDetails.java
@@ -52,9 +52,13 @@ public class CreateGroupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateGroupDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateIdpGroupMappingDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateIdpGroupMappingDetails.java
@@ -43,7 +43,10 @@ public class CreateIdpGroupMappingDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateIdpGroupMappingDetails o) {
-            return idpGroupName(o.getIdpGroupName()).groupId(o.getGroupId());
+            Builder copiedBuilder = idpGroupName(o.getIdpGroupName()).groupId(o.getGroupId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreatePolicyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreatePolicyDetails.java
@@ -71,11 +71,15 @@ public class CreatePolicyDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreatePolicyDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .statements(o.getStatements())
-                    .description(o.getDescription())
-                    .versionDate(o.getVersionDate());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .statements(o.getStatements())
+                            .description(o.getDescription())
+                            .versionDate(o.getVersionDate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateRegionSubscriptionDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateRegionSubscriptionDetails.java
@@ -34,7 +34,10 @@ public class CreateRegionSubscriptionDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateRegionSubscriptionDetails o) {
-            return regionKey(o.getRegionKey());
+            Builder copiedBuilder = regionKey(o.getRegionKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSaml2IdentityProviderDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSaml2IdentityProviderDetails.java
@@ -87,12 +87,16 @@ public class CreateSaml2IdentityProviderDetails extends CreateIdentityProviderDe
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateSaml2IdentityProviderDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .productType(o.getProductType())
-                    .metadataUrl(o.getMetadataUrl())
-                    .metadata(o.getMetadata());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .productType(o.getProductType())
+                            .metadataUrl(o.getMetadataUrl())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSwiftPasswordDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateSwiftPasswordDetails.java
@@ -33,7 +33,10 @@ public class CreateSwiftPasswordDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateSwiftPasswordDetails o) {
-            return description(o.getDescription());
+            Builder copiedBuilder = description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateUserDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateUserDetails.java
@@ -52,9 +52,13 @@ public class CreateUserDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateUserDetails o) {
-            return compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription());
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKey.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKey.java
@@ -115,14 +115,18 @@ public class CustomerSecretKey {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CustomerSecretKey o) {
-            return key(o.getKey())
-                    .id(o.getId())
-                    .userId(o.getUserId())
-                    .displayName(o.getDisplayName())
-                    .timeCreated(o.getTimeCreated())
-                    .timeExpires(o.getTimeExpires())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .id(o.getId())
+                            .userId(o.getUserId())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .timeExpires(o.getTimeExpires())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKeySummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CustomerSecretKeySummary.java
@@ -100,13 +100,17 @@ public class CustomerSecretKeySummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CustomerSecretKeySummary o) {
-            return id(o.getId())
-                    .userId(o.getUserId())
-                    .displayName(o.getDisplayName())
-                    .timeCreated(o.getTimeCreated())
-                    .timeExpires(o.getTimeExpires())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .userId(o.getUserId())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .timeExpires(o.getTimeExpires())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Group.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Group.java
@@ -109,13 +109,17 @@ public class Group {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Group o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdpGroupMapping.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdpGroupMapping.java
@@ -117,14 +117,18 @@ public class IdpGroupMapping {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IdpGroupMapping o) {
-            return id(o.getId())
-                    .idpId(o.getIdpId())
-                    .idpGroupName(o.getIdpGroupName())
-                    .groupId(o.getGroupId())
-                    .compartmentId(o.getCompartmentId())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .idpId(o.getIdpId())
+                            .idpGroupName(o.getIdpGroupName())
+                            .groupId(o.getGroupId())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Policy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Policy.java
@@ -129,15 +129,19 @@ public class Policy {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Policy o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .statements(o.getStatements())
-                    .description(o.getDescription())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus())
-                    .versionDate(o.getVersionDate());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .statements(o.getStatements())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus())
+                            .versionDate(o.getVersionDate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
@@ -50,7 +50,10 @@ public class Region {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Region o) {
-            return key(o.getKey()).name(o.getName());
+            Builder copiedBuilder = key(o.getKey()).name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
@@ -70,10 +70,14 @@ public class RegionSubscription {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(RegionSubscription o) {
-            return regionKey(o.getRegionKey())
-                    .regionName(o.getRegionName())
-                    .status(o.getStatus())
-                    .isHomeRegion(o.getIsHomeRegion());
+            Builder copiedBuilder =
+                    regionKey(o.getRegionKey())
+                            .regionName(o.getRegionName())
+                            .status(o.getStatus())
+                            .isHomeRegion(o.getIsHomeRegion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Saml2IdentityProvider.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Saml2IdentityProvider.java
@@ -148,17 +148,21 @@ public class Saml2IdentityProvider extends IdentityProvider {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Saml2IdentityProvider o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .productType(o.getProductType())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus())
-                    .metadataUrl(o.getMetadataUrl())
-                    .signingCertificate(o.getSigningCertificate())
-                    .redirectUrl(o.getRedirectUrl());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .productType(o.getProductType())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus())
+                            .metadataUrl(o.getMetadataUrl())
+                            .signingCertificate(o.getSigningCertificate())
+                            .redirectUrl(o.getRedirectUrl());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SwiftPassword.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/SwiftPassword.java
@@ -113,14 +113,18 @@ public class SwiftPassword {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SwiftPassword o) {
-            return password(o.getPassword())
-                    .id(o.getId())
-                    .userId(o.getUserId())
-                    .description(o.getDescription())
-                    .timeCreated(o.getTimeCreated())
-                    .expiresOn(o.getExpiresOn())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    password(o.getPassword())
+                            .id(o.getId())
+                            .userId(o.getUserId())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .expiresOn(o.getExpiresOn())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
@@ -69,10 +69,14 @@ public class Tenancy {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Tenancy o) {
-            return id(o.getId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .homeRegionKey(o.getHomeRegionKey());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .homeRegionKey(o.getHomeRegionKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UIPassword.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UIPassword.java
@@ -75,11 +75,15 @@ public class UIPassword {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UIPassword o) {
-            return password(o.getPassword())
-                    .userId(o.getUserId())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    password(o.getPassword())
+                            .userId(o.getUserId())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCompartmentDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCompartmentDetails.java
@@ -42,7 +42,10 @@ public class UpdateCompartmentDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCompartmentDetails o) {
-            return description(o.getDescription()).name(o.getName());
+            Builder copiedBuilder = description(o.getDescription()).name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCustomerSecretKeyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateCustomerSecretKeyDetails.java
@@ -34,7 +34,10 @@ public class UpdateCustomerSecretKeyDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCustomerSecretKeyDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateGroupDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateGroupDetails.java
@@ -33,7 +33,10 @@ public class UpdateGroupDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateGroupDetails o) {
-            return description(o.getDescription());
+            Builder copiedBuilder = description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateIdpGroupMappingDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateIdpGroupMappingDetails.java
@@ -43,7 +43,10 @@ public class UpdateIdpGroupMappingDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateIdpGroupMappingDetails o) {
-            return idpGroupName(o.getIdpGroupName()).groupId(o.getGroupId());
+            Builder copiedBuilder = idpGroupName(o.getIdpGroupName()).groupId(o.getGroupId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdatePolicyDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdatePolicyDetails.java
@@ -52,9 +52,13 @@ public class UpdatePolicyDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdatePolicyDetails o) {
-            return description(o.getDescription())
-                    .statements(o.getStatements())
-                    .versionDate(o.getVersionDate());
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .statements(o.getStatements())
+                            .versionDate(o.getVersionDate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSaml2IdentityProviderDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSaml2IdentityProviderDetails.java
@@ -59,9 +59,13 @@ public class UpdateSaml2IdentityProviderDetails extends UpdateIdentityProviderDe
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateSaml2IdentityProviderDetails o) {
-            return description(o.getDescription())
-                    .metadataUrl(o.getMetadataUrl())
-                    .metadata(o.getMetadata());
+            Builder copiedBuilder =
+                    description(o.getDescription())
+                            .metadataUrl(o.getMetadataUrl())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateStateDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateStateDetails.java
@@ -33,7 +33,10 @@ public class UpdateStateDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateStateDetails o) {
-            return blocked(o.getBlocked());
+            Builder copiedBuilder = blocked(o.getBlocked());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSwiftPasswordDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateSwiftPasswordDetails.java
@@ -33,7 +33,10 @@ public class UpdateSwiftPasswordDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateSwiftPasswordDetails o) {
-            return description(o.getDescription());
+            Builder copiedBuilder = description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateUserDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateUserDetails.java
@@ -33,7 +33,10 @@ public class UpdateUserDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateUserDetails o) {
-            return description(o.getDescription());
+            Builder copiedBuilder = description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
@@ -112,13 +112,17 @@ public class User {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(User o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .name(o.getName())
-                    .description(o.getDescription())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UserGroupMembership.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UserGroupMembership.java
@@ -100,13 +100,17 @@ public class UserGroupMembership {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UserGroupMembership o) {
-            return id(o.getId())
-                    .compartmentId(o.getCompartmentId())
-                    .groupId(o.getGroupId())
-                    .userId(o.getUserId())
-                    .timeCreated(o.getTimeCreated())
-                    .lifecycleState(o.getLifecycleState())
-                    .inactiveStatus(o.getInactiveStatus());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .groupId(o.getGroupId())
+                            .userId(o.getUserId())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .inactiveStatus(o.getInactiveStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancer.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancer.java
@@ -85,7 +85,7 @@ public interface LoadBalancer extends AutoCloseable {
      * To get a list of Availability Domains, use the `ListAvailabilityDomains` operation
      * in the Identity and Access Management Service API.
      * <p>
-     * All Oracle Bare Metal Cloud Services resources, including load balancers, get an Oracle-assigned,
+     * All Oracle Cloud Infrastructure resources, including load balancers, get an Oracle-assigned,
      * unique ID called an Oracle Cloud Identifier (OCID). When you create a resource, you can find its OCID
      * in the response. You can also retrieve a resource's OCID by using a List API operation on that resource type,
      * or by viewing the resource in the Console. Fore more information, see

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsync.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsync.java
@@ -114,7 +114,7 @@ public interface LoadBalancerAsync extends AutoCloseable {
      * To get a list of Availability Domains, use the `ListAvailabilityDomains` operation
      * in the Identity and Access Management Service API.
      * <p>
-     * All Oracle Bare Metal Cloud Services resources, including load balancers, get an Oracle-assigned,
+     * All Oracle Cloud Infrastructure resources, including load balancers, get an Oracle-assigned,
      * unique ID called an Oracle Cloud Identifier (OCID). When you create a resource, you can find its OCID
      * in the response. You can also retrieve a resource's OCID by using a List API operation on that resource type,
      * or by viewing the resource in the Console. Fore more information, see

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsyncClient.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.loadbalancer;
 
+import java.util.Locale;
 import com.oracle.bmc.loadbalancer.internal.http.*;
 import com.oracle.bmc.loadbalancer.requests.*;
 import com.oracle.bmc.loadbalancer.responses.*;
@@ -101,7 +102,7 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerClient.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.loadbalancer;
 
+import java.util.Locale;
 import com.oracle.bmc.loadbalancer.internal.http.*;
 import com.oracle.bmc.loadbalancer.requests.*;
 import com.oracle.bmc.loadbalancer.responses.*;
@@ -120,7 +121,7 @@ public class LoadBalancerClient implements LoadBalancer {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/ListLoadBalancersConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/ListLoadBalancersConverter.java
@@ -62,6 +62,38 @@ public class ListLoadBalancersConverter {
                                     request.getDetail()));
         }
 
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Backend.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Backend.java
@@ -91,13 +91,17 @@ public class Backend {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Backend o) {
-            return backup(o.getBackup())
-                    .drain(o.getDrain())
-                    .ipAddress(o.getIpAddress())
-                    .name(o.getName())
-                    .offline(o.getOffline())
-                    .port(o.getPort())
-                    .weight(o.getWeight());
+            Builder copiedBuilder =
+                    backup(o.getBackup())
+                            .drain(o.getDrain())
+                            .ipAddress(o.getIpAddress())
+                            .name(o.getName())
+                            .offline(o.getOffline())
+                            .port(o.getPort())
+                            .weight(o.getWeight());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendDetails.java
@@ -80,12 +80,16 @@ public class BackendDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BackendDetails o) {
-            return backup(o.getBackup())
-                    .drain(o.getDrain())
-                    .ipAddress(o.getIpAddress())
-                    .offline(o.getOffline())
-                    .port(o.getPort())
-                    .weight(o.getWeight());
+            Builder copiedBuilder =
+                    backup(o.getBackup())
+                            .drain(o.getDrain())
+                            .ipAddress(o.getIpAddress())
+                            .offline(o.getOffline())
+                            .port(o.getPort())
+                            .weight(o.getWeight());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendHealth.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendHealth.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.loadbalancer.model;
 
 /**
- * The health status of the specified backend server as reported by the primary and stand-by load balancers.
+ * The health status of the specified backend server as reported by the primary and standby load balancers.
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
@@ -44,7 +44,11 @@ public class BackendHealth {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BackendHealth o) {
-            return healthCheckResults(o.getHealthCheckResults()).status(o.getStatus());
+            Builder copiedBuilder =
+                    healthCheckResults(o.getHealthCheckResults()).status(o.getStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -62,7 +66,7 @@ public class BackendHealth {
     @com.fasterxml.jackson.annotation.JsonProperty("healthCheckResults")
     java.util.List<HealthCheckResult> healthCheckResults;
     /**
-     * The general health status of the specified backend server as reported by the primary and stand-by load balancers.
+     * The general health status of the specified backend server as reported by the primary and standby load balancers.
      * <p>
      *   **OK:** Both health checks returned `OK`.
      * <p>
@@ -119,7 +123,7 @@ public class BackendHealth {
         }
     };
     /**
-     * The general health status of the specified backend server as reported by the primary and stand-by load balancers.
+     * The general health status of the specified backend server as reported by the primary and standby load balancers.
      * <p>
      *   **OK:** Both health checks returned `OK`.
      * <p>

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSet.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSet.java
@@ -90,12 +90,16 @@ public class BackendSet {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BackendSet o) {
-            return backends(o.getBackends())
-                    .healthChecker(o.getHealthChecker())
-                    .name(o.getName())
-                    .policy(o.getPolicy())
-                    .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    backends(o.getBackends())
+                            .healthChecker(o.getHealthChecker())
+                            .name(o.getName())
+                            .policy(o.getPolicy())
+                            .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -125,9 +129,8 @@ public class BackendSet {
     String name;
 
     /**
-     * The load balancer policy for the backend set. The default load balancing policy is 'ROUND_ROBIN'
-     * To get a list of available policies, use the {@link #listPolicies(ListPoliciesRequest) listPolicies}
-     * operation.
+     * The load balancer policy for the backend set. To get a list of available policies, use the
+     * {@link #listPolicies(ListPoliciesRequest) listPolicies} operation.
      * <p>
      * Example: `LEAST_CONNECTIONS`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSetDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSetDetails.java
@@ -82,11 +82,15 @@ public class BackendSetDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BackendSetDetails o) {
-            return backends(o.getBackends())
-                    .healthChecker(o.getHealthChecker())
-                    .policy(o.getPolicy())
-                    .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    backends(o.getBackends())
+                            .healthChecker(o.getHealthChecker())
+                            .policy(o.getPolicy())
+                            .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -104,9 +108,8 @@ public class BackendSetDetails {
     HealthCheckerDetails healthChecker;
 
     /**
-     * The load balancer policy for the backend set. The default load balancing policy is 'ROUND_ROBIN'
-     * To get a list of available policies, use the {@link #listPolicies(ListPoliciesRequest) listPolicies}
-     * operation.
+     * The load balancer policy for the backend set. To get a list of available policies, use the
+     * {@link #listPolicies(ListPoliciesRequest) listPolicies} operation.
      * <p>
      * Example: `LEAST_CONNECTIONS`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSetHealth.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/BackendSetHealth.java
@@ -80,11 +80,15 @@ public class BackendSetHealth {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BackendSetHealth o) {
-            return criticalStateBackendNames(o.getCriticalStateBackendNames())
-                    .status(o.getStatus())
-                    .totalBackendCount(o.getTotalBackendCount())
-                    .unknownStateBackendNames(o.getUnknownStateBackendNames())
-                    .warningStateBackendNames(o.getWarningStateBackendNames());
+            Builder copiedBuilder =
+                    criticalStateBackendNames(o.getCriticalStateBackendNames())
+                            .status(o.getStatus())
+                            .totalBackendCount(o.getTotalBackendCount())
+                            .unknownStateBackendNames(o.getUnknownStateBackendNames())
+                            .warningStateBackendNames(o.getWarningStateBackendNames());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Certificate.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Certificate.java
@@ -56,9 +56,13 @@ public class Certificate {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Certificate o) {
-            return caCertificate(o.getCaCertificate())
-                    .certificateName(o.getCertificateName())
-                    .publicCertificate(o.getPublicCertificate());
+            Builder copiedBuilder =
+                    caCertificate(o.getCaCertificate())
+                            .certificateName(o.getCertificateName())
+                            .publicCertificate(o.getPublicCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CertificateDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CertificateDetails.java
@@ -81,11 +81,15 @@ public class CertificateDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CertificateDetails o) {
-            return caCertificate(o.getCaCertificate())
-                    .certificateName(o.getCertificateName())
-                    .passphrase(o.getPassphrase())
-                    .privateKey(o.getPrivateKey())
-                    .publicCertificate(o.getPublicCertificate());
+            Builder copiedBuilder =
+                    caCertificate(o.getCaCertificate())
+                            .certificateName(o.getCertificateName())
+                            .passphrase(o.getPassphrase())
+                            .privateKey(o.getPrivateKey())
+                            .publicCertificate(o.getPublicCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateBackendDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateBackendDetails.java
@@ -85,12 +85,16 @@ public class CreateBackendDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateBackendDetails o) {
-            return backup(o.getBackup())
-                    .drain(o.getDrain())
-                    .ipAddress(o.getIpAddress())
-                    .offline(o.getOffline())
-                    .port(o.getPort())
-                    .weight(o.getWeight());
+            Builder copiedBuilder =
+                    backup(o.getBackup())
+                            .drain(o.getDrain())
+                            .ipAddress(o.getIpAddress())
+                            .offline(o.getOffline())
+                            .port(o.getPort())
+                            .weight(o.getWeight());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateBackendSetDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateBackendSetDetails.java
@@ -92,12 +92,16 @@ public class CreateBackendSetDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateBackendSetDetails o) {
-            return backends(o.getBackends())
-                    .healthChecker(o.getHealthChecker())
-                    .name(o.getName())
-                    .policy(o.getPolicy())
-                    .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    backends(o.getBackends())
+                            .healthChecker(o.getHealthChecker())
+                            .name(o.getName())
+                            .policy(o.getPolicy())
+                            .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -127,8 +131,8 @@ public class CreateBackendSetDetails {
     String name;
 
     /**
-     * The load balancer policy for the backend set. The default load balancing policy is 'ROUND_ROBIN'
-     * To get a list of available policies, use the {@link #listPolicies(ListPoliciesRequest) listPolicies} operation.
+     * The load balancer policy for the backend set. To get a list of available policies, use the
+     * {@link #listPolicies(ListPoliciesRequest) listPolicies} operation.
      * <p>
      * Example: `LEAST_CONNECTIONS`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateCertificateDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateCertificateDetails.java
@@ -81,11 +81,15 @@ public class CreateCertificateDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCertificateDetails o) {
-            return caCertificate(o.getCaCertificate())
-                    .certificateName(o.getCertificateName())
-                    .passphrase(o.getPassphrase())
-                    .privateKey(o.getPrivateKey())
-                    .publicCertificate(o.getPublicCertificate());
+            Builder copiedBuilder =
+                    caCertificate(o.getCaCertificate())
+                            .certificateName(o.getCertificateName())
+                            .passphrase(o.getPassphrase())
+                            .privateKey(o.getPrivateKey())
+                            .publicCertificate(o.getPublicCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateListenerDetails.java
@@ -77,11 +77,15 @@ public class CreateListenerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateListenerDetails o) {
-            return defaultBackendSetName(o.getDefaultBackendSetName())
-                    .name(o.getName())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    defaultBackendSetName(o.getDefaultBackendSetName())
+                            .name(o.getName())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateLoadBalancerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateLoadBalancerDetails.java
@@ -108,14 +108,18 @@ public class CreateLoadBalancerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateLoadBalancerDetails o) {
-            return backendSets(o.getBackendSets())
-                    .certificates(o.getCertificates())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .isPrivate(o.getIsPrivate())
-                    .listeners(o.getListeners())
-                    .shapeName(o.getShapeName())
-                    .subnetIds(o.getSubnetIds());
+            Builder copiedBuilder =
+                    backendSets(o.getBackendSets())
+                            .certificates(o.getCertificates())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .isPrivate(o.getIsPrivate())
+                            .listeners(o.getListeners())
+                            .shapeName(o.getShapeName())
+                            .subnetIds(o.getSubnetIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -160,7 +164,7 @@ public class CreateLoadBalancerDetails {
      * <p>
      * If \"false\", the service assigns a public IP address to the load balancer. A load balancer with a public IP address
      * requires two subnets, each in a different Availability Domain. One subnet hosts the primary load balancer and the other
-     * hosts the secondary (stand-by) load balancer. A public load balancer is accessible from the internet, depending on your
+     * hosts the secondary (standby) load balancer. A public load balancer is accessible from the internet, depending on your
      * VCN's [security list rules](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Concepts/securitylists.htm).
      * <p>
      * Example: `false`

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthCheckResult.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthCheckResult.java
@@ -65,10 +65,14 @@ public class HealthCheckResult {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(HealthCheckResult o) {
-            return healthCheckStatus(o.getHealthCheckStatus())
-                    .sourceIpAddress(o.getSourceIpAddress())
-                    .subnetId(o.getSubnetId())
-                    .timestamp(o.getTimestamp());
+            Builder copiedBuilder =
+                    healthCheckStatus(o.getHealthCheckStatus())
+                            .sourceIpAddress(o.getSourceIpAddress())
+                            .subnetId(o.getSubnetId())
+                            .timestamp(o.getTimestamp());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthChecker.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthChecker.java
@@ -108,14 +108,18 @@ public class HealthChecker {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(HealthChecker o) {
-            return intervalInMillis(o.getIntervalInMillis())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .responseBodyRegex(o.getResponseBodyRegex())
-                    .retries(o.getRetries())
-                    .returnCode(o.getReturnCode())
-                    .timeoutInMillis(o.getTimeoutInMillis())
-                    .urlPath(o.getUrlPath());
+            Builder copiedBuilder =
+                    intervalInMillis(o.getIntervalInMillis())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .responseBodyRegex(o.getResponseBodyRegex())
+                            .retries(o.getRetries())
+                            .returnCode(o.getReturnCode())
+                            .timeoutInMillis(o.getTimeoutInMillis())
+                            .urlPath(o.getUrlPath());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthCheckerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/HealthCheckerDetails.java
@@ -108,14 +108,18 @@ public class HealthCheckerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(HealthCheckerDetails o) {
-            return intervalInMillis(o.getIntervalInMillis())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .responseBodyRegex(o.getResponseBodyRegex())
-                    .retries(o.getRetries())
-                    .returnCode(o.getReturnCode())
-                    .timeoutInMillis(o.getTimeoutInMillis())
-                    .urlPath(o.getUrlPath());
+            Builder copiedBuilder =
+                    intervalInMillis(o.getIntervalInMillis())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .responseBodyRegex(o.getResponseBodyRegex())
+                            .retries(o.getRetries())
+                            .returnCode(o.getReturnCode())
+                            .timeoutInMillis(o.getTimeoutInMillis())
+                            .urlPath(o.getUrlPath());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/IpAddress.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/IpAddress.java
@@ -43,7 +43,10 @@ public class IpAddress {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IpAddress o) {
-            return ipAddress(o.getIpAddress()).isPublic(o.getIsPublic());
+            Builder copiedBuilder = ipAddress(o.getIpAddress()).isPublic(o.getIsPublic());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Listener.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Listener.java
@@ -74,11 +74,15 @@ public class Listener {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(Listener o) {
-            return defaultBackendSetName(o.getDefaultBackendSetName())
-                    .name(o.getName())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    defaultBackendSetName(o.getDefaultBackendSetName())
+                            .name(o.getName())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ListenerDetails.java
@@ -62,10 +62,14 @@ public class ListenerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ListenerDetails o) {
-            return defaultBackendSetName(o.getDefaultBackendSetName())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    defaultBackendSetName(o.getDefaultBackendSetName())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancer.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancer.java
@@ -156,18 +156,22 @@ public class LoadBalancer {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancer o) {
-            return backendSets(o.getBackendSets())
-                    .certificates(o.getCertificates())
-                    .compartmentId(o.getCompartmentId())
-                    .displayName(o.getDisplayName())
-                    .id(o.getId())
-                    .ipAddresses(o.getIpAddresses())
-                    .isPrivate(o.getIsPrivate())
-                    .lifecycleState(o.getLifecycleState())
-                    .listeners(o.getListeners())
-                    .shapeName(o.getShapeName())
-                    .subnetIds(o.getSubnetIds())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    backendSets(o.getBackendSets())
+                            .certificates(o.getCertificates())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .ipAddresses(o.getIpAddresses())
+                            .isPrivate(o.getIsPrivate())
+                            .lifecycleState(o.getLifecycleState())
+                            .listeners(o.getListeners())
+                            .shapeName(o.getShapeName())
+                            .subnetIds(o.getSubnetIds())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -224,13 +228,15 @@ public class LoadBalancer {
      * <p>
      * If \"false\", the service assigns a public IP address to the load balancer. A load balancer with a public IP address
      * requires two subnets, each in a different Availability Domain. One subnet hosts the primary load balancer and the other
-     * hosts the secondary (stand-by) load balancer. A public load balancer is accessible from the internet, depending on your
+     * hosts the secondary (standby) load balancer. A public load balancer is accessible from the internet, depending on your
      * VCN's [security list rules](https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Concepts/securitylists.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPrivate")
     Boolean isPrivate;
     /**
+     * The current state of the load balancer.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LifecycleState {
@@ -278,7 +284,10 @@ public class LoadBalancer {
             return UnknownEnumValue;
         }
     };
-
+    /**
+     * The current state of the load balancer.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerHealth.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerHealth.java
@@ -85,11 +85,15 @@ public class LoadBalancerHealth {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancerHealth o) {
-            return criticalStateBackendSetNames(o.getCriticalStateBackendSetNames())
-                    .status(o.getStatus())
-                    .totalBackendSetCount(o.getTotalBackendSetCount())
-                    .unknownStateBackendSetNames(o.getUnknownStateBackendSetNames())
-                    .warningStateBackendSetNames(o.getWarningStateBackendSetNames());
+            Builder copiedBuilder =
+                    criticalStateBackendSetNames(o.getCriticalStateBackendSetNames())
+                            .status(o.getStatus())
+                            .totalBackendSetCount(o.getTotalBackendSetCount())
+                            .unknownStateBackendSetNames(o.getUnknownStateBackendSetNames())
+                            .warningStateBackendSetNames(o.getWarningStateBackendSetNames());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -214,7 +218,7 @@ public class LoadBalancerHealth {
      * A list of backend sets that are currently in the `UNKNOWN` health state. The list identifies each backend set by the
      * friendly name you assigned when you created it.
      * <p>
-     * Example: `Backend set2`
+     * Example: `Backend_set2`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("unknownStateBackendSetNames")
@@ -224,7 +228,7 @@ public class LoadBalancerHealth {
      * A list of backend sets that are currently in the `WARNING` health state. The list identifies each backend set by the
      * friendly name you assigned when you created it.
      * <p>
-     * Example: `Backend set3`
+     * Example: `Backend_set3`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("warningStateBackendSetNames")

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerHealthSummary.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerHealthSummary.java
@@ -46,7 +46,10 @@ public class LoadBalancerHealthSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancerHealthSummary o) {
-            return loadBalancerId(o.getLoadBalancerId()).status(o.getStatus());
+            Builder copiedBuilder = loadBalancerId(o.getLoadBalancerId()).status(o.getStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerPolicy.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerPolicy.java
@@ -39,7 +39,10 @@ public class LoadBalancerPolicy {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancerPolicy o) {
-            return name(o.getName());
+            Builder copiedBuilder = name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerProtocol.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerProtocol.java
@@ -36,7 +36,10 @@ public class LoadBalancerProtocol {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancerProtocol o) {
-            return name(o.getName());
+            Builder copiedBuilder = name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerShape.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancerShape.java
@@ -41,7 +41,10 @@ public class LoadBalancerShape {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LoadBalancerShape o) {
-            return name(o.getName());
+            Builder copiedBuilder = name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SSLConfiguration.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SSLConfiguration.java
@@ -56,9 +56,13 @@ public class SSLConfiguration {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SSLConfiguration o) {
-            return certificateName(o.getCertificateName())
-                    .verifyDepth(o.getVerifyDepth())
-                    .verifyPeerCertificate(o.getVerifyPeerCertificate());
+            Builder copiedBuilder =
+                    certificateName(o.getCertificateName())
+                            .verifyDepth(o.getVerifyDepth())
+                            .verifyPeerCertificate(o.getVerifyPeerCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SSLConfigurationDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SSLConfigurationDetails.java
@@ -56,9 +56,13 @@ public class SSLConfigurationDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SSLConfigurationDetails o) {
-            return certificateName(o.getCertificateName())
-                    .verifyDepth(o.getVerifyDepth())
-                    .verifyPeerCertificate(o.getVerifyPeerCertificate());
+            Builder copiedBuilder =
+                    certificateName(o.getCertificateName())
+                            .verifyDepth(o.getVerifyDepth())
+                            .verifyPeerCertificate(o.getVerifyPeerCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SessionPersistenceConfigurationDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SessionPersistenceConfigurationDetails.java
@@ -55,7 +55,11 @@ public class SessionPersistenceConfigurationDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SessionPersistenceConfigurationDetails o) {
-            return cookieName(o.getCookieName()).disableFallback(o.getDisableFallback());
+            Builder copiedBuilder =
+                    cookieName(o.getCookieName()).disableFallback(o.getDisableFallback());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateBackendDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateBackendDetails.java
@@ -64,10 +64,14 @@ public class UpdateBackendDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateBackendDetails o) {
-            return backup(o.getBackup())
-                    .drain(o.getDrain())
-                    .offline(o.getOffline())
-                    .weight(o.getWeight());
+            Builder copiedBuilder =
+                    backup(o.getBackup())
+                            .drain(o.getDrain())
+                            .offline(o.getOffline())
+                            .weight(o.getWeight());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateBackendSetDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateBackendSetDetails.java
@@ -82,11 +82,15 @@ public class UpdateBackendSetDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateBackendSetDetails o) {
-            return backends(o.getBackends())
-                    .healthChecker(o.getHealthChecker())
-                    .policy(o.getPolicy())
-                    .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    backends(o.getBackends())
+                            .healthChecker(o.getHealthChecker())
+                            .policy(o.getPolicy())
+                            .sessionPersistenceConfiguration(o.getSessionPersistenceConfiguration())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -104,9 +108,8 @@ public class UpdateBackendSetDetails {
     HealthCheckerDetails healthChecker;
 
     /**
-     * The load balancer policy for the backend set. The default load balancing policy is 'ROUND_ROBIN'
-     * To get a list of available policies, use the {@link #listPolicies(ListPoliciesRequest) listPolicies}
-     * operation.
+     * The load balancer policy for the backend set. To get a list of available policies, use the
+     * {@link #listPolicies(ListPoliciesRequest) listPolicies} operation.
      * <p>
      * Example: `LEAST_CONNECTIONS`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateHealthCheckerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateHealthCheckerDetails.java
@@ -108,14 +108,18 @@ public class UpdateHealthCheckerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateHealthCheckerDetails o) {
-            return intervalInMillis(o.getIntervalInMillis())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .responseBodyRegex(o.getResponseBodyRegex())
-                    .retries(o.getRetries())
-                    .returnCode(o.getReturnCode())
-                    .timeoutInMillis(o.getTimeoutInMillis())
-                    .urlPath(o.getUrlPath());
+            Builder copiedBuilder =
+                    intervalInMillis(o.getIntervalInMillis())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .responseBodyRegex(o.getResponseBodyRegex())
+                            .retries(o.getRetries())
+                            .returnCode(o.getReturnCode())
+                            .timeoutInMillis(o.getTimeoutInMillis())
+                            .urlPath(o.getUrlPath());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateListenerDetails.java
@@ -65,10 +65,14 @@ public class UpdateListenerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateListenerDetails o) {
-            return defaultBackendSetName(o.getDefaultBackendSetName())
-                    .port(o.getPort())
-                    .protocol(o.getProtocol())
-                    .sslConfiguration(o.getSslConfiguration());
+            Builder copiedBuilder =
+                    defaultBackendSetName(o.getDefaultBackendSetName())
+                            .port(o.getPort())
+                            .protocol(o.getProtocol())
+                            .sslConfiguration(o.getSslConfiguration());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateLoadBalancerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateLoadBalancerDetails.java
@@ -36,7 +36,10 @@ public class UpdateLoadBalancerDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateLoadBalancerDetails o) {
-            return displayName(o.getDisplayName());
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/WorkRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/WorkRequest.java
@@ -110,14 +110,18 @@ public class WorkRequest {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(WorkRequest o) {
-            return errorDetails(o.getErrorDetails())
-                    .id(o.getId())
-                    .lifecycleState(o.getLifecycleState())
-                    .loadBalancerId(o.getLoadBalancerId())
-                    .message(o.getMessage())
-                    .timeAccepted(o.getTimeAccepted())
-                    .timeFinished(o.getTimeFinished())
-                    .type(o.getType());
+            Builder copiedBuilder =
+                    errorDetails(o.getErrorDetails())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .loadBalancerId(o.getLoadBalancerId())
+                            .message(o.getMessage())
+                            .timeAccepted(o.getTimeAccepted())
+                            .timeFinished(o.getTimeFinished())
+                            .type(o.getType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 
@@ -137,6 +141,8 @@ public class WorkRequest {
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
     /**
+     * The current state of the work request.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LifecycleState {
@@ -183,7 +189,10 @@ public class WorkRequest {
             return UnknownEnumValue;
         }
     };
-
+    /**
+     * The current state of the work request.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/WorkRequestError.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/WorkRequestError.java
@@ -43,7 +43,10 @@ public class WorkRequestError {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(WorkRequestError o) {
-            return errorCode(o.getErrorCode()).message(o.getMessage());
+            Builder copiedBuilder = errorCode(o.getErrorCode()).message(o.getMessage());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/ListLoadBalancersRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/ListLoadBalancersRequest.java
@@ -46,6 +46,104 @@ public class ListLoadBalancersRequest extends com.oracle.bmc.requests.BmcRequest
      */
     private String detail;
 
+    /**
+     * The field to sort by.  Only one sort order may be provided.  Time created is default ordered as descending.  Display name is default ordered as ascending.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by.  Only one sort order may be provided.  Time created is default ordered as descending.  Display name is default ordered as ascending.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortBy: " + key);
+        }
+    };
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortOrder: " + key);
+        }
+    };
+
+    /**
+     * A filter to only return resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to only return resources that match the given lifecycle state.
+     *
+     */
+    private LoadBalancer.LifecycleState lifecycleState;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -72,6 +170,10 @@ public class ListLoadBalancersRequest extends com.oracle.bmc.requests.BmcRequest
             limit(o.getLimit());
             page(o.getPage());
             detail(o.getDetail());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
             return this;
         }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.objectstorage;
 
+import java.util.Locale;
 import com.oracle.bmc.objectstorage.internal.http.*;
 import com.oracle.bmc.objectstorage.requests.*;
 import com.oracle.bmc.objectstorage.responses.*;
@@ -75,6 +76,8 @@ public class ObjectStorageAsyncClient implements ObjectStorageAsync {
             com.oracle.bmc.http.signing.RequestSignerFactory requestSignerFactory) {
         com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
                 com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .defaultConfigurator(
+                                new com.oracle.bmc.http.DefaultConfigurator.NonBuffering())
                         .clientConfigurator(clientConfigurator)
                         .build();
         com.oracle.bmc.http.signing.RequestSigner requestSigner =
@@ -101,7 +104,7 @@ public class ObjectStorageAsyncClient implements ObjectStorageAsync {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
@@ -3,6 +3,7 @@
  */
 package com.oracle.bmc.objectstorage;
 
+import java.util.Locale;
 import com.oracle.bmc.objectstorage.internal.http.*;
 import com.oracle.bmc.objectstorage.requests.*;
 import com.oracle.bmc.objectstorage.responses.*;
@@ -75,6 +76,8 @@ public class ObjectStorageClient implements ObjectStorage {
             com.oracle.bmc.http.signing.RequestSignerFactory requestSignerFactory) {
         com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
                 com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .defaultConfigurator(
+                                new com.oracle.bmc.http.DefaultConfigurator.NonBuffering())
                         .clientConfigurator(clientConfigurator)
                         .build();
         com.oracle.bmc.http.signing.RequestSigner requestSigner =
@@ -101,7 +104,7 @@ public class ObjectStorageClient implements ObjectStorage {
 
     @Override
     public void setRegion(String regionId) {
-        regionId = regionId.toLowerCase();
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
         try {
             com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
             setRegion(region);

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/internal/http/GetObjectConverter.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/internal/http/GetObjectConverter.java
@@ -141,10 +141,13 @@ public class GetObjectConverter {
                                 }
 
                                 java.util.Map<String, String> opcMeta = new java.util.HashMap<>();
-                                String opcMetaPattern = "opc-meta-".toLowerCase();
+                                String opcMetaPattern =
+                                        "opc-meta-".toLowerCase(java.util.Locale.ROOT);
                                 for (java.util.Map.Entry<String, java.util.List<String>> header :
                                         headers.entrySet()) {
-                                    if (header.getKey().toLowerCase().startsWith(opcMetaPattern)) {
+                                    if (header.getKey()
+                                            .toLowerCase(java.util.Locale.ROOT)
+                                            .startsWith(opcMetaPattern)) {
                                         opcMeta.put(header.getKey(), header.getValue().get(0));
                                     }
                                 }

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/internal/http/HeadObjectConverter.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/internal/http/HeadObjectConverter.java
@@ -133,10 +133,13 @@ public class HeadObjectConverter {
                                 }
 
                                 java.util.Map<String, String> opcMeta = new java.util.HashMap<>();
-                                String opcMetaPattern = "opc-meta-".toLowerCase();
+                                String opcMetaPattern =
+                                        "opc-meta-".toLowerCase(java.util.Locale.ROOT);
                                 for (java.util.Map.Entry<String, java.util.List<String>> header :
                                         headers.entrySet()) {
-                                    if (header.getKey().toLowerCase().startsWith(opcMetaPattern)) {
+                                    if (header.getKey()
+                                            .toLowerCase(java.util.Locale.ROOT)
+                                            .startsWith(opcMetaPattern)) {
                                         opcMeta.put(header.getKey(), header.getValue().get(0));
                                     }
                                 }

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/BucketSummary.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/BucketSummary.java
@@ -83,12 +83,16 @@ public class BucketSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(BucketSummary o) {
-            return namespace(o.getNamespace())
-                    .name(o.getName())
-                    .compartmentId(o.getCompartmentId())
-                    .createdBy(o.getCreatedBy())
-                    .timeCreated(o.getTimeCreated())
-                    .etag(o.getEtag());
+            Builder copiedBuilder =
+                    namespace(o.getNamespace())
+                            .name(o.getName())
+                            .compartmentId(o.getCompartmentId())
+                            .createdBy(o.getCreatedBy())
+                            .timeCreated(o.getTimeCreated())
+                            .etag(o.getEtag());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CommitMultipartUploadDetails.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CommitMultipartUploadDetails.java
@@ -50,7 +50,11 @@ public class CommitMultipartUploadDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CommitMultipartUploadDetails o) {
-            return partsToCommit(o.getPartsToCommit()).partsToExclude(o.getPartsToExclude());
+            Builder copiedBuilder =
+                    partsToCommit(o.getPartsToCommit()).partsToExclude(o.getPartsToExclude());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CommitMultipartUploadPartDetails.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CommitMultipartUploadPartDetails.java
@@ -49,7 +49,10 @@ public class CommitMultipartUploadPartDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CommitMultipartUploadPartDetails o) {
-            return partNum(o.getPartNum()).etag(o.getEtag());
+            Builder copiedBuilder = partNum(o.getPartNum()).etag(o.getEtag());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CreateMultipartUploadDetails.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CreateMultipartUploadDetails.java
@@ -77,11 +77,15 @@ public class CreateMultipartUploadDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateMultipartUploadDetails o) {
-            return object(o.getObject())
-                    .contentType(o.getContentType())
-                    .contentLanguage(o.getContentLanguage())
-                    .contentEncoding(o.getContentEncoding())
-                    .metadata(o.getMetadata());
+            Builder copiedBuilder =
+                    object(o.getObject())
+                            .contentType(o.getContentType())
+                            .contentLanguage(o.getContentLanguage())
+                            .contentEncoding(o.getContentEncoding())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CreatePreauthenticatedRequestDetails.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/CreatePreauthenticatedRequestDetails.java
@@ -62,10 +62,14 @@ public class CreatePreauthenticatedRequestDetails {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreatePreauthenticatedRequestDetails o) {
-            return name(o.getName())
-                    .objectName(o.getObjectName())
-                    .accessType(o.getAccessType())
-                    .timeExpires(o.getTimeExpires());
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .objectName(o.getObjectName())
+                            .accessType(o.getAccessType())
+                            .timeExpires(o.getTimeExpires());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/ListObjects.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/ListObjects.java
@@ -55,9 +55,13 @@ public class ListObjects {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ListObjects o) {
-            return objects(o.getObjects())
-                    .prefixes(o.getPrefixes())
-                    .nextStartWith(o.getNextStartWith());
+            Builder copiedBuilder =
+                    objects(o.getObjects())
+                            .prefixes(o.getPrefixes())
+                            .nextStartWith(o.getNextStartWith());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/MultipartUpload.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/MultipartUpload.java
@@ -80,11 +80,15 @@ public class MultipartUpload {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(MultipartUpload o) {
-            return namespace(o.getNamespace())
-                    .bucket(o.getBucket())
-                    .object(o.getObject())
-                    .uploadId(o.getUploadId())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    namespace(o.getNamespace())
+                            .bucket(o.getBucket())
+                            .object(o.getObject())
+                            .uploadId(o.getUploadId())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/MultipartUploadPartSummary.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/MultipartUploadPartSummary.java
@@ -68,10 +68,14 @@ public class MultipartUploadPartSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(MultipartUploadPartSummary o) {
-            return etag(o.getEtag())
-                    .md5(o.getMd5())
-                    .size(o.getSize())
-                    .partNumber(o.getPartNumber());
+            Builder copiedBuilder =
+                    etag(o.getEtag())
+                            .md5(o.getMd5())
+                            .size(o.getSize())
+                            .partNumber(o.getPartNumber());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/ObjectSummary.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/ObjectSummary.java
@@ -64,10 +64,14 @@ public class ObjectSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ObjectSummary o) {
-            return name(o.getName())
-                    .size(o.getSize())
-                    .md5(o.getMd5())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .size(o.getSize())
+                            .md5(o.getMd5())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/PreauthenticatedRequest.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/PreauthenticatedRequest.java
@@ -98,13 +98,17 @@ public class PreauthenticatedRequest {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PreauthenticatedRequest o) {
-            return id(o.getId())
-                    .name(o.getName())
-                    .accessUri(o.getAccessUri())
-                    .objectName(o.getObjectName())
-                    .accessType(o.getAccessType())
-                    .timeExpires(o.getTimeExpires())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .name(o.getName())
+                            .accessUri(o.getAccessUri())
+                            .objectName(o.getObjectName())
+                            .accessType(o.getAccessType())
+                            .timeExpires(o.getTimeExpires())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/PreauthenticatedRequestSummary.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/model/PreauthenticatedRequestSummary.java
@@ -84,12 +84,16 @@ public class PreauthenticatedRequestSummary {
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(PreauthenticatedRequestSummary o) {
-            return id(o.getId())
-                    .name(o.getName())
-                    .objectName(o.getObjectName())
-                    .accessType(o.getAccessType())
-                    .timeExpires(o.getTimeExpires())
-                    .timeCreated(o.getTimeCreated());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .name(o.getName())
+                            .objectName(o.getObjectName())
+                            .accessType(o.getAccessType())
+                            .timeExpires(o.getTimeExpires())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
         }
     }
 

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
@@ -311,7 +311,13 @@ public class UploadManager {
          * @return a new UploadRequestBuilder instance.
          */
         public static UploadRequestBuilder builder(File file) {
-            return new UploadRequestBuilder(StreamUtils.toInputStream(file), file.length());
+            InputStream stream = StreamUtils.toInputStream(file);
+            try {
+                return new UploadRequestBuilder(stream, file.length());
+            } catch (Exception e) {
+                StreamUtils.closeQuietly(stream);
+                throw e;
+            }
         }
 
         @RequiredArgsConstructor

--- a/bmc-objectstorage/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
+++ b/bmc-objectstorage/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
@@ -219,10 +219,9 @@ public class MultipartObjectAssemblerTest {
 
         File file = File.createTempFile("unitTest", ".txt");
         file.deleteOnExit();
-        FileOutputStream fos = new FileOutputStream(file);
-
-        fos.write(bytes);
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(bytes);
+        }
 
         String etag1 = "etag1";
         String etag2 = "etag2";
@@ -274,10 +273,9 @@ public class MultipartObjectAssemblerTest {
 
         File file = File.createTempFile("unitTest", ".txt");
         file.deleteOnExit();
-        FileOutputStream fos = new FileOutputStream(file);
-
-        fos.write(bytes);
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(bytes);
+        }
 
         String etag1 = "etag1";
         UploadPartResponse uploadPartResponse1 = UploadPartResponse.builder().eTag(etag1).build();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.2.17</version>
+  <version>1.2.18</version>
   <packaging>pom</packaging>
 
   <name>Oracle Cloud Infrastructure SDK</name>


### PR DESCRIPTION
## 1.2.18 - 2017-11-27

### Changed
- Passphrases are now passed as char[] instead of as String
- Requests are now buffered in memory by default, except by the ObjectStorageClient and ObjectStorageAsyncClient. This allows for better error messages on PUT and POST requests. If you do not want to buffer requests in memory, pass an instance of `com.oracle.bmc.http.DefaultConfigurator.NonBuffering` to the constructor of the client.

### Added
- Support for VCN to VCN peering within region
- Support option for second NIC on X7 bare metal instances
- Support for user-managed boot volumes
- Support for creating database from backup in Database service
- Support for sort and filter in ListLoadBalancers method in Load Balancer Service

### Deprecated
- Methods accepting passphrases as String are deprecated; use char[] instead