### PR TITLE
Releasing version 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.4.3 - 2019-03-19
+### Added
+- Support for specifying metadata on node pools in the Container Engine for Kubernetes service
+- Support for provisioning a new autonomous database or autonomous data warehouse as a clone of another in the Database service
+
+### Changed
+- Most third-party dependencies are now shaded into the single shaded fat jar. Contrary to previous releases, this also includes Jersey; however, the shaded fat jar specifically excludes SLF4J along with BouncyCastle dependencies to allow customers to choose cryptography libraries based on their requirements (e.g., FIPS compliance).
+
 ## 1.4.2 - 2019-03-12
 ### Added
 - Support for the Budgets service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,145 +19,145 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsyncClient.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsyncClient.java
@@ -31,6 +31,7 @@ public class ContainerEngineAsyncClient implements ContainerEngineAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("CONTAINERENGINE")
                     .serviceEndpointPrefix("containerengine")
+                    .serviceEndpointTemplate("https://containerengine.{region}.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
@@ -18,6 +18,7 @@ public class ContainerEngineClient implements ContainerEngine {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("CONTAINERENGINE")
                     .serviceEndpointPrefix("containerengine")
+                    .serviceEndpointTemplate("https://containerengine.{region}.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/Cluster.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/Cluster.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.containerengine.model;
 
 /**
- * A Kubernetes cluster.
+ * A Kubernetes cluster. Avoid entering confidential information.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolDetails.java
@@ -60,6 +60,15 @@ public class CreateNodePoolDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+        private java.util.Map<String, String> nodeMetadata;
+
+        public Builder nodeMetadata(java.util.Map<String, String> nodeMetadata) {
+            this.nodeMetadata = nodeMetadata;
+            this.__explicitlySet__.add("nodeMetadata");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("nodeImageName")
         private String nodeImageName;
 
@@ -124,6 +133,7 @@ public class CreateNodePoolDetails {
                             clusterId,
                             name,
                             kubernetesVersion,
+                            nodeMetadata,
                             nodeImageName,
                             nodeShape,
                             initialNodeLabels,
@@ -141,6 +151,7 @@ public class CreateNodePoolDetails {
                             .clusterId(o.getClusterId())
                             .name(o.getName())
                             .kubernetesVersion(o.getKubernetesVersion())
+                            .nodeMetadata(o.getNodeMetadata())
                             .nodeImageName(o.getNodeImageName())
                             .nodeShape(o.getNodeShape())
                             .initialNodeLabels(o.getInitialNodeLabels())
@@ -183,6 +194,12 @@ public class CreateNodePoolDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesVersion")
     String kubernetesVersion;
+
+    /**
+     * A list of key/value pairs to add to each underlying OCI instance in the node pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+    java.util.Map<String, String> nodeMetadata;
 
     /**
      * The name of the image running on the nodes in the node pool.

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePool.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePool.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.containerengine.model;
 
 /**
- * A pool of compute nodes attached to a cluster.
+ * A pool of compute nodes attached to a cluster. Avoid entering confidential information.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -64,6 +64,15 @@ public class NodePool {
         public Builder kubernetesVersion(String kubernetesVersion) {
             this.kubernetesVersion = kubernetesVersion;
             this.__explicitlySet__.add("kubernetesVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+        private java.util.Map<String, String> nodeMetadata;
+
+        public Builder nodeMetadata(java.util.Map<String, String> nodeMetadata) {
+            this.nodeMetadata = nodeMetadata;
+            this.__explicitlySet__.add("nodeMetadata");
             return this;
         }
 
@@ -150,6 +159,7 @@ public class NodePool {
                             clusterId,
                             name,
                             kubernetesVersion,
+                            nodeMetadata,
                             nodeImageId,
                             nodeImageName,
                             nodeShape,
@@ -170,6 +180,7 @@ public class NodePool {
                             .clusterId(o.getClusterId())
                             .name(o.getName())
                             .kubernetesVersion(o.getKubernetesVersion())
+                            .nodeMetadata(o.getNodeMetadata())
                             .nodeImageId(o.getNodeImageId())
                             .nodeImageName(o.getNodeImageName())
                             .nodeShape(o.getNodeShape())
@@ -220,6 +231,12 @@ public class NodePool {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetesVersion")
     String kubernetesVersion;
+
+    /**
+     * A list of key/value pairs to add to each underlying OCI instance in the node pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+    java.util.Map<String, String> nodeMetadata;
 
     /**
      * The OCID of the image running on the nodes in the node pool.

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListClustersRequest.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListClustersRequest.java
@@ -27,13 +27,16 @@ public class ListClustersRequest extends com.oracle.bmc.requests.BmcRequest {
     private String name;
 
     /**
-     * The maximum number of items to return in a paginated \"List\" call.
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call.
+     * 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private Integer limit;
 
     /**
-     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListNodePoolsRequest.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListNodePoolsRequest.java
@@ -26,13 +26,16 @@ public class ListNodePoolsRequest extends com.oracle.bmc.requests.BmcRequest {
     private String name;
 
     /**
-     * The maximum number of items to return in a paginated \"List\" call.
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call.
+     * 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private Integer limit;
 
     /**
-     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListWorkRequestsRequest.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/ListWorkRequestsRequest.java
@@ -72,13 +72,16 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest 
     private java.util.List<com.oracle.bmc.containerengine.model.WorkRequestStatus> status;
 
     /**
-     * The maximum number of items to return in a paginated \"List\" call.
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call.
+     * 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private Integer limit;
 
     /**
-     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListClustersResponse.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListClustersResponse.java
@@ -11,9 +11,8 @@ import com.oracle.bmc.containerengine.model.*;
 public class ListClustersResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then there might be additional items still to get. Include this value as the `page` parameter for the
-     * subsequent GET request.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListNodePoolsResponse.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListNodePoolsResponse.java
@@ -11,9 +11,8 @@ import com.oracle.bmc.containerengine.model.*;
 public class ListNodePoolsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then there might be additional items still to get. Include this value as the `page` parameter for the
-     * subsequent GET request.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListWorkRequestsResponse.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/ListWorkRequestsResponse.java
@@ -11,9 +11,8 @@ import com.oracle.bmc.containerengine.model.*;
 public class ListWorkRequestsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then there might be additional items still to get. Include this value as the `page` parameter for the
-     * subsequent GET request.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -133,6 +133,15 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("usedDataStorageSizeInTBs")
+        private Integer usedDataStorageSizeInTBs;
+
+        public Builder usedDataStorageSizeInTBs(Integer usedDataStorageSizeInTBs) {
+            this.usedDataStorageSizeInTBs = usedDataStorageSizeInTBs;
+            this.__explicitlySet__.add("usedDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -188,6 +197,7 @@ public class AutonomousDatabase {
                             serviceConsoleUrl,
                             connectionStrings,
                             licenseModel,
+                            usedDataStorageSizeInTBs,
                             freeformTags,
                             definedTags,
                             dbVersion,
@@ -211,6 +221,7 @@ public class AutonomousDatabase {
                             .serviceConsoleUrl(o.getServiceConsoleUrl())
                             .connectionStrings(o.getConnectionStrings())
                             .licenseModel(o.getLicenseModel())
+                            .usedDataStorageSizeInTBs(o.getUsedDataStorageSizeInTBs())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
@@ -402,6 +413,12 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
     LicenseModel licenseModel;
+
+    /**
+     * The amount of storage that has been used, in terabytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("usedDataStorageSizeInTBs")
+    Integer usedDataStorageSizeInTBs;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -135,6 +135,15 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("usedDataStorageSizeInTBs")
+        private Integer usedDataStorageSizeInTBs;
+
+        public Builder usedDataStorageSizeInTBs(Integer usedDataStorageSizeInTBs) {
+            this.usedDataStorageSizeInTBs = usedDataStorageSizeInTBs;
+            this.__explicitlySet__.add("usedDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -190,6 +199,7 @@ public class AutonomousDatabaseSummary {
                             serviceConsoleUrl,
                             connectionStrings,
                             licenseModel,
+                            usedDataStorageSizeInTBs,
                             freeformTags,
                             definedTags,
                             dbVersion,
@@ -213,6 +223,7 @@ public class AutonomousDatabaseSummary {
                             .serviceConsoleUrl(o.getServiceConsoleUrl())
                             .connectionStrings(o.getConnectionStrings())
                             .licenseModel(o.getLicenseModel())
+                            .usedDataStorageSizeInTBs(o.getUsedDataStorageSizeInTBs())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
@@ -404,6 +415,12 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
     LicenseModel licenseModel;
+
+    /**
+     * The amount of storage that has been used, in terabytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("usedDataStorageSizeInTBs")
+    Integer usedDataStorageSizeInTBs;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details to create an Oracle Autonomous Database.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source",
+    defaultImpl = CreateAutonomousDatabaseBase.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateAutonomousDatabaseCloneDetails.class,
+        name = "DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateAutonomousDatabaseDetails.class,
+        name = "NONE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateAutonomousDatabaseBase {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment of the autonomous database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The database name. The name must begin with an alphabetic character and can contain a maximum of 14 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+    String dbName;
+
+    /**
+     * The number of CPU Cores to be made available to the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+    /**
+     * The autonomous database workload type.
+     **/
+    public enum DbWorkload {
+        Oltp("OLTP"),
+        Dw("DW"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DbWorkload> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DbWorkload v : DbWorkload.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DbWorkload(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DbWorkload create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid DbWorkload: " + key);
+        }
+    };
+    /**
+     * The autonomous database workload type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")
+    DbWorkload dbWorkload;
+
+    /**
+     * The size, in terabytes, of the data volume that will be created and attached to the database. This storage can later be scaled up if needed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Integer dataStorageSizeInTBs;
+
+    /**
+     * The password must be between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (\") or the username \"admin\", regardless of casing.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+    String adminPassword;
+
+    /**
+     * The user-friendly name for the Autonomous Database. The name does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+    /**
+     * The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LicenseModel: " + key);
+        }
+    };
+    /**
+     * The Oracle license model that applies to the Oracle Autonomous Database. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.database.model;
 
 /**
- * Details to create an Oracle Autonomous Database.
+ * Details to create an Oracle Autonomous Database by cloning an existing Autonomous Database.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -17,7 +17,7 @@ package com.oracle.bmc.database.model;
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
-    builder = CreateAutonomousDatabaseDetails.Builder.class
+    builder = CreateAutonomousDatabaseCloneDetails.Builder.class
 )
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)
@@ -27,7 +27,7 @@ package com.oracle.bmc.database.model;
     property = "source"
 )
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBase {
+public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDatabaseBase {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
@@ -122,12 +122,30 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
+        private String sourceId;
+
+        public Builder sourceId(String sourceId) {
+            this.sourceId = sourceId;
+            this.__explicitlySet__.add("sourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloneType")
+        private CloneType cloneType;
+
+        public Builder cloneType(CloneType cloneType) {
+            this.cloneType = cloneType;
+            this.__explicitlySet__.add("cloneType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
-        public CreateAutonomousDatabaseDetails build() {
-            CreateAutonomousDatabaseDetails __instance__ =
-                    new CreateAutonomousDatabaseDetails(
+        public CreateAutonomousDatabaseCloneDetails build() {
+            CreateAutonomousDatabaseCloneDetails __instance__ =
+                    new CreateAutonomousDatabaseCloneDetails(
                             compartmentId,
                             dbName,
                             cpuCoreCount,
@@ -137,13 +155,15 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             displayName,
                             licenseModel,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            sourceId,
+                            cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(CreateAutonomousDatabaseDetails o) {
+        public Builder copy(CreateAutonomousDatabaseCloneDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
                             .dbName(o.getDbName())
@@ -154,7 +174,9 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .displayName(o.getDisplayName())
                             .licenseModel(o.getLicenseModel())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .sourceId(o.getSourceId())
+                            .cloneType(o.getCloneType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -169,7 +191,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
     }
 
     @Deprecated
-    public CreateAutonomousDatabaseDetails(
+    public CreateAutonomousDatabaseCloneDetails(
             String compartmentId,
             String dbName,
             Integer cpuCoreCount,
@@ -179,7 +201,9 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             String displayName,
             LicenseModel licenseModel,
             java.util.Map<String, String> freeformTags,
-            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String sourceId,
+            CloneType cloneType) {
         super(
                 compartmentId,
                 dbName,
@@ -191,7 +215,55 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 licenseModel,
                 freeformTags,
                 definedTags);
+        this.sourceId = sourceId;
+        this.cloneType = cloneType;
     }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the source Autonomous Database that you will clone to create a new Autonomous Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
+    String sourceId;
+    /**
+     * The clone type.
+     **/
+    public enum CloneType {
+        Full("FULL"),
+        Metadata("METADATA"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, CloneType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CloneType v : CloneType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        CloneType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CloneType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid CloneType: " + key);
+        }
+    };
+    /**
+     * The clone type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloneType")
+    CloneType cloneType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateAutonomousDatabaseRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateAutonomousDatabaseRequest.java
@@ -13,7 +13,7 @@ public class CreateAutonomousDatabaseRequest extends com.oracle.bmc.requests.Bmc
     /**
      * Request to create a new Autonomous Database.
      */
-    private CreateAutonomousDatabaseDetails createAutonomousDatabaseDetails;
+    private CreateAutonomousDatabaseBase createAutonomousDatabaseDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case of a timeout or

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/AutonomousTransactionProcessingSharedExample.java
+++ b/bmc-examples/src/main/java/AutonomousTransactionProcessingSharedExample.java
@@ -7,6 +7,8 @@ import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.database.DatabaseClient;
 import com.oracle.bmc.database.DatabaseWaiters;
 import com.oracle.bmc.database.model.AutonomousDatabase;
+import com.oracle.bmc.database.model.CreateAutonomousDatabaseBase;
+import com.oracle.bmc.database.model.CreateAutonomousDatabaseCloneDetails;
 import com.oracle.bmc.database.model.CreateAutonomousDatabaseDetails;
 import com.oracle.bmc.database.model.UpdateAutonomousDatabaseDetails;
 import com.oracle.bmc.database.requests.CreateAutonomousDatabaseRequest;
@@ -53,6 +55,16 @@ public class AutonomousTransactionProcessingSharedExample {
 
         atpShared = waitForInstanceToBecomeAvailable(dbClient, atpShared.getId());
         System.out.println("Instance is provisioned:" + atpShared);
+
+        //Clone
+        CreateAutonomousDatabaseCloneDetails createAutonomousDatabaseCloneDetails =
+                createAtpCloneRequest(compartmentId, atpShared.getId());
+        System.out.println(
+                "Creating Autonomous Transaction Processing Clone with request : "
+                        + createAutonomousDatabaseCloneDetails);
+        AutonomousDatabase clonedAtp = createATP(dbClient, createAutonomousDatabaseCloneDetails);
+        atpShared = waitForInstanceToBecomeAvailable(dbClient, clonedAtp.getId());
+        System.out.println("Instance is provisioned:" + clonedAtp);
 
         // Get
         atpShared =
@@ -134,7 +146,7 @@ public class AutonomousTransactionProcessingSharedExample {
     }
 
     public static AutonomousDatabase createATP(
-            DatabaseClient dbClient, CreateAutonomousDatabaseDetails request) {
+            DatabaseClient dbClient, CreateAutonomousDatabaseBase request) {
 
         CreateAutonomousDatabaseResponse response =
                 dbClient.createAutonomousDatabase(
@@ -197,6 +209,23 @@ public class AutonomousTransactionProcessingSharedExample {
                 .compartmentId(compartmentId)
                 .dbWorkload(CreateAutonomousDatabaseDetails.DbWorkload.Oltp)
                 .licenseModel(CreateAutonomousDatabaseDetails.LicenseModel.LicenseIncluded)
+                .build();
+    }
+
+    private static CreateAutonomousDatabaseCloneDetails createAtpCloneRequest(
+            String compartmentId, String sourceId) {
+        Random rand = new Random();
+        return CreateAutonomousDatabaseCloneDetails.builder()
+                .cpuCoreCount(1)
+                .dataStorageSizeInTBs(1)
+                .displayName("javaSdkExample")
+                .adminPassword("DBaaS12345_#")
+                .dbName("javaSdkExam" + rand.nextInt(500))
+                .compartmentId(compartmentId)
+                .dbWorkload(CreateAutonomousDatabaseDetails.DbWorkload.Oltp)
+                .licenseModel(CreateAutonomousDatabaseDetails.LicenseModel.LicenseIncluded)
+                .sourceId(sourceId)
+                .cloneType(CreateAutonomousDatabaseCloneDetails.CloneType.Metadata)
                 .build();
     }
 

--- a/bmc-examples/src/main/java/ContainerEngineNodePoolExample.java
+++ b/bmc-examples/src/main/java/ContainerEngineNodePoolExample.java
@@ -54,7 +54,9 @@ import com.oracle.bmc.identity.responses.ListAvailabilityDomainsResponse;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class provides an example of how to create a Container Engine node pool in the Java SDK.
@@ -69,8 +71,8 @@ import java.util.List;
  *   <li>The subnet created by this example will have a display name of: java_sdk_oke_example_subnet_3</li>
  *   <li>The VCN will have a private IP CIDR block of 10.0.0.0/16</li>
  *   <li>The subnets will have private IP CIDR blocks of 10.0.0.0/24, 10.0.1.0/24 and 10.0.2.0/24</li>
- *   <li>The cluster created will have hardcoded display names of ContanerEngineExampleCluster</li>
- *   <li>The node pool created will have hardcoded display names of ContanerEngineNodePoolExample</li>
+ *   <li>The cluster created will have hardcoded display names of ContainerEngineExampleCluster</li>
+ *   <li>The node pool created will have hardcoded display names of ContainerEngineNodePoolExample</li>
  *   <li>The first two subnets are used for creating cluster</li>
  *   <li>The third subnet is used for creating node pool</li>
  *   <li>
@@ -96,11 +98,12 @@ public class ContainerEngineNodePoolExample {
     private static final String CONFIG_LOCATION = "~/.oci/config";
     private static final String CONFIG_PROFILE = "DEFAULT";
 
-    private static final String CLUSTER_DISPLAY_NAME = "ContanerEngineExampleCluster";
-    private static final String NODE_POOL_DISPLAY_NAME = "ContanerEngineExampleNodePool";
-    private static final String NEW_NODE_POOL_DISPLAY_NAME = "ContanerEngineExampleNodePoolNew";
+    private static final String CLUSTER_DISPLAY_NAME = "ContainerEngineCluster";
+    private static final String NODE_POOL_DISPLAY_NAME = "ContainerEngineNodePool";
+    private static final String NEW_NODE_POOL_DISPLAY_NAME = "ContainerEngineNodePoolNew";
     private static final String NODE_IMAGE_NAME = "Oracle-Linux-7.4";
     private static final String NODE_SHAPE = "VM.Standard1.1";
+    private static final Map<String, String> NODE_METADATA = createNodeMetadata();
 
     private static String clusterId = null;
     private static String nodePoolId = null;
@@ -198,6 +201,7 @@ public class ContainerEngineNodePoolExample {
                             kubernetesVersion,
                             NODE_IMAGE_NAME,
                             NODE_SHAPE,
+                            NODE_METADATA,
                             initialNodeLabels,
                             quantityPerSubnet,
                             pool_subnetIds);
@@ -510,6 +514,7 @@ public class ContainerEngineNodePoolExample {
             final String kubernetesVersion,
             final String nodeImageName,
             final String nodeShape,
+            final Map<String, String> nodeMetadata,
             final List<KeyValue> initialNodeLabels,
             final Integer quantityPerSubnet,
             final List<String> subnetIds)
@@ -528,6 +533,7 @@ public class ContainerEngineNodePoolExample {
                                                 .kubernetesVersion(kubernetesVersion)
                                                 .nodeImageName(nodeImageName)
                                                 .nodeShape(nodeShape)
+                                                .nodeMetadata(nodeMetadata)
                                                 .initialNodeLabels(initialNodeLabels)
                                                 .quantityPerSubnet(quantityPerSubnet)
                                                 .subnetIds(subnetIds)
@@ -632,7 +638,7 @@ public class ContainerEngineNodePoolExample {
     /**
      * Get the first work request resource ID that match the entity type
      *
-     * @param GetWorkRequestResponse The work request response for getting work request resource ID
+     * @param getWorkRequestResponse The work request response for getting work request resource ID
      * @param entityType resource entity type
      *
      * @return work request resource ID
@@ -676,7 +682,7 @@ public class ContainerEngineNodePoolExample {
 
     /**
      * Check work request in Success state
-     * @param containerEngineClient the service client to use to get work request
+     * @param workRequestResponse work request response to check
      * @return boolean
      * @throws Exception If there is error
      */
@@ -691,5 +697,12 @@ public class ContainerEngineNodePoolExample {
             inSuccessState = true;
         }
         return inSuccessState;
+    }
+
+    private static Map<String, String> createNodeMetadata() {
+        Map<String, String> result = new HashMap<String, String>();
+        result.put("key1", "value1");
+        result.put("key2", "value2");
+        return result;
     }
 }

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>
@@ -14,54 +14,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-client</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-     <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>${jsr305.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>${validation-api.version}</version>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs-api.version}</version>
-    </dependency>
-    <dependency>
-    <groupId>org.bouncycastle</groupId>
-    <artifactId>bcpkix-jdk15on</artifactId>
-    <version>${bouncycastle.version}</version>
-    </dependency>
-    <dependency>
-    <groupId>org.bouncycastle</groupId>
-    <artifactId>bcprov-jdk15on</artifactId>
-    <version>${bouncycastle.version}</version>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>${bouncycastle.version}</version>
     </dependency>
 
   </dependencies>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.4.2</version>
+  <version>1.4.3</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added
- Support for specifying metadata on node pools in the Container Engine for Kubernetes service
- Support for provisioning a new autonomous database or autonomous data warehouse as a clone of another in the Database service

### Changed
- Most third-party dependencies are now shaded into the single shaded fat jar. Contrary to previous releases, this also includes Jersey; however, the shaded fat jar specifically excludes SLF4J along with BouncyCastle dependencies to allow customers to choose cryptography libraries based on their requirements (e.g., FIPS compliance).