### PR TITLE
Releasing version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.5.0 - 2019-04-02
+### Added
+- Support for provider service key names on virtual circuits in the FastConnect service
+- Support for customer reference names on cross connects and cross connect groups in the FastConnect service
+
+### Changed
+- Use of the SDK with Java 7 is no longer supported
+- `com.oracle.bmc.Region` and `com.oracle.bmc.Realm` enumerations have been converted to classes to allow using the SDK with new unreleased regions and realms. An example of how to do this is available [here](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/NewRegionAndRealmSupportWithoutSDKUpdate.java)
+
+### Security
+- Due to a security vulnerability in a dependency of older versions of the Java SDK, **it is important that you upgrade to this or a later version of the Java SDK**. Jackson-databind version 2.9.6, used by prior versions of the SDK, has known security vulnerabilities. The SDK now uses Jackson-databind version 2.9.8 which fixes these vulnerabilities.
 
 ## 1.4.4 - 2019-03-26
 ### Added
@@ -48,7 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 - Removed unused Announcements service `NotificationFollowupDetails` model and `getFollowups` operation
 
-## 1.3.7 - 2018-02-07 
+## 1.3.7 - 2018-02-07
 ### Added
 - Support for the Web Application Acceleration and Security (WAAS) service
 - Support for the Health Checks service
@@ -72,7 +83,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Support for device attributes on volume attachments in the Compute service
 - Support for custom header rulesets in the Load Balancing service
-- Add support to use RESTEasy with Java SDK. Examples can be found at [ResteasyClientWithObjectStorageExample](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java) and [InstancePrincipalsAuthenticationDetailsProviderWithResteasyClientExample](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/InstancePrincipalsAuthenticationDetailsProviderWithResteasyClientExample.java) 
+- Add support to use RESTEasy with Java SDK. Examples can be found at [ResteasyClientWithObjectStorageExample](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java) and [InstancePrincipalsAuthenticationDetailsProviderWithResteasyClientExample](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/InstancePrincipalsAuthenticationDetailsProviderWithResteasyClientExample.java)
 
 ### Fixed
 - Reading entities from HTTP response without a Content-Type header no longer throws a NullPointerException

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,145 +19,145 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -80,9 +80,9 @@
       <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>nimbus-jose-jwt</artifactId>
-        <version>4.9</version>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>4.9</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Realm.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Realm.java
@@ -3,23 +3,134 @@
  */
 package com.oracle.bmc;
 
+import com.oracle.bmc.util.internal.NameUtils;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Enumeration of all Identity realms.
+ * Class containing all Identity realms.
  * <p>
  * Accounts (tenancies) are per Realm.
  */
-@RequiredArgsConstructor
-public enum Realm {
-    OC1("oc1"),
-    OC2("oc2"),
-    OC3("oc3");
+@EqualsAndHashCode
+public final class Realm implements Serializable, Comparable<Realm> {
+    // LinkedHashMap to ensure stable ordering of registered realms
+    private static final Map<String, Realm> KNOWN_REALMS = new LinkedHashMap<>();
+
+    public static final Realm OC1 = new Realm("oc1", "oraclecloud.com");
+    public static final Realm OC2 = new Realm("oc2", "oraclegovcloud.com");
+    public static final Realm OC3 = new Realm("oc3", "oraclegovcloud.com");
+
+    private static final long serialVersionUID = -905344971L;
 
     @Getter
     /**
      * The id of the realm.
      */
     private final String realmId;
+
+    @Getter
+    /**
+     * The second level domain of the realm.
+     */
+    private final String secondLevelDomain;
+
+    private Realm(@NonNull String realmId, @NonNull String secondLevelDomain) {
+        this.realmId = realmId;
+        this.secondLevelDomain = secondLevelDomain;
+
+        synchronized (KNOWN_REALMS) {
+            // The field name is named after the regionId, but follows enum naming convention.
+            // For backwards compatibility, we keep track of the enum-named field.
+            KNOWN_REALMS.put(NameUtils.canonicalizeForEnumTypes(realmId), this);
+        }
+    }
+
+    /**
+     * Compares to realms lexicographically based on their realmId.
+     *
+     * @param other The Realm to be compared.
+     * @return the value {@code 0} if the realmId of the compared
+     *  Realm is equal to the realmId of this Realm; a value less
+     *  than {@code 0} if the realmId of this Realm is
+     *  lexicographically less than the realmId of the compared
+     *  Realm; and a value greater than {@code 0} if the realmId of
+     *  this Realm is lexicographically greater than the realmId of
+     *  the compared Realm.
+     */
+    public int compareTo(Realm other) {
+        return realmId.compareTo(other.realmId);
+    }
+
+    @Override
+    // For backward compatibility maintain the enum toString behavior
+    public String toString() {
+        return NameUtils.canonicalizeForEnumTypes(getRealmId());
+    }
+
+    /**
+     * All known Realms in this version of the SDK
+     *
+     * @return Known realms
+     */
+    public static Realm[] values() {
+        synchronized (KNOWN_REALMS) {
+            return KNOWN_REALMS.values().toArray(new Realm[0]);
+        }
+    }
+
+    /**
+     * Returns the Realm object matching the specified name. The name must
+     * match exactly. (Extraneous whitespace characters are not permitted.)
+     *
+     * @param name The name of the realm
+     * @return The Realm object matching the specified name, if available.
+     * @throws IllegalArgumentException if no realm exists with the specified
+     * name
+     */
+    public static Realm valueOf(@NonNull String name) throws IllegalArgumentException {
+        final Realm realm;
+        synchronized (KNOWN_REALMS) {
+            realm = KNOWN_REALMS.get(name);
+        }
+        if (realm == null) {
+            throw new IllegalArgumentException("Unknown realm " + name);
+        }
+        return realm;
+    }
+
+    /**
+     * Register a new Realm. Used to allow the SDK to be forward compatible with unreleased realms.
+     *
+     * @param realmId The realm id.
+     * @param secondLevelDomain The second level domain of the realm.
+     * @return The registered Realm (or existing one if found).
+     */
+    public static Realm register(@NonNull String realmId, @NonNull String secondLevelDomain) {
+        realmId = realmId.toLowerCase(Locale.US);
+        secondLevelDomain = secondLevelDomain.toLowerCase(Locale.US);
+        synchronized (KNOWN_REALMS) {
+            for (Realm realm : Realm.values()) {
+                if (realm.realmId.equals(realmId)) {
+                    if (!realm.secondLevelDomain.equals(secondLevelDomain)) {
+                        throw new IllegalArgumentException(
+                                "RealmId : "
+                                        + realmId
+                                        + " is already registered with "
+                                        + realm.getSecondLevelDomain()
+                                        + ". It cannot be re-registered with a different secondLevelDomain");
+                    }
+                    return realm;
+                }
+            }
+
+            return new Realm(realmId, secondLevelDomain);
+        }
+    }
 }

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -3,44 +3,54 @@
  */
 package com.oracle.bmc;
 
+import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.oracle.bmc.internal.EndpointBuilder;
 
+import com.oracle.bmc.util.internal.NameUtils;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Enumeration of all of the known Regions that can be contacted.
+ * Class containing all of the known Regions that can be contacted.
  * <p>
  * Note, not all services may be available in all regions.
  */
 @Slf4j
-@RequiredArgsConstructor
-public enum Region {
+@EqualsAndHashCode
+public final class Region implements Serializable, Comparable<Region> {
+    // LinkedHashMap to ensure stable ordering of registered regions
+    private static final Map<String, Region> KNOWN_REGIONS = new LinkedHashMap<>();
+
     // OC1
-    CA_TORONTO_1("ca-toronto-1", Realm.OC1),
+    public static final Region CA_TORONTO_1 = new Region("ca-toronto-1", Realm.OC1);
     // regionCode for FRA shouldn't be needed, but left for backwards compatibility
-    EU_FRANKFURT_1("eu-frankfurt-1", "fra", Realm.OC1),
+    public static final Region EU_FRANKFURT_1 = new Region("eu-frankfurt-1", "fra", Realm.OC1);
     // regionCode for LHR shouldn't be needed, but left for backwards compatibility
-    UK_LONDON_1("uk-london-1", "lhr", Realm.OC1),
-    US_ASHBURN_1("us-ashburn-1", "iad", Realm.OC1),
-    US_PHOENIX_1("us-phoenix-1", "phx", Realm.OC1),
+    public static final Region UK_LONDON_1 = new Region("uk-london-1", "lhr", Realm.OC1);
+    public static final Region US_ASHBURN_1 = new Region("us-ashburn-1", "iad", Realm.OC1);
+    public static final Region US_PHOENIX_1 = new Region("us-phoenix-1", "phx", Realm.OC1);
 
     // OC2
-    US_LANGLEY_1("us-langley-1", Realm.OC2),
-    US_LUKE_1("us-luke-1", Realm.OC2),
+    public static final Region US_LANGLEY_1 = new Region("us-langley-1", Realm.OC2);
+    public static final Region US_LUKE_1 = new Region("us-luke-1", Realm.OC2);
 
     // OC3
-    US_GOV_ASHBURN_1("us-gov-ashburn-1", Realm.OC3),
-    US_GOV_CHICAGO_1("us-gov-chicago-1", Realm.OC3),
-    US_GOV_PHOENIX_1("us-gov-phoenix-1", Realm.OC3);
+    public static final Region US_GOV_ASHBURN_1 = new Region("us-gov-ashburn-1", Realm.OC3);
+    public static final Region US_GOV_CHICAGO_1 = new Region("us-gov-chicago-1", Realm.OC3);
+    public static final Region US_GOV_PHOENIX_1 = new Region("us-gov-phoenix-1", Realm.OC3);
 
     private static final Map<String, Map<Region, String>> SERVICE_TO_REGION_ENDPOINTS =
             new HashMap<>();
+
+    private static final long serialVersionUID = -905384971L;
 
     /**
      * Get the region ID.
@@ -67,6 +77,19 @@ public enum Region {
         this(regionId, Optional.<String>of(regionCode), realm);
     }
 
+    private Region(
+            @NonNull String regionId, @NonNull Optional<String> regionCode, @NonNull Realm realm) {
+        this.regionId = regionId;
+        this.regionCode = regionCode;
+        this.realm = realm;
+
+        synchronized (KNOWN_REGIONS) {
+            // The field name is named after the regionId, but follows enum naming convention.
+            // For backwards compatibility, we keep track of the enum-named field.
+            KNOWN_REGIONS.put(NameUtils.canonicalizeForEnumTypes(regionId), this);
+        }
+    }
+
     /**
      * Get the region code.
      * @Deprecated Do not use regionCode anymore.  Use {@link #getRegionId()} to retrieve
@@ -89,10 +112,8 @@ public enum Region {
         synchronized (SERVICE_TO_REGION_ENDPOINTS) {
             if (!SERVICE_TO_REGION_ENDPOINTS.containsKey(service.getServiceName())) {
                 HashMap<Region, String> endpoints = new HashMap<>();
-                for (Region region : Region.values()) {
-                    String endpoint = formatDefaultRegionEndpoint(service, region);
-                    endpoints.put(region, endpoint);
-                }
+                endpoints.put(this, formatDefaultRegionEndpoint(service, this));
+
                 SERVICE_TO_REGION_ENDPOINTS.put(service.getServiceName(), endpoints);
                 LOG.info(
                         "Loaded service '{}' endpoint mappings: {}",
@@ -100,9 +121,72 @@ public enum Region {
                         endpoints);
             }
 
+            final Map<Region, String> endpoints =
+                    SERVICE_TO_REGION_ENDPOINTS.get(service.getServiceName());
+            if (!endpoints.containsKey(this)) {
+                endpoints.put(this, formatDefaultRegionEndpoint(service, this));
+                LOG.info(
+                        "Loaded service '{}' endpoint mappings: {}",
+                        service.getServiceName(),
+                        endpoints);
+            }
             String endpoint = SERVICE_TO_REGION_ENDPOINTS.get(service.getServiceName()).get(this);
             return Optional.fromNullable(endpoint);
         }
+    }
+
+    /**
+     * Compares to regions lexicographically based on their regionId.
+     *
+     * @param other The Region to be compared.
+     * @return the value {@code 0} if the regionId of the compared Region is
+     *  equal to the regionId of this Region; a value less than {@code 0} if
+     *  the regionId of this Region is lexicographically less than the regionId
+     *  of the compared Region; and a value greater than {@code 0} if the
+     *  regionId of this Region is lexicographically greater than the regionId
+     *  of the compared Region.
+     */
+    public int compareTo(Region other) {
+        return regionId.compareTo(other.regionId);
+    }
+
+    @Override
+    // For backward compatibility maintain the enum toString behavior
+    public String toString() {
+        return NameUtils.canonicalizeForEnumTypes(getRegionId());
+    }
+
+    /**
+     * All known Regions in this version of the SDK
+     *
+     * @return Known regions
+     */
+    public static Region[] values() {
+        synchronized (KNOWN_REGIONS) {
+            return KNOWN_REGIONS.values().toArray(new Region[0]);
+        }
+    }
+
+    /**
+     * Returns the Region object matching the specified name. The name must
+     * match exactly. (Extraneous whitespace characters are not permitted.)
+     *
+     * @param name The name of the region
+     * @return The Region object matching the specified name, if available.
+     * @throws IllegalArgumentException if no region exists with the specified
+     * name
+     */
+    public static Region valueOf(@NonNull String name) throws IllegalArgumentException {
+        Region region;
+
+        synchronized (KNOWN_REGIONS) {
+            region = KNOWN_REGIONS.get(name);
+        }
+
+        if (region == null) {
+            throw new IllegalArgumentException("Unknown region " + name);
+        }
+        return region;
     }
 
     /**
@@ -145,12 +229,12 @@ public enum Region {
     }
 
     /**
-     * Returns the region enum from the canonical public region ID. Throws
+     * Returns the Region object from the canonical public region ID. Throws
      * IllegalArgumentException if the region ID is not known.
      *
      * @param regionId
      *            The region ID.
-     * @return The enum value.
+     * @return The Region object.
      */
     public static Region fromRegionId(String regionId) {
         Optional<Region> maybeRegion = maybeFromRegionId(regionId);
@@ -170,12 +254,12 @@ public enum Region {
     }
 
     /**
-     * Returns the region enum from the public region code. Throws
+     * Returns the Region object from the public region code. Throws
      * IllegalArgumentException if the region code is not known.
      *
      * @param regionCode
      *            The region code.
-     * @return The enum value.
+     * @return The Region object.
      * @deprecated use {@link #fromRegionId(String)} and provide the canonical region ID.
      */
     @Deprecated
@@ -189,12 +273,12 @@ public enum Region {
     }
 
     /**
-     * Returns the region enum from the public region code or id. Throws
+     * Returns the Region object from the public region code or id. Throws
      * IllegalArgumentException if the region code or id is not known.
      *
      * @param regionCodeOrId
      *            The region code or id.
-     * @return The enum value.
+     * @return The Region object.
      * @deprecated use {@link #fromRegionId(String)} and provide the canonical region ID.
      */
     @Deprecated
@@ -206,5 +290,33 @@ public enum Region {
             }
         }
         throw new IllegalArgumentException("Unknown region: " + regionCodeOrId);
+    }
+
+    /**
+     * Register a new region. Used to allow the SDK to be forward compatible with unreleased regions.
+     *
+     * @param regionId The region ID.
+     * @param realm The realm of the new region.
+     * @return The registered region (or existing one if found).
+     */
+    public static Region register(@NonNull String regionId, @NonNull final Realm realm) {
+        regionId = regionId.toLowerCase(Locale.US);
+        synchronized (KNOWN_REGIONS) {
+            for (Region region : Region.values()) {
+                if (region.getRegionId().equals(regionId)) {
+                    if (!region.getRealm().equals(realm)) {
+                        throw new IllegalArgumentException(
+                                "Region : "
+                                        + regionId
+                                        + " is already registered with "
+                                        + region.getRealm()
+                                        + ". It cannot be re-registered with a different realm.");
+                    }
+                    return region;
+                }
+            }
+
+            return new Region(regionId, realm);
+        }
     }
 }

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.Realm;
 import com.oracle.bmc.Region;
 import com.oracle.bmc.ConfigFileReader.ConfigFile;
 
@@ -86,10 +87,14 @@ public class ConfigFileAuthenticationDetailsProvider
                 region = Region.fromRegionId(regionId);
             } catch (IllegalArgumentException e) {
                 LOG.warn(
-                        "Found regionId '{}' in config file, but not supported by this version of the SDK, continuing without region",
+                        "Found regionId '{}' in config file, but not supported by this version of the SDK",
                         regionId,
                         e);
+                // Proceed by assuming the region id in the config file belongs to OC1 realm.
+                region = Region.register(regionId, Realm.OC1);
             }
+        } else {
+            LOG.info("Region not specified in Config file. Proceeding without setting a region.");
         }
 
         SimpleAuthenticationDetailsProvider.SimpleAuthenticationDetailsProviderBuilder builder =

--- a/bmc-common/src/main/java/com/oracle/bmc/internal/EndpointBuilder.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/internal/EndpointBuilder.java
@@ -24,25 +24,6 @@ public class EndpointBuilder {
     public static final String DEFAULT_ENDPOINT_TEMPLATE =
             "https://{serviceEndpointPrefix}.{region}.{secondLevelDomain}";
 
-    @RequiredArgsConstructor
-    private enum SecondLevelDomainNames {
-        ORACLECLOUD_COM("oraclecloud.com"),
-        ORACLEGOVCLOUD_COM("oraclegovcloud.com");
-
-        /**
-         * The default second level domain for all regions in this realm.
-         * Does not start with '.'.
-         */
-        private final String secondLevelDomain;
-    }
-
-    @Getter(value = AccessLevel.PACKAGE)
-    private final static ImmutableMap<Realm, String> realmToSecondLevelDomainName =
-            ImmutableMap.of(
-                    Realm.OC1, SecondLevelDomainNames.ORACLECLOUD_COM.secondLevelDomain,
-                    Realm.OC2, SecondLevelDomainNames.ORACLEGOVCLOUD_COM.secondLevelDomain,
-                    Realm.OC3, SecondLevelDomainNames.ORACLEGOVCLOUD_COM.secondLevelDomain);
-
     /**
      * Creates the service endpoint using the {@link DefaultEndpointConfiguration}
      * method.
@@ -63,7 +44,7 @@ public class EndpointBuilder {
         return DefaultEndpointConfiguration.builder(endpointTemplateToUse)
                 .regionId(regionId)
                 .serviceEndpointPrefix(service.getServiceEndpointPrefix())
-                .secondLevelDomain(realmToSecondLevelDomainName.get(realm))
+                .secondLevelDomain(realm.getSecondLevelDomain())
                 .build();
     }
 

--- a/bmc-common/src/main/java/com/oracle/bmc/util/internal/NameUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/util/internal/NameUtils.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.util.internal;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility functions related to naming
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NameUtils {
+    /**
+     * Canonicalizes a name for use in enum types. This specifically is for enum ids (values) that matched
+     * the enum name except were lower case and used hyphen delimiters vs upper case and underscores (enum naming convention)
+     *
+     * @param name The un-canonicalized name.
+     * @return The canonicalized name.
+     */
+    public static String canonicalizeForEnumTypes(final String name) {
+        return name.toUpperCase().replaceAll("-", "_");
+    }
+}

--- a/bmc-common/src/test/java/com/oracle/bmc/RealmTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/RealmTest.java
@@ -3,17 +3,20 @@
  */
 package com.oracle.bmc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.oracle.bmc.util.internal.NameUtils;
 import org.junit.Test;
 
 public class RealmTest {
@@ -23,19 +26,7 @@ public class RealmTest {
                     .put("OC2", "oc2")
                     .put("OC3", "oc3")
                     .build();
-
-    // Note: This test will fail if the Realm Enum is updated without updating this test.  This is intentional.
-    @Test
-    public void withExpectedRealms_shouldNotContainUnexpectedValues() {
-        final Set<Realm> actualRealms = new HashSet<>(Arrays.asList(Realm.values()));
-        for (String name : EXPECTED_REALMS.keySet()) {
-            actualRealms.remove(Realm.valueOf(name));
-        }
-
-        assertTrue(
-                "Found unexpected realm definitions: " + actualRealms.toString(),
-                actualRealms.isEmpty());
-    }
+    private static final String NEW_SECOND_LEVEL_DOMAIN = "oracle-foo-cloud.com";
 
     @Test
     public void withExpectedRealms_shouldContainAllValues() {
@@ -53,5 +44,96 @@ public class RealmTest {
             assertFalse(realmIds.contains(realm.getRealmId()));
             realmIds.add(realm.getRealmId());
         }
+    }
+
+    @Test
+    public void valueOfKnownRealmName() {
+        Realm testRealm = Realm.valueOf("OC1");
+        assertEquals(Realm.OC1, testRealm);
+        assertSame(Realm.OC1, testRealm);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void valueOfUnknownRealmName() {
+        Realm.valueOf("foobar");
+    }
+
+    @Test
+    public void registerKnownRealm() {
+        int realmCount = Realm.values().length;
+        final Realm existingRealm =
+                Realm.register(Realm.OC1.getRealmId(), Realm.OC1.getSecondLevelDomain());
+
+        assertSame(Realm.OC1, existingRealm);
+        assertEquals(Realm.OC1.getRealmId(), existingRealm.getRealmId());
+        assertEquals(Realm.OC1.getSecondLevelDomain(), existingRealm.getSecondLevelDomain());
+        assertEquals(realmCount, Realm.values().length);
+        assertSame(
+                existingRealm,
+                Realm.valueOf(NameUtils.canonicalizeForEnumTypes(Realm.OC1.getRealmId())));
+        assertSame(
+                existingRealm,
+                Realm.register(Realm.OC1.getRealmId(), Realm.OC1.getSecondLevelDomain()));
+        assertEquals(realmCount, Realm.values().length);
+    }
+
+    @Test
+    public void registerNewRealm() {
+        final String newRealmId = "foo";
+        int realmCount = Realm.values().length;
+        final Realm newRealm = Realm.register(newRealmId, NEW_SECOND_LEVEL_DOMAIN);
+
+        assertEquals(newRealmId, newRealm.getRealmId());
+        assertEquals(NEW_SECOND_LEVEL_DOMAIN, newRealm.getSecondLevelDomain());
+        assertEquals(realmCount + 1, Realm.values().length);
+        assertSame(newRealm, Realm.valueOf(NameUtils.canonicalizeForEnumTypes(newRealmId)));
+        assertSame(newRealm, Realm.register(newRealmId, NEW_SECOND_LEVEL_DOMAIN));
+        assertEquals(realmCount + 1, Realm.values().length);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void existingRealmsAreImmutable() {
+        Realm.register(Realm.OC1.getRealmId(), NEW_SECOND_LEVEL_DOMAIN);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void newRealmsAreImmutable() {
+        final String newRealmId = "foo1";
+        Realm.register(newRealmId, NEW_SECOND_LEVEL_DOMAIN);
+        Realm.register(newRealmId, Realm.OC1.getSecondLevelDomain());
+    }
+
+    @Test
+    // Check that the realm names follow enum naming convention (if the realmId is oc1, then the name of the realm
+    // object should be OC1). This allows for forward compatibility when registering new realms.
+    public void knownRealmsFollowNamingGuidelines() throws IllegalAccessException {
+        final Field[] declaredFields = Realm.class.getDeclaredFields();
+        for (Field field : declaredFields) {
+            if (field.getType() == Realm.class
+                    && Modifier.isStatic(field.getModifiers())
+                    && Modifier.isPublic(field.getModifiers())) {
+                final Realm realm = (Realm) field.get(null);
+                assertEquals(
+                        field.getName(), NameUtils.canonicalizeForEnumTypes(realm.getRealmId()));
+            }
+        }
+    }
+
+    @Test
+    public void stableOrderingOfRealmValues() {
+        final List<Realm> realmList = new ArrayList<>(Arrays.asList(Realm.values()));
+        assertEquals(realmList, Arrays.asList(Realm.values()));
+
+        // Register realm ocx
+        realmList.add(Realm.register("ocx", "ocx.com"));
+        assertEquals(realmList, Arrays.asList(Realm.values()));
+
+        // Register realm ocy
+        realmList.add(Realm.register("ocy", "ocy.com"));
+        assertEquals(realmList, Arrays.asList(Realm.values()));
+
+        // Register realm ocz
+        realmList.add(Realm.register("ocz", "ocz.com"));
+        assertEquals(realmList, Arrays.asList(Realm.values()));
     }
 }

--- a/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
@@ -4,6 +4,7 @@
 package com.oracle.bmc;
 
 import com.google.common.base.Optional;
+import com.oracle.bmc.util.internal.NameUtils;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -11,12 +12,23 @@ import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class RegionTest {
-
     private static final Service TEST_SERVICE =
             Services.serviceBuilder()
                     .serviceEndpointPrefix("foobar")
@@ -110,11 +122,135 @@ public class RegionTest {
 
     @Test
     public void invalidRegion() {
+        final String regionId = "baz";
         try {
-            assertNotNull(Region.fromRegionCodeOrId(("foo")));
+            assertNotNull(Region.fromRegionCodeOrId(regionId));
             fail("should have thrown");
         } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
+            assertTrue(e.getMessage().contains(regionId));
+            final Region newRegion = Region.register(regionId, Realm.OC1);
+            final Optional<String> endpoint = newRegion.getEndpoint(TEST_SERVICE);
+            assertTrue(endpoint.isPresent());
+            assertEquals("https://foobar.baz.oraclecloud.com", endpoint.get());
         }
+    }
+
+    @Test
+    public void validRegionName() {
+        assertSame(Region.CA_TORONTO_1, Region.valueOf("CA_TORONTO_1"));
+        assertSame(Region.US_PHOENIX_1, Region.valueOf("US_PHOENIX_1"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegionName() {
+        Region.valueOf("foobar");
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws IOException, ClassNotFoundException {
+        final File tempFile = File.createTempFile("test", ".data");
+        tempFile.deleteOnExit();
+
+        final FileOutputStream outputFile = new FileOutputStream(tempFile.getPath());
+        final ObjectOutputStream out = new ObjectOutputStream(outputFile);
+        final Region unknownRegion = Region.register("foobar", Realm.OC1);
+
+        out.writeObject(Region.US_PHOENIX_1);
+        out.writeObject(unknownRegion);
+
+        out.close();
+        outputFile.close();
+
+        final FileInputStream inputFile = new FileInputStream(tempFile.getPath());
+        final ObjectInputStream in = new ObjectInputStream(inputFile);
+
+        final Region region1 = (Region) in.readObject();
+        final Region region2 = (Region) in.readObject();
+
+        in.close();
+        inputFile.close();
+
+        assertEquals(Region.US_PHOENIX_1, region1);
+        assertEquals(unknownRegion, region2);
+    }
+
+    @Test
+    public void registerKnownRegion() {
+        int regionCount = Region.values().length;
+        final Region existingRegion =
+                Region.register(Region.US_PHOENIX_1.getRegionId(), Region.US_PHOENIX_1.getRealm());
+
+        assertSame(Region.US_PHOENIX_1, existingRegion);
+        assertEquals(Region.US_PHOENIX_1.getRegionId(), existingRegion.getRegionId());
+        assertEquals(Region.US_PHOENIX_1.getRealm(), existingRegion.getRealm());
+        assertEquals(regionCount, Region.values().length);
+        assertSame(
+                existingRegion,
+                Region.valueOf(
+                        NameUtils.canonicalizeForEnumTypes(Region.US_PHOENIX_1.getRegionId())));
+        assertSame(
+                existingRegion,
+                Region.register(Region.US_PHOENIX_1.getRegionId(), Region.US_PHOENIX_1.getRealm()));
+        assertEquals(regionCount, Region.values().length);
+    }
+
+    @Test
+    public void registerNewRegion() {
+        final String newRegionId = "us-foo-1";
+        int regionCount = Region.values().length;
+        final Region newRegion = Region.register(newRegionId, Realm.OC3);
+
+        assertEquals(newRegionId, newRegion.getRegionId());
+        assertEquals(Realm.OC3, newRegion.getRealm());
+        assertEquals(regionCount + 1, Region.values().length);
+        assertSame(newRegion, Region.valueOf(NameUtils.canonicalizeForEnumTypes(newRegionId)));
+        assertSame(newRegion, Region.register(newRegionId, Realm.OC3));
+        assertEquals(regionCount + 1, Region.values().length);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void existingRegionsAreImmutable() {
+        Region.register(Region.US_PHOENIX_1.getRegionId(), Realm.OC3);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void newRegionsAreImmutable() {
+        final String newRegionId = "us-foo-2";
+        Region.register(newRegionId, Realm.OC3);
+        Region.register(newRegionId, Realm.OC2);
+    }
+
+    @Test
+    // Check that the region names follow enum naming convention (if the regionId is us-phoenix-1, then the name of the
+    // region object should be US-PHOENIX-1). This allows for forward compatibility when registering new regions.
+    public void knownRegionsFollowNamingGuidelines() throws IllegalAccessException {
+        final Field[] declaredFields = Region.class.getDeclaredFields();
+        for (Field field : declaredFields) {
+            if (field.getType() == Region.class
+                    && Modifier.isStatic(field.getModifiers())
+                    && Modifier.isPublic(field.getModifiers())) {
+                final Region region = (Region) field.get(null);
+                assertEquals(
+                        field.getName(), NameUtils.canonicalizeForEnumTypes(region.getRegionId()));
+            }
+        }
+    }
+
+    @Test
+    public void stableOrderingOfRegionValues() {
+        final List<Region> regionList = new ArrayList<>(Arrays.asList(Region.values()));
+        assertEquals(regionList, Arrays.asList(Region.values()));
+
+        // register region xxx
+        regionList.add(Region.register("xxx", Realm.OC1));
+        assertEquals(regionList, Arrays.asList(Region.values()));
+
+        // register region yyy
+        regionList.add(Region.register("yyy", Realm.OC2));
+        assertEquals(regionList, Arrays.asList(Region.values()));
+
+        // register region zzz
+        regionList.add(Region.register("zzz", Realm.OC3));
+        assertEquals(regionList, Arrays.asList(Region.values()));
     }
 }

--- a/bmc-common/src/test/java/com/oracle/bmc/internal/EndpointBuilderTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/internal/EndpointBuilderTest.java
@@ -16,13 +16,6 @@ import com.oracle.bmc.Services;
 public class EndpointBuilderTest {
 
     @Test
-    public void allRealmsHaveSecondLevelDomainsConfigured() {
-        for (Realm realm : Realm.values()) {
-            assertNotNull(EndpointBuilder.getRealmToSecondLevelDomainName().get(realm));
-        }
-    }
-
-    @Test
     public void createEndpoint_useDefaultTemplate() {
         Service testService =
                 Services.serviceBuilder()

--- a/bmc-common/src/test/java/com/oracle/bmc/util/internal/NameUtilsTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/util/internal/NameUtilsTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.util.internal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NameUtilsTest {
+
+    @Test
+    public void canonicalizeName() {
+        // lower case name
+        assertEquals("FOO", NameUtils.canonicalizeForEnumTypes("foo"));
+        // upper case name
+        assertEquals("FOO", NameUtils.canonicalizeForEnumTypes("FOO"));
+        // camel case name
+        assertEquals("FOOBAR", NameUtils.canonicalizeForEnumTypes("fooBar"));
+        // Pascal case name
+        assertEquals("FOOBAR", NameUtils.canonicalizeForEnumTypes("FooBar"));
+        // snake case name
+        assertEquals("FOO_BAR", NameUtils.canonicalizeForEnumTypes("foo_bar"));
+        // upper snake case name
+        assertEquals("FOO_BAR", NameUtils.canonicalizeForEnumTypes("Foo_Bar"));
+        // kebab case name
+        assertEquals("FOO_BAR", NameUtils.canonicalizeForEnumTypes("foo-bar"));
+        // upper kebab case name
+        assertEquals("FOO_BAR", NameUtils.canonicalizeForEnumTypes("Foo-Bar"));
+
+        assertEquals("FOO_BAR", NameUtils.canonicalizeForEnumTypes("FOO_BAR"));
+    }
+}

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
@@ -115,7 +115,7 @@ public interface Compute extends AutoCloseable {
      * <p>
      * When importing an image based on the Object Storage URL, use
      * {@link #imageSourceViaObjectStorageUriDetails(ImageSourceViaObjectStorageUriDetailsRequest) imageSourceViaObjectStorageUriDetails}.
-     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [pre-authenticated requests](https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth)
+     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [Using Pre-Authenticated Requests](https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm)
      * for constructing URLs for image import/export.
      * <p>
      * For more information about importing exported images, see
@@ -230,7 +230,7 @@ public interface Compute extends AutoCloseable {
      * To perform an image export, you need write access to the Object Storage bucket for the image,
      * see [Let Users Write Objects to Object Storage Buckets](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm#Let4).
      * <p>
-     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [pre-authenticated requests](https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth)
+     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [Using Pre-Authenticated Requests](https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm)
      * for constructing URLs for image import/export.
      *
      * @param request The request object containing the details to send

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
@@ -151,7 +151,7 @@ public interface ComputeAsync extends AutoCloseable {
      * <p>
      * When importing an image based on the Object Storage URL, use
      * {@link #imageSourceViaObjectStorageUriDetails(ImageSourceViaObjectStorageUriDetailsRequest, Consumer, Consumer) imageSourceViaObjectStorageUriDetails}.
-     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [pre-authenticated requests](https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth)
+     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [Using Pre-Authenticated Requests](https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm)
      * for constructing URLs for image import/export.
      * <p>
      * For more information about importing exported images, see
@@ -332,7 +332,7 @@ public interface ComputeAsync extends AutoCloseable {
      * To perform an image export, you need write access to the Object Storage bucket for the image,
      * see [Let Users Write Objects to Object Storage Buckets](https://docs.cloud.oracle.com/Content/Identity/Concepts/commonpolicies.htm#Let4).
      * <p>
-     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [pre-authenticated requests](https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth)
+     * See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs) and [Using Pre-Authenticated Requests](https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm)
      * for constructing URLs for image import/export.
      *
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -894,6 +894,16 @@ public interface VirtualNetwork extends AutoCloseable {
             GetFastConnectProviderServiceRequest request);
 
     /**
+     * Gets the specified provider service key's information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetFastConnectProviderServiceKeyResponse getFastConnectProviderServiceKey(
+            GetFastConnectProviderServiceKeyRequest request);
+
+    /**
      * Gets the specified IPSec connection's basic information, including the static routes for the
      * on-premises router. If you want the status of the connection (whether it's up or down), use
      * {@link #getIPSecConnectionDeviceStatus(GetIPSecConnectionDeviceStatusRequest) getIPSecConnectionDeviceStatus}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -1291,6 +1291,25 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Gets the specified provider service key's information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetFastConnectProviderServiceKeyResponse>
+            getFastConnectProviderServiceKey(
+                    GetFastConnectProviderServiceKeyRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetFastConnectProviderServiceKeyRequest,
+                                    GetFastConnectProviderServiceKeyResponse>
+                            handler);
+
+    /**
      * Gets the specified IPSec connection's basic information, including the static routes for the
      * on-premises router. If you want the status of the connection (whether it's up or down), use
      * {@link #getIPSecConnectionDeviceStatus(GetIPSecConnectionDeviceStatusRequest, Consumer, Consumer) getIPSecConnectionDeviceStatus}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
@@ -4661,6 +4661,86 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetFastConnectProviderServiceKeyResponse>
+            getFastConnectProviderServiceKey(
+                    final GetFastConnectProviderServiceKeyRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetFastConnectProviderServiceKeyRequest,
+                                    GetFastConnectProviderServiceKeyResponse>
+                            handler) {
+        LOG.trace("Called async getFastConnectProviderServiceKey");
+        final GetFastConnectProviderServiceKeyRequest interceptedRequest =
+                GetFastConnectProviderServiceKeyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetFastConnectProviderServiceKeyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetFastConnectProviderServiceKeyResponse>
+                transformer = GetFastConnectProviderServiceKeyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetFastConnectProviderServiceKeyRequest,
+                        GetFastConnectProviderServiceKeyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetFastConnectProviderServiceKeyRequest,
+                            GetFastConnectProviderServiceKeyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetFastConnectProviderServiceKeyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetIPSecConnectionResponse> getIPSecConnection(
             final GetIPSecConnectionRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
@@ -1751,6 +1751,33 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public GetFastConnectProviderServiceKeyResponse getFastConnectProviderServiceKey(
+            GetFastConnectProviderServiceKeyRequest request) {
+        LOG.trace("Called getFastConnectProviderServiceKey");
+        request = GetFastConnectProviderServiceKeyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetFastConnectProviderServiceKeyConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetFastConnectProviderServiceKeyResponse>
+                transformer = GetFastConnectProviderServiceKeyConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response = client.get(ib, request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
     public GetIPSecConnectionResponse getIPSecConnection(GetIPSecConnectionRequest request) {
         LOG.trace("Called getIPSecConnection");
         request = GetIPSecConnectionConverter.interceptRequest(request);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetFastConnectProviderServiceKeyConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetFastConnectProviderServiceKeyConverter.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetFastConnectProviderServiceKeyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetFastConnectProviderServiceKeyRequest interceptRequest(
+            GetFastConnectProviderServiceKeyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetFastConnectProviderServiceKeyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getProviderServiceId(), "providerServiceId must not be blank");
+        Validate.notBlank(
+                request.getProviderServiceKeyName(), "providerServiceKeyName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("fastConnectProviderServices")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getProviderServiceId()))
+                        .path("providerServiceKeys")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getProviderServiceKeyName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetFastConnectProviderServiceKeyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetFastConnectProviderServiceKeyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GetFastConnectProviderServiceKeyResponse>() {
+                            @Override
+                            public GetFastConnectProviderServiceKeyResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetFastConnectProviderServiceKeyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        FastConnectProviderServiceKey>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        FastConnectProviderServiceKey.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                FastConnectProviderServiceKey>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetFastConnectProviderServiceKeyResponse.Builder builder =
+                                        GetFastConnectProviderServiceKeyResponse.builder();
+
+                                builder.fastConnectProviderServiceKey(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetFastConnectProviderServiceKeyResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachParavirtualizedVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AttachParavirtualizedVolumeDetails.java
@@ -135,7 +135,7 @@ public class AttachParavirtualizedVolumeDetails extends AttachVolumeDetails {
     }
 
     /**
-     * Whether to enable encryption in transit for the PV data volume attachment. Defaults to false.
+     * Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeAttachment.java
@@ -259,7 +259,7 @@ public class BootVolumeAttachment {
     java.util.Date timeCreated;
 
     /**
-     * Whether the enable encryption in transit for the PV volume attachment is on or not.
+     * Whether in-transit encryption for the boot volume's paravirtualized attachment is enabled or not.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectDetails.java
@@ -89,6 +89,15 @@ public class CreateCrossConnectDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -101,7 +110,8 @@ public class CreateCrossConnectDetails {
                             farCrossConnectOrCrossConnectGroupId,
                             locationName,
                             nearCrossConnectOrCrossConnectGroupId,
-                            portSpeedShapeName);
+                            portSpeedShapeName,
+                            customerReferenceName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -117,7 +127,8 @@ public class CreateCrossConnectDetails {
                             .locationName(o.getLocationName())
                             .nearCrossConnectOrCrossConnectGroupId(
                                     o.getNearCrossConnectOrCrossConnectGroupId())
-                            .portSpeedShapeName(o.getPortSpeedShapeName());
+                            .portSpeedShapeName(o.getPortSpeedShapeName())
+                            .customerReferenceName(o.getCustomerReferenceName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -190,6 +201,14 @@ public class CreateCrossConnectDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("portSpeedShapeName")
     String portSpeedShapeName;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCrossConnectGroupDetails.java
@@ -42,12 +42,22 @@ public class CreateCrossConnectGroupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateCrossConnectGroupDetails build() {
             CreateCrossConnectGroupDetails __instance__ =
-                    new CreateCrossConnectGroupDetails(compartmentId, displayName);
+                    new CreateCrossConnectGroupDetails(
+                            compartmentId, displayName, customerReferenceName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -55,7 +65,9 @@ public class CreateCrossConnectGroupDetails {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateCrossConnectGroupDetails o) {
             Builder copiedBuilder =
-                    compartmentId(o.getCompartmentId()).displayName(o.getDisplayName());
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .customerReferenceName(o.getCustomerReferenceName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -82,6 +94,14 @@ public class CreateCrossConnectGroupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * group uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
@@ -180,7 +180,7 @@ public class CreateImageDetails {
     String instanceId;
     /**
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
-     * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
+     * * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
      * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
@@ -222,7 +222,7 @@ public class CreateImageDetails {
     };
     /**
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
-     * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
+     * * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
      * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVirtualCircuitDetails.java
@@ -97,6 +97,15 @@ public class CreateVirtualCircuitDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+        private String providerServiceKeyName;
+
+        public Builder providerServiceKeyName(String providerServiceKeyName) {
+            this.providerServiceKeyName = providerServiceKeyName;
+            this.__explicitlySet__.add("providerServiceKeyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("providerServiceName")
         private String providerServiceName;
 
@@ -148,6 +157,7 @@ public class CreateVirtualCircuitDetails {
                             gatewayId,
                             providerName,
                             providerServiceId,
+                            providerServiceKeyName,
                             providerServiceName,
                             publicPrefixes,
                             region,
@@ -167,6 +177,7 @@ public class CreateVirtualCircuitDetails {
                             .gatewayId(o.getGatewayId())
                             .providerName(o.getProviderName())
                             .providerServiceId(o.getProviderServiceId())
+                            .providerServiceKeyName(o.getProviderServiceKeyName())
                             .providerServiceName(o.getProviderServiceName())
                             .publicPrefixes(o.getPublicPrefixes())
                             .region(o.getRegion())
@@ -251,6 +262,13 @@ public class CreateVirtualCircuitDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("providerServiceId")
     String providerServiceId;
+
+    /**
+     * The service key name offered by the provider (if the customer is connecting via a provider).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+    String providerServiceKeyName;
 
     /**
      * Deprecated. Instead use `providerServiceId`.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
@@ -113,6 +113,15 @@ public class CrossConnect {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -136,6 +145,7 @@ public class CrossConnect {
                             locationName,
                             portName,
                             portSpeedShapeName,
+                            customerReferenceName,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -152,6 +162,7 @@ public class CrossConnect {
                             .locationName(o.getLocationName())
                             .portName(o.getPortName())
                             .portSpeedShapeName(o.getPortSpeedShapeName())
+                            .customerReferenceName(o.getCustomerReferenceName())
                             .timeCreated(o.getTimeCreated());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -267,6 +278,14 @@ public class CrossConnect {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("portSpeedShapeName")
     String portSpeedShapeName;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     /**
      * The date and time the cross-connect was created, in the format defined by RFC3339.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
@@ -76,6 +76,15 @@ public class CrossConnectGroup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -91,7 +100,12 @@ public class CrossConnectGroup {
         public CrossConnectGroup build() {
             CrossConnectGroup __instance__ =
                     new CrossConnectGroup(
-                            compartmentId, displayName, id, lifecycleState, timeCreated);
+                            compartmentId,
+                            displayName,
+                            id,
+                            lifecycleState,
+                            customerReferenceName,
+                            timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -103,6 +117,7 @@ public class CrossConnectGroup {
                             .displayName(o.getDisplayName())
                             .id(o.getId())
                             .lifecycleState(o.getLifecycleState())
+                            .customerReferenceName(o.getCustomerReferenceName())
                             .timeCreated(o.getTimeCreated());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -190,6 +205,14 @@ public class CrossConnectGroup {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * group uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     /**
      * The date and time the cross-connect group was created, in the format defined by RFC3339.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
@@ -73,7 +73,7 @@ public class ExportImageViaObjectStorageUriDetails extends ExportImageDetails {
 
     /**
      * The Object Storage URL to export the image to. See [Object Storage URLs](https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs)
-     * and [pre-authenticated requests](https://docs.cloud.oracle.com/Content/Object/Tasks/managingaccess.htm#pre-auth) for constructing URLs for image import/export.
+     * and [Using Pre-Authenticated Requests](https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm) for constructing URLs for image import/export.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("destinationUri")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
@@ -92,6 +92,43 @@ public class FastConnectProviderService {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerAsnManagement")
+        private CustomerAsnManagement customerAsnManagement;
+
+        public Builder customerAsnManagement(CustomerAsnManagement customerAsnManagement) {
+            this.customerAsnManagement = customerAsnManagement;
+            this.__explicitlySet__.add("customerAsnManagement");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyManagement")
+        private ProviderServiceKeyManagement providerServiceKeyManagement;
+
+        public Builder providerServiceKeyManagement(
+                ProviderServiceKeyManagement providerServiceKeyManagement) {
+            this.providerServiceKeyManagement = providerServiceKeyManagement;
+            this.__explicitlySet__.add("providerServiceKeyManagement");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bandwithShapeManagement")
+        private BandwithShapeManagement bandwithShapeManagement;
+
+        public Builder bandwithShapeManagement(BandwithShapeManagement bandwithShapeManagement) {
+            this.bandwithShapeManagement = bandwithShapeManagement;
+            this.__explicitlySet__.add("bandwithShapeManagement");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requiredTotalCrossConnects")
+        private Integer requiredTotalCrossConnects;
+
+        public Builder requiredTotalCrossConnects(Integer requiredTotalCrossConnects) {
+            this.requiredTotalCrossConnects = requiredTotalCrossConnects;
+            this.__explicitlySet__.add("requiredTotalCrossConnects");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("type")
         private Type type;
 
@@ -114,6 +151,10 @@ public class FastConnectProviderService {
                             providerServiceName,
                             publicPeeringBgpManagement,
                             supportedVirtualCircuitTypes,
+                            customerAsnManagement,
+                            providerServiceKeyManagement,
+                            bandwithShapeManagement,
+                            requiredTotalCrossConnects,
                             type);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -129,6 +170,10 @@ public class FastConnectProviderService {
                             .providerServiceName(o.getProviderServiceName())
                             .publicPeeringBgpManagement(o.getPublicPeeringBgpManagement())
                             .supportedVirtualCircuitTypes(o.getSupportedVirtualCircuitTypes())
+                            .customerAsnManagement(o.getCustomerAsnManagement())
+                            .providerServiceKeyManagement(o.getProviderServiceKeyManagement())
+                            .bandwithShapeManagement(o.getBandwithShapeManagement())
+                            .requiredTotalCrossConnects(o.getRequiredTotalCrossConnects())
                             .type(o.getType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -329,6 +374,177 @@ public class FastConnectProviderService {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("supportedVirtualCircuitTypes")
     java.util.List<SupportedVirtualCircuitTypes> supportedVirtualCircuitTypes;
+    /**
+     * Who is responsible for managing the ASN information for the network at the other end
+     * of the connection from Oracle.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CustomerAsnManagement {
+        CustomerManaged("CUSTOMER_MANAGED"),
+        ProviderManaged("PROVIDER_MANAGED"),
+        OracleManaged("ORACLE_MANAGED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CustomerAsnManagement> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CustomerAsnManagement v : CustomerAsnManagement.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CustomerAsnManagement(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CustomerAsnManagement create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CustomerAsnManagement', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Who is responsible for managing the ASN information for the network at the other end
+     * of the connection from Oracle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerAsnManagement")
+    CustomerAsnManagement customerAsnManagement;
+    /**
+     * Who is responsible for managing the provider service key.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ProviderServiceKeyManagement {
+        CustomerManaged("CUSTOMER_MANAGED"),
+        ProviderManaged("PROVIDER_MANAGED"),
+        OracleManaged("ORACLE_MANAGED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ProviderServiceKeyManagement> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ProviderServiceKeyManagement v : ProviderServiceKeyManagement.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ProviderServiceKeyManagement(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ProviderServiceKeyManagement create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ProviderServiceKeyManagement', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Who is responsible for managing the provider service key.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyManagement")
+    ProviderServiceKeyManagement providerServiceKeyManagement;
+    /**
+     * Who is responsible for managing the virtual circuit bandwidth.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum BandwithShapeManagement {
+        CustomerManaged("CUSTOMER_MANAGED"),
+        ProviderManaged("PROVIDER_MANAGED"),
+        OracleManaged("ORACLE_MANAGED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, BandwithShapeManagement> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BandwithShapeManagement v : BandwithShapeManagement.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        BandwithShapeManagement(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BandwithShapeManagement create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'BandwithShapeManagement', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Who is responsible for managing the virtual circuit bandwidth.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bandwithShapeManagement")
+    BandwithShapeManagement bandwithShapeManagement;
+
+    /**
+     * Total number of cross-connect or cross-connect groups required for the virtual circuit.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("requiredTotalCrossConnects")
+    Integer requiredTotalCrossConnects;
     /**
      * Provider service type.
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderServiceKey.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderServiceKey.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * A provider service key and its details. A provider service key is an identifier for a provider's
+ * virtual circuit.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FastConnectProviderServiceKey.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class FastConnectProviderServiceKey {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bandwidthShapeName")
+        private String bandwidthShapeName;
+
+        public Builder bandwidthShapeName(String bandwidthShapeName) {
+            this.bandwidthShapeName = bandwidthShapeName;
+            this.__explicitlySet__.add("bandwidthShapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peeringLocation")
+        private String peeringLocation;
+
+        public Builder peeringLocation(String peeringLocation) {
+            this.peeringLocation = peeringLocation;
+            this.__explicitlySet__.add("peeringLocation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FastConnectProviderServiceKey build() {
+            FastConnectProviderServiceKey __instance__ =
+                    new FastConnectProviderServiceKey(name, bandwidthShapeName, peeringLocation);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FastConnectProviderServiceKey o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .bandwidthShapeName(o.getBandwidthShapeName())
+                            .peeringLocation(o.getPeeringLocation());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the service key offered by the provider.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The provisioned data rate of the connection.  To get a list of the
+     * available bandwidth levels (that is, shapes), see
+     * {@link #listFastConnectProviderVirtualCircuitBandwidthShapes(ListFastConnectProviderVirtualCircuitBandwidthShapesRequest) listFastConnectProviderVirtualCircuitBandwidthShapes}.
+     * <p>
+     * Example: `10 Gbps`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bandwidthShapeName")
+    String bandwidthShapeName;
+
+    /**
+     * The provider's peering location.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peeringLocation")
+    String peeringLocation;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageSourceDetails.java
@@ -40,8 +40,8 @@ package com.oracle.bmc.core.model;
 public class ImageSourceDetails {
 
     /**
-     * The format of the image to be imported.  Exported Oracle images are QCOW2.  Only monolithic
-     * images are supported.
+     * The format of the image to be imported.  Only monolithic
+     * images are supported. This attribute is not used for exported Oracle images with the OCI image format.
      *
      **/
     public enum SourceImageType {
@@ -77,8 +77,8 @@ public class ImageSourceDetails {
         }
     };
     /**
-     * The format of the image to be imported.  Exported Oracle images are QCOW2.  Only monolithic
-     * images are supported.
+     * The format of the image to be imported.  Only monolithic
+     * images are supported. This attribute is not used for exported Oracle images with the OCI image format.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceImageType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -465,7 +465,7 @@ public class LaunchInstanceDetails {
     String subnetId;
 
     /**
-     * Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+     * Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchOptions.java
@@ -379,7 +379,7 @@ public class LaunchOptions {
     RemoteDataVolumeType remoteDataVolumeType;
 
     /**
-     * Whether to enable encryption in transit for the PV boot volume attachment. Defaults to false.
+     * Whether to enable in-transit encryption for the boot volume's paravirtualized attachment. The default value is false.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectDetails.java
@@ -43,19 +43,31 @@ public class UpdateCrossConnectDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateCrossConnectDetails build() {
             UpdateCrossConnectDetails __instance__ =
-                    new UpdateCrossConnectDetails(displayName, isActive);
+                    new UpdateCrossConnectDetails(displayName, isActive, customerReferenceName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCrossConnectDetails o) {
-            Builder copiedBuilder = displayName(o.getDisplayName()).isActive(o.getIsActive());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .isActive(o.getIsActive())
+                            .customerReferenceName(o.getCustomerReferenceName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -87,6 +99,14 @@ public class UpdateCrossConnectDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isActive")
     Boolean isActive;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCrossConnectGroupDetails.java
@@ -33,19 +33,30 @@ public class UpdateCrossConnectGroupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+        private String customerReferenceName;
+
+        public Builder customerReferenceName(String customerReferenceName) {
+            this.customerReferenceName = customerReferenceName;
+            this.__explicitlySet__.add("customerReferenceName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateCrossConnectGroupDetails build() {
             UpdateCrossConnectGroupDetails __instance__ =
-                    new UpdateCrossConnectGroupDetails(displayName);
+                    new UpdateCrossConnectGroupDetails(displayName, customerReferenceName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateCrossConnectGroupDetails o) {
-            Builder copiedBuilder = displayName(o.getDisplayName());
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .customerReferenceName(o.getCustomerReferenceName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -66,6 +77,14 @@ public class UpdateCrossConnectGroupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * A reference name or identifier for the physical fiber connection that this cross-connect
+     * group uses.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReferenceName")
+    String customerReferenceName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVirtualCircuitDetails.java
@@ -79,6 +79,15 @@ public class UpdateVirtualCircuitDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+        private String providerServiceKeyName;
+
+        public Builder providerServiceKeyName(String providerServiceKeyName) {
+            this.providerServiceKeyName = providerServiceKeyName;
+            this.__explicitlySet__.add("providerServiceKeyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("referenceComment")
         private String referenceComment;
 
@@ -100,6 +109,7 @@ public class UpdateVirtualCircuitDetails {
                             displayName,
                             gatewayId,
                             providerState,
+                            providerServiceKeyName,
                             referenceComment);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -114,6 +124,7 @@ public class UpdateVirtualCircuitDetails {
                             .displayName(o.getDisplayName())
                             .gatewayId(o.getGatewayId())
                             .providerState(o.getProviderState())
+                            .providerServiceKeyName(o.getProviderServiceKeyName())
                             .referenceComment(o.getReferenceComment());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -239,6 +250,13 @@ public class UpdateVirtualCircuitDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("providerState")
     ProviderState providerState;
+
+    /**
+     * The service key name offered by the provider (if the customer is connecting via a provider).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+    String providerServiceKeyName;
 
     /**
      * Provider-supplied reference information about this virtual circuit.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
@@ -162,6 +162,15 @@ public class VirtualCircuit {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+        private String providerServiceKeyName;
+
+        public Builder providerServiceKeyName(String providerServiceKeyName) {
+            this.providerServiceKeyName = providerServiceKeyName;
+            this.__explicitlySet__.add("providerServiceKeyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("providerServiceName")
         private String providerServiceName;
 
@@ -253,6 +262,7 @@ public class VirtualCircuit {
                             oracleBgpAsn,
                             providerName,
                             providerServiceId,
+                            providerServiceKeyName,
                             providerServiceName,
                             providerState,
                             publicPrefixes,
@@ -281,6 +291,7 @@ public class VirtualCircuit {
                             .oracleBgpAsn(o.getOracleBgpAsn())
                             .providerName(o.getProviderName())
                             .providerServiceId(o.getProviderServiceId())
+                            .providerServiceKeyName(o.getProviderServiceKeyName())
                             .providerServiceName(o.getProviderServiceName())
                             .providerState(o.getProviderState())
                             .publicPrefixes(o.getPublicPrefixes())
@@ -313,7 +324,8 @@ public class VirtualCircuit {
     @com.fasterxml.jackson.annotation.JsonProperty("bandwidthShapeName")
     String bandwidthShapeName;
     /**
-     * BGP management option.
+     * Deprecated. Instead use the information in
+     * {@link FastConnectProviderService}.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -361,7 +373,8 @@ public class VirtualCircuit {
         }
     };
     /**
-     * BGP management option.
+     * Deprecated. Instead use the information in
+     * {@link FastConnectProviderService}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bgpManagement")
@@ -548,6 +561,13 @@ public class VirtualCircuit {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("providerServiceId")
     String providerServiceId;
+
+    /**
+     * The service key name offered by the provider (if the customer is connecting via a provider).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("providerServiceKeyName")
+    String providerServiceKeyName;
 
     /**
      * Deprecated. Instead use `providerServiceId`.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeAttachment.java
@@ -166,7 +166,7 @@ public class VolumeAttachment {
     String volumeId;
 
     /**
-     * Whether the enable encryption in transit for the PV volume attachment is on or not.
+     * Whether in-transit encryption for the data volume's paravirtualized attachment is enabled or not.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetFastConnectProviderServiceKeyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetFastConnectProviderServiceKeyRequest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetFastConnectProviderServiceKeyRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the provider service.
+     */
+    private String providerServiceId;
+
+    /**
+     * The provider service key name.
+     */
+    private String providerServiceKeyName;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetFastConnectProviderServiceKeyRequest o) {
+            providerServiceId(o.getProviderServiceId());
+            providerServiceKeyName(o.getProviderServiceKeyName());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetFastConnectProviderServiceKeyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetFastConnectProviderServiceKeyRequest
+         */
+        public GetFastConnectProviderServiceKeyRequest build() {
+            GetFastConnectProviderServiceKeyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetFastConnectProviderServiceKeyResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetFastConnectProviderServiceKeyResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetFastConnectProviderServiceKeyResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned FastConnectProviderServiceKey instance.
+     */
+    private FastConnectProviderServiceKey fastConnectProviderServiceKey;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetFastConnectProviderServiceKeyResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            fastConnectProviderServiceKey(o.getFastConnectProviderServiceKey());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/FastConnectCrossConnectExample.java
+++ b/bmc-examples/src/main/java/FastConnectCrossConnectExample.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.core.VirtualNetwork;
+import com.oracle.bmc.core.VirtualNetworkClient;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import com.oracle.bmc.identity.IdentityClient;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sample to demonstrate setting up FastConnect CrossConnect
+ * <p>
+ *
+ *
+ *  Oracle Cloud Infrastructure FastConnect provides an easy way to create a dedicated,
+ *  private connection between your data center and Oracle Cloud Infrastructure.
+ *
+ *  FastConnect provides higher-bandwidth options, and a more reliable and consistent
+ *  networking experience compared to internet-based connections.
+ *
+ *  Details information on FastConnect: https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm
+ *
+ *  Details CrossConnect API: https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/CrossConnect
+ */
+public class FastConnectCrossConnectExample {
+    // Set this with your own compartment ID
+    private static final String COMPARTMENT_ID = "";
+
+    private static final String TIMESTAMP_SUFFIX =
+            String.valueOf(System.currentTimeMillis() % TimeUnit.SECONDS.toMillis(10L));
+
+    private final VirtualNetworkClient virtualNetworkClient;
+    private final Region region;
+
+    public FastConnectCrossConnectExample(
+            VirtualNetworkClient virtualNetworkClient, Region region) {
+        this.virtualNetworkClient = virtualNetworkClient;
+        this.region = region;
+    }
+
+    public static void main(final String... args) throws Exception {
+        if ("".equals(COMPARTMENT_ID)) {
+            throw new IllegalStateException("A compartment ID must be defined");
+        }
+
+        final AuthenticationDetailsProvider authProvider =
+                new ConfigFileAuthenticationDetailsProvider("~/.oci/config", "DEFAULT");
+
+        final VirtualNetworkClient phxVirtualNetworkClient = new VirtualNetworkClient(authProvider);
+        phxVirtualNetworkClient.setRegion(Region.US_PHOENIX_1);
+        final FastConnectCrossConnectExample example =
+                new FastConnectCrossConnectExample(phxVirtualNetworkClient, Region.US_PHOENIX_1);
+        final IdentityClient identityClient = new IdentityClient(authProvider);
+
+        example.run(identityClient);
+    }
+
+    public void run(IdentityClient identityClient) throws Exception {
+
+        System.out.println("Create CrossConnect example, NON-LAG physical connection.");
+
+        System.out.println("Get list of CrossConnect locations POP.");
+        List<CrossConnectLocation> listCrossConnectLocations =
+                getCrossConnectLocations(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Get list of CrossConnect port speeds.");
+        List<CrossConnectPortSpeedShape> listCrossConnectPortSpeedShape =
+                getCrossConnectPortSpeedShapes(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Create CrossConnect.");
+        CrossConnect cc =
+                createCrossConnect(
+                        virtualNetworkClient,
+                        COMPARTMENT_ID,
+                        null,
+                        listCrossConnectLocations.get(0).getName(),
+                        listCrossConnectPortSpeedShape.get(0).getName());
+
+        System.out.println("Activate the CrossConnect.");
+        cc = updateCrossConnect(virtualNetworkClient, cc.getId(), true);
+
+        System.out.println("Delete CrossConnect.");
+        deleteCrossConnect(virtualNetworkClient, cc.getId());
+    }
+
+    private static List<CrossConnectLocation> getCrossConnectLocations(
+            final VirtualNetwork virtualNetwork, final String compartmentId) {
+        ListCrossConnectLocationsResponse listCrossConnectLocationsResponse =
+                virtualNetwork.listCrossConnectLocations(
+                        ListCrossConnectLocationsRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+
+        return listCrossConnectLocationsResponse.getItems();
+    }
+
+    private static List<CrossConnectPortSpeedShape> getCrossConnectPortSpeedShapes(
+            final VirtualNetwork virtualNetwork, final String compartmentId) {
+        final ListCrossconnectPortSpeedShapesResponse listCrossconnectPortSpeedShapesResponse =
+                virtualNetwork.listCrossconnectPortSpeedShapes(
+                        ListCrossconnectPortSpeedShapesRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+
+        return listCrossconnectPortSpeedShapesResponse.getItems();
+    }
+
+    private static CrossConnect createCrossConnect(
+            final VirtualNetwork virtualNetwork,
+            final String compartmentId,
+            final String ccgId,
+            final String locationName,
+            final String portSpeedShapeName)
+            throws Exception {
+        final CreateCrossConnectRequest request =
+                CreateCrossConnectRequest.builder()
+                        .createCrossConnectDetails(
+                                CreateCrossConnectDetails.builder()
+                                        .compartmentId(COMPARTMENT_ID)
+                                        .displayName(String.format("CC-%s", TIMESTAMP_SUFFIX))
+                                        .crossConnectGroupId(ccgId)
+                                        .locationName(locationName)
+                                        .portSpeedShapeName(portSpeedShapeName)
+                                        .build())
+                        .build();
+
+        final CreateCrossConnectResponse response = virtualNetwork.createCrossConnect(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder()
+                                .crossConnectId(response.getCrossConnect().getId())
+                                .build(),
+                        CrossConnect.LifecycleState.PendingCustomer)
+                .execute();
+        return response.getCrossConnect();
+    }
+
+    private static CrossConnect getCrossConnect(
+            final VirtualNetwork virtualNetwork, final String ccId) throws Exception {
+
+        final GetCrossConnectRequest request =
+                GetCrossConnectRequest.builder().crossConnectId(ccId).build();
+        final GetCrossConnectResponse response = virtualNetwork.getCrossConnect(request);
+
+        return response.getCrossConnect();
+    }
+
+    /*
+     * Use UPDATE to update display name and activate the physical connection
+     */
+    private static CrossConnect updateCrossConnect(
+            final VirtualNetwork virtualNetwork, final String ccId, final boolean isActive)
+            throws Exception {
+        final UpdateCrossConnectRequest request =
+                UpdateCrossConnectRequest.builder()
+                        .crossConnectId(ccId)
+                        .updateCrossConnectDetails(
+                                UpdateCrossConnectDetails.builder()
+                                        .displayName(String.format("CC-%s", TIMESTAMP_SUFFIX))
+                                        .isActive(isActive)
+                                        .build())
+                        .build();
+
+        final UpdateCrossConnectResponse response = virtualNetwork.updateCrossConnect(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder()
+                                .crossConnectId(response.getCrossConnect().getId())
+                                .build(),
+                        CrossConnect.LifecycleState.Provisioned)
+                .execute();
+
+        if (StringUtils.isNoneBlank(response.getCrossConnect().getCrossConnectGroupId())) {
+            virtualNetwork
+                    .getWaiters()
+                    .forCrossConnectGroup(
+                            GetCrossConnectGroupRequest.builder()
+                                    .crossConnectGroupId(
+                                            response.getCrossConnect().getCrossConnectGroupId())
+                                    .build(),
+                            CrossConnectGroup.LifecycleState.Provisioned)
+                    .execute();
+        }
+        return response.getCrossConnect();
+    }
+
+    private static void deleteCrossConnect(VirtualNetwork virtualNetwork, final String ccId)
+            throws Exception {
+
+        // if cc is in provisioning, wait until provisioned
+        CrossConnect cc = getCrossConnect(virtualNetwork, ccId);
+        if (cc.getLifecycleState() == CrossConnect.LifecycleState.Provisioning) {
+            throw new Exception(
+                    "Failed to start deleting CrossConnect due to CrossConnect in invalid state.");
+        }
+
+        virtualNetwork.deleteCrossConnect(
+                DeleteCrossConnectRequest.builder().crossConnectId(ccId).build());
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder().crossConnectId(ccId).build(),
+                        CrossConnect.LifecycleState.Terminated)
+                .execute();
+        System.out.println("Deleted CrossConnect: " + cc.getId());
+    }
+}

--- a/bmc-examples/src/main/java/FastConnectCrossConnectGroupExample.java
+++ b/bmc-examples/src/main/java/FastConnectCrossConnectGroupExample.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.core.VirtualNetwork;
+import com.oracle.bmc.core.VirtualNetworkClient;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import com.oracle.bmc.identity.IdentityClient;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sample to demonstrate setting up FastConnect CrossConnectGroup
+ * <p>
+ *
+ *
+ *  Oracle Cloud Infrastructure FastConnect provides an easy way to create a dedicated,
+ *  private connection between your data center and Oracle Cloud Infrastructure.
+ *
+ *  FastConnect provides higher-bandwidth options, and a more reliable and consistent
+ *  networking experience compared to internet-based connections.
+ *
+ *  Details information on FastConnect: https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm
+ *
+ *  Details CrossConnectGroup API: https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/CrossConnectGroup
+ */
+public class FastConnectCrossConnectGroupExample {
+    // Set this with your own compartment ID
+    private static final String COMPARTMENT_ID = "";
+
+    private static final String TIMESTAMP_SUFFIX =
+            String.valueOf(System.currentTimeMillis() % TimeUnit.SECONDS.toMillis(10L));
+
+    private final VirtualNetworkClient virtualNetworkClient;
+    private final Region region;
+
+    public FastConnectCrossConnectGroupExample(
+            VirtualNetworkClient virtualNetworkClient, Region region) {
+        this.virtualNetworkClient = virtualNetworkClient;
+        this.region = region;
+    }
+
+    public static void main(final String... args) throws Exception {
+        if ("".equals(COMPARTMENT_ID)) {
+            throw new IllegalStateException("A compartment ID must be defined");
+        }
+
+        final AuthenticationDetailsProvider authProvider =
+                new ConfigFileAuthenticationDetailsProvider("~/.oci/config", "DEFAULT");
+
+        final VirtualNetworkClient phxVirtualNetworkClient = new VirtualNetworkClient(authProvider);
+        phxVirtualNetworkClient.setRegion(Region.US_PHOENIX_1);
+        final FastConnectCrossConnectGroupExample example =
+                new FastConnectCrossConnectGroupExample(
+                        phxVirtualNetworkClient, Region.US_PHOENIX_1);
+        final IdentityClient identityClient = new IdentityClient(authProvider);
+
+        example.run(identityClient);
+    }
+
+    public void run(IdentityClient identityClient) throws Exception {
+
+        System.out.println("Create CrossConnectGroup example, LAG physical connection.");
+
+        System.out.println("Get list of CrossConnect locations POP.");
+        List<CrossConnectLocation> listCrossConnectLocations =
+                getCrossConnectLocations(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Get list of CrossConnect port speeds.");
+        List<CrossConnectPortSpeedShape> listCrossConnectPortSpeedShape =
+                getCrossConnectPortSpeedShapes(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Create CrossConnectGroup.");
+        CrossConnectGroup ccg = createCrossConnectGroup(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Update CrossConnectGroup.");
+        ccg = updateCrossConnectGroup(virtualNetworkClient, ccg.getId());
+
+        System.out.println("Add a (physical connection) CrossConnect to CrossConnectGroup.");
+        CrossConnect cc =
+                createCrossConnect(
+                        virtualNetworkClient,
+                        COMPARTMENT_ID,
+                        ccg.getId(),
+                        listCrossConnectLocations.get(0).getName(),
+                        listCrossConnectPortSpeedShape.get(0).getName());
+
+        System.out.println(
+                "Activate the CrossConnect. This also activate CrossConnectGroup as well.");
+        cc = updateCrossConnect(virtualNetworkClient, cc.getId(), true);
+
+        System.out.println("Remove physical connection from LAG.");
+        deleteCrossConnect(virtualNetworkClient, ccg.getId(), cc.getId());
+
+        System.out.println("Delete CrossConnect group.");
+        deleteCrossConnectGroup(virtualNetworkClient, ccg.getId());
+    }
+
+    private static List<CrossConnectLocation> getCrossConnectLocations(
+            final VirtualNetwork virtualNetwork, final String compartmentId) {
+        ListCrossConnectLocationsResponse listCrossConnectLocationsResponse =
+                virtualNetwork.listCrossConnectLocations(
+                        ListCrossConnectLocationsRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+
+        return listCrossConnectLocationsResponse.getItems();
+    }
+
+    private static List<CrossConnectPortSpeedShape> getCrossConnectPortSpeedShapes(
+            final VirtualNetwork virtualNetwork, final String compartmentId) {
+        final ListCrossconnectPortSpeedShapesResponse listCrossconnectPortSpeedShapesResponse =
+                virtualNetwork.listCrossconnectPortSpeedShapes(
+                        ListCrossconnectPortSpeedShapesRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+
+        return listCrossconnectPortSpeedShapesResponse.getItems();
+    }
+
+    private static CrossConnectGroup createCrossConnectGroup(
+            final VirtualNetwork virtualNetwork, final String compartmentId) throws Exception {
+        final CreateCrossConnectGroupRequest request =
+                CreateCrossConnectGroupRequest.builder()
+                        .createCrossConnectGroupDetails(
+                                CreateCrossConnectGroupDetails.builder()
+                                        .compartmentId(COMPARTMENT_ID)
+                                        .displayName(String.format("CCG-%s", TIMESTAMP_SUFFIX))
+                                        .build())
+                        .build();
+
+        final CreateCrossConnectGroupResponse response =
+                virtualNetwork.createCrossConnectGroup(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnectGroup(
+                        GetCrossConnectGroupRequest.builder()
+                                .crossConnectGroupId(response.getCrossConnectGroup().getId())
+                                .build(),
+                        CrossConnectGroup.LifecycleState.Inactive)
+                .execute();
+        return response.getCrossConnectGroup();
+    }
+
+    private static CrossConnectGroup getCrossConnectGroup(
+            final VirtualNetwork virtualNetwork, final String ccgId) throws Exception {
+
+        final GetCrossConnectGroupRequest request =
+                GetCrossConnectGroupRequest.builder().crossConnectGroupId(ccgId).build();
+        final GetCrossConnectGroupResponse response = virtualNetwork.getCrossConnectGroup(request);
+
+        return response.getCrossConnectGroup();
+    }
+
+    private static CrossConnectGroup updateCrossConnectGroup(
+            final VirtualNetwork virtualNetwork, final String ccgId) throws Exception {
+        final UpdateCrossConnectGroupRequest request =
+                UpdateCrossConnectGroupRequest.builder()
+                        .crossConnectGroupId(ccgId)
+                        .updateCrossConnectGroupDetails(
+                                UpdateCrossConnectGroupDetails.builder()
+                                        .displayName(String.format("CCG-%s", TIMESTAMP_SUFFIX))
+                                        .build())
+                        .build();
+
+        final UpdateCrossConnectGroupResponse response =
+                virtualNetwork.updateCrossConnectGroup(request);
+
+        return response.getCrossConnectGroup();
+    }
+
+    private static void deleteCrossConnectGroup(VirtualNetwork virtualNetwork, final String ccgId)
+            throws Exception {
+
+        // if ccg is in provisioning, wait until provisioned
+        CrossConnectGroup ccg = getCrossConnectGroup(virtualNetwork, ccgId);
+
+        if (ccg.getLifecycleState() != CrossConnectGroup.LifecycleState.Inactive) {
+            throw new Exception(
+                    "Failed to start deleting CrossConnectGroup due to CrossConnectGroup in invalid state.");
+        }
+
+        virtualNetwork.deleteCrossConnectGroup(
+                DeleteCrossConnectGroupRequest.builder().crossConnectGroupId(ccgId).build());
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder().crossConnectId(ccgId).build(),
+                        CrossConnect.LifecycleState.Terminated)
+                .execute();
+        System.out.println("Deleted CrossConnectGroup: " + ccg.getId());
+    }
+
+    private static CrossConnect createCrossConnect(
+            final VirtualNetwork virtualNetwork,
+            final String compartmentId,
+            final String ccgId,
+            final String locationName,
+            final String portSpeedShapeName)
+            throws Exception {
+        final CreateCrossConnectRequest request =
+                CreateCrossConnectRequest.builder()
+                        .createCrossConnectDetails(
+                                CreateCrossConnectDetails.builder()
+                                        .compartmentId(COMPARTMENT_ID)
+                                        .displayName(String.format("CC-%s", TIMESTAMP_SUFFIX))
+                                        .crossConnectGroupId(ccgId)
+                                        .locationName(locationName)
+                                        .portSpeedShapeName(portSpeedShapeName)
+                                        .build())
+                        .build();
+
+        final CreateCrossConnectResponse response = virtualNetwork.createCrossConnect(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder()
+                                .crossConnectId(response.getCrossConnect().getId())
+                                .build(),
+                        CrossConnect.LifecycleState.PendingCustomer)
+                .execute();
+        return response.getCrossConnect();
+    }
+
+    private static CrossConnect getCrossConnect(
+            final VirtualNetwork virtualNetwork, final String ccId) throws Exception {
+
+        final GetCrossConnectRequest request =
+                GetCrossConnectRequest.builder().crossConnectId(ccId).build();
+        final GetCrossConnectResponse response = virtualNetwork.getCrossConnect(request);
+
+        return response.getCrossConnect();
+    }
+
+    /*
+     * Use UPDATE to update display name and activate the physical connection
+     */
+    private static CrossConnect updateCrossConnect(
+            final VirtualNetwork virtualNetwork, final String ccId, final boolean isActive)
+            throws Exception {
+        final UpdateCrossConnectRequest request =
+                UpdateCrossConnectRequest.builder()
+                        .crossConnectId(ccId)
+                        .updateCrossConnectDetails(
+                                UpdateCrossConnectDetails.builder()
+                                        .displayName(String.format("CC-%s", TIMESTAMP_SUFFIX))
+                                        .isActive(isActive)
+                                        .build())
+                        .build();
+
+        final UpdateCrossConnectResponse response = virtualNetwork.updateCrossConnect(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder()
+                                .crossConnectId(response.getCrossConnect().getId())
+                                .build(),
+                        CrossConnect.LifecycleState.Provisioned)
+                .execute();
+
+        if (StringUtils.isNoneBlank(response.getCrossConnect().getCrossConnectGroupId())) {
+            virtualNetwork
+                    .getWaiters()
+                    .forCrossConnectGroup(
+                            GetCrossConnectGroupRequest.builder()
+                                    .crossConnectGroupId(
+                                            response.getCrossConnect().getCrossConnectGroupId())
+                                    .build(),
+                            CrossConnectGroup.LifecycleState.Provisioned)
+                    .execute();
+        }
+        return response.getCrossConnect();
+    }
+
+    private static void deleteCrossConnect(
+            VirtualNetwork virtualNetwork, final String ccgId, final String ccId) throws Exception {
+
+        // if ccg is in provisioning, wait until provisioned
+        CrossConnectGroup ccg = getCrossConnectGroup(virtualNetwork, ccgId);
+        if (ccg.getLifecycleState() == CrossConnectGroup.LifecycleState.Provisioning) {
+            throw new Exception(
+                    "Failed to start deleting CrossConnect of CrossConnectGroup due to CrossConnectGroup in invalid state.");
+        }
+        virtualNetwork.deleteCrossConnect(
+                DeleteCrossConnectRequest.builder().crossConnectId(ccId).build());
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder().crossConnectId(ccId).build(),
+                        CrossConnect.LifecycleState.Terminated)
+                .execute();
+        System.out.println("Deleted CrossConnect: " + ccId);
+    }
+}

--- a/bmc-examples/src/main/java/FastConnectVirtualCircuitExample.java
+++ b/bmc-examples/src/main/java/FastConnectVirtualCircuitExample.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.core.VirtualNetwork;
+import com.oracle.bmc.core.VirtualNetworkClient;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import com.oracle.bmc.identity.IdentityClient;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sample to demonstrate setting up FastConnect Virtual Circuit
+ * <p>
+ *
+ *
+ *  Oracle Cloud Infrastructure FastConnect provides an easy way to create a dedicated,
+ *  private connection between your data center and Oracle Cloud Infrastructure.
+ *
+ *  FastConnect provides higher-bandwidth options, and a more reliable and consistent
+ *  networking experience compared to internet-based connections.
+ *
+ *  Details information on FastConnect: https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm
+ *
+ *  Details virtual circuit API: https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/VirtualCircuit
+ */
+public class FastConnectVirtualCircuitExample {
+    // Set this with your own compartment ID
+    private static final String COMPARTMENT_ID = "";
+
+    private static final String CUSTOMER_BGP_IP = "10.0.0.3/31";
+    private static final String UPDATE_CUSTOMER_BGP_IP = "10.0.1.3/31";
+
+    private static final int CUSTOMER_ASN = 1234;
+    private static final int UPDATE_CUSTOMER_ASN = 1001;
+
+    private static final String TIMESTAMP_SUFFIX =
+            String.valueOf(System.currentTimeMillis() % TimeUnit.SECONDS.toMillis(10L));
+
+    private final VirtualNetworkClient virtualNetworkClient;
+    private final Region region;
+
+    public FastConnectVirtualCircuitExample(
+            VirtualNetworkClient virtualNetworkClient, Region region) {
+        this.virtualNetworkClient = virtualNetworkClient;
+        this.region = region;
+    }
+
+    public static void main(final String... args) throws Exception {
+        if ("".equals(COMPARTMENT_ID)) {
+            throw new IllegalStateException("A compartment ID must be defined");
+        }
+
+        final AuthenticationDetailsProvider authProvider =
+                new ConfigFileAuthenticationDetailsProvider("~/.oci/config", "DEFAULT");
+
+        final VirtualNetworkClient phxVirtualNetworkClient = new VirtualNetworkClient(authProvider);
+        phxVirtualNetworkClient.setRegion(Region.US_PHOENIX_1);
+        final FastConnectVirtualCircuitExample example =
+                new FastConnectVirtualCircuitExample(phxVirtualNetworkClient, Region.US_PHOENIX_1);
+        final IdentityClient identityClient = new IdentityClient(authProvider);
+
+        example.run(identityClient);
+    }
+
+    public void run(IdentityClient identityClient) throws Exception {
+
+        System.out.println("Create Virtual Circuit via provider.");
+
+        System.out.println("Get provider service list.");
+        List<FastConnectProviderService> fastConnectProviderServiceList =
+                getFastConnectProviderServices(virtualNetworkClient, COMPARTMENT_ID);
+
+        System.out.println("Setting up DRG.");
+
+        System.out.println("Creating DRG.");
+        Drg drg = createDrg(virtualNetworkClient, region);
+
+        FastConnectProviderService layer2ProviderService = null;
+        for (FastConnectProviderService item : fastConnectProviderServiceList) {
+            if (item.getType() == FastConnectProviderService.Type.Layer2) {
+                layer2ProviderService = item;
+                break;
+            }
+        }
+        List<VirtualCircuitBandwidthShape> vcBandwidthShapes =
+                getFastConnectProviderVirtualCircuitBandwidthShapes(
+                        virtualNetworkClient, layer2ProviderService.getId());
+
+        VirtualCircuit vc =
+                createVirtualCircuitViaLayer2Provider(
+                        virtualNetworkClient,
+                        COMPARTMENT_ID,
+                        layer2ProviderService.getId(),
+                        vcBandwidthShapes.get(0).getName(),
+                        CUSTOMER_BGP_IP,
+                        CUSTOMER_ASN,
+                        drg.getId(),
+                        CreateVirtualCircuitDetails.Type.Private);
+
+        vc =
+                updateVirtualCircuitViaLayer2Provider(
+                        virtualNetworkClient,
+                        vc.getId(),
+                        vcBandwidthShapes.get(1).getName(),
+                        UPDATE_CUSTOMER_BGP_IP,
+                        UPDATE_CUSTOMER_ASN);
+
+        System.out.println("Deleting virtual circuit.");
+        deleteVirtualCircuit(virtualNetworkClient, vc.getId());
+
+        System.out.println("Deleting the DRG.");
+        deleteDrg(virtualNetworkClient, drg);
+    }
+
+    private static Drg createDrg(final VirtualNetwork virtualNetwork, final Region region)
+            throws Exception {
+        final CreateDrgRequest request =
+                CreateDrgRequest.builder()
+                        .createDrgDetails(
+                                CreateDrgDetails.builder()
+                                        .compartmentId(COMPARTMENT_ID)
+                                        .displayName(
+                                                String.format(
+                                                        "Drg-%s-%s",
+                                                        region.getRegionId(),
+                                                        TIMESTAMP_SUFFIX))
+                                        .build())
+                        .build();
+
+        final CreateDrgResponse response = virtualNetwork.createDrg(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forDrg(
+                        GetDrgRequest.builder().drgId(response.getDrg().getId()).build(),
+                        Drg.LifecycleState.Available)
+                .execute();
+        return response.getDrg();
+    }
+
+    private static void deleteDrg(final VirtualNetwork virtualNetwork, final Drg drg)
+            throws Exception {
+        final DeleteDrgRequest request = DeleteDrgRequest.builder().drgId(drg.getId()).build();
+        virtualNetwork.deleteDrg(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forDrg(
+                        GetDrgRequest.builder().drgId(drg.getId()).build(),
+                        Drg.LifecycleState.Terminated)
+                .execute();
+        System.out.println("Deleted DRG: " + drg.getId());
+    }
+
+    private static List<FastConnectProviderService> getFastConnectProviderServices(
+            final VirtualNetwork virtualNetwork, final String compartmentId) {
+        ListFastConnectProviderServicesResponse listFastConnectProviderServicesResponse =
+                virtualNetwork.listFastConnectProviderServices(
+                        ListFastConnectProviderServicesRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+
+        return listFastConnectProviderServicesResponse.getItems();
+    }
+
+    private static List<VirtualCircuitBandwidthShape>
+            getFastConnectProviderVirtualCircuitBandwidthShapes(
+                    final VirtualNetwork virtualNetwork, final String providerServiceId) {
+        ListFastConnectProviderVirtualCircuitBandwidthShapesResponse
+                listFastConnectProviderVirtualCircuitBandwidthShapesResponse =
+                        virtualNetwork.listFastConnectProviderVirtualCircuitBandwidthShapes(
+                                ListFastConnectProviderVirtualCircuitBandwidthShapesRequest
+                                        .builder()
+                                        .providerServiceId(providerServiceId)
+                                        .build());
+
+        return listFastConnectProviderVirtualCircuitBandwidthShapesResponse.getItems();
+    }
+
+    private static VirtualCircuit createVirtualCircuitViaLayer2Provider(
+            final VirtualNetwork virtualNetwork,
+            final String compartmentId,
+            final String providerServiceId,
+            final String bandwidthShapeName,
+            final String customerBgpIp,
+            final int customerBgpAsn,
+            final String gatewayId,
+            final CreateVirtualCircuitDetails.Type type)
+            throws Exception {
+        final CreateVirtualCircuitRequest request =
+                CreateVirtualCircuitRequest.builder()
+                        .createVirtualCircuitDetails(
+                                CreateVirtualCircuitDetails.builder()
+                                        .compartmentId(COMPARTMENT_ID)
+                                        .displayName(String.format("VC-%s", TIMESTAMP_SUFFIX))
+                                        .crossConnectMappings(
+                                                Arrays.asList(
+                                                        CrossConnectMapping.builder()
+                                                                .customerBgpPeeringIp(customerBgpIp)
+                                                                .build()))
+                                        .providerServiceId(providerServiceId)
+                                        .bandwidthShapeName(bandwidthShapeName)
+                                        .customerBgpAsn(customerBgpAsn)
+                                        .gatewayId(gatewayId)
+                                        .type(type)
+                                        .build())
+                        .build();
+
+        final CreateVirtualCircuitResponse response = virtualNetwork.createVirtualCircuit(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forVirtualCircuit(
+                        GetVirtualCircuitRequest.builder()
+                                .virtualCircuitId(response.getVirtualCircuit().getId())
+                                .build(),
+                        VirtualCircuit.LifecycleState.PendingProvider)
+                .execute();
+        return response.getVirtualCircuit();
+    }
+
+    private static VirtualCircuit updateVirtualCircuitViaLayer2Provider(
+            final VirtualNetwork virtualNetwork,
+            final String vcId,
+            final String bandwidthShapeName,
+            final String customerBgpIp,
+            final int customerBgpAsn)
+            throws Exception {
+        final UpdateVirtualCircuitRequest request =
+                UpdateVirtualCircuitRequest.builder()
+                        .virtualCircuitId(vcId)
+                        .updateVirtualCircuitDetails(
+                                UpdateVirtualCircuitDetails.builder()
+                                        .displayName(String.format("VC-%s", TIMESTAMP_SUFFIX))
+                                        .crossConnectMappings(
+                                                Arrays.asList(
+                                                        CrossConnectMapping.builder()
+                                                                .customerBgpPeeringIp(customerBgpIp)
+                                                                .build()))
+                                        .bandwidthShapeName(bandwidthShapeName)
+                                        .customerBgpAsn(customerBgpAsn)
+                                        .build())
+                        .build();
+
+        final UpdateVirtualCircuitResponse response = virtualNetwork.updateVirtualCircuit(request);
+
+        return response.getVirtualCircuit();
+    }
+
+    private static void deleteVirtualCircuit(final VirtualNetwork virtualNetwork, final String vcId)
+            throws Exception {
+        final DeleteVirtualCircuitRequest request =
+                DeleteVirtualCircuitRequest.builder().virtualCircuitId(vcId).build();
+        virtualNetwork.deleteVirtualCircuit(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forVirtualCircuit(
+                        GetVirtualCircuitRequest.builder().virtualCircuitId(vcId).build(),
+                        VirtualCircuit.LifecycleState.Terminated)
+                .execute();
+        System.out.println("Deleted virtual circuit: " + vcId);
+    }
+}

--- a/bmc-examples/src/main/java/MonitoringMetricPostExample.java
+++ b/bmc-examples/src/main/java/MonitoringMetricPostExample.java
@@ -102,7 +102,7 @@ public class MonitoringMetricPostExample {
                                                                         makeMap(
                                                                                 "region",
                                                                                 Region.US_PHOENIX_1
-                                                                                        .name(),
+                                                                                        .getRegionId(),
                                                                                 "host",
                                                                                 "some-host"))
                                                                 .build()))

--- a/bmc-examples/src/main/java/NewRegionAndRealmSupportWithoutSDKUpdate.java
+++ b/bmc-examples/src/main/java/NewRegionAndRealmSupportWithoutSDKUpdate.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.Realm;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.identity.Identity;
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.requests.ListRegionsRequest;
+import com.oracle.bmc.identity.responses.ListRegionsResponse;
+
+import java.io.IOException;
+
+/**
+ * This sample demonstrates how to use the SDK with new regions (and realms) without upgrading the SDK.
+ *
+ * When using either the {@link ConfigFileAuthenticationDetailsProvider} or the {@link
+ * com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider}, register the new region (and realm)
+ * before instantiating the provider.
+ * If you call the {@code setRegion} method to target the new region, pass in the region object returned from prior
+ * {@link Region#register(String, Realm)} method invocation.
+ */
+public class NewRegionAndRealmSupportWithoutSDKUpdate {
+    public static void main(String args[]) throws IOException {
+        // Assume a new region us-foo-1 is launched in OC2 realm
+        // Register the new region
+        final Region fooRegion = Region.register("us-foo-1", Realm.OC2);
+
+        // Create the client
+        Identity identityClient = createIdentityClient();
+
+        // If the config file contains a value for region, then it will be picked up automatically by the SDK,
+        // else set it up manually by calling setRegion
+        System.out.println("Setting region to " + fooRegion.getRegionId());
+        identityClient.setRegion(fooRegion);
+
+        // Use the client to make calls to the endpoint for the new region
+        listRegions(identityClient);
+
+        // Now, assume a new region us-bar-1 is launched in OCX realm
+        // (having secondLevelDomain oracle-baz-cloud.com)
+        // Register the new region and realm
+        final Region barRegion =
+                Region.register("us-bar-1", Realm.register("ocx", "oracle-baz-cloud.com"));
+
+        // Call setRegion to use the endpoint in the new region
+        System.out.println("Setting region to " + barRegion.getRegionId());
+        identityClient.setRegion(barRegion);
+
+        // The client now makes calls to the endpoint for the new region
+        listRegions(identityClient);
+
+        // If you use InstancePrincipals, register the new region (and realm) before initializing the
+        // InstancePrincipalsAuthenticationDetailsProvider.
+    }
+
+    private static Identity createIdentityClient() throws IOException {
+        final String configurationFilePath = "~/.oci/config";
+        final String configurationProfile = "DEFAULT";
+
+        final AuthenticationDetailsProvider authenticationDetailsProvider =
+                new ConfigFileAuthenticationDetailsProvider(
+                        configurationFilePath, configurationProfile);
+
+        return IdentityClient.builder().build(authenticationDetailsProvider);
+    }
+
+    private static void listRegions(final Identity identityClient) {
+        System.out.println("Querying for list of regions");
+        final ListRegionsResponse response =
+                identityClient.listRegions(ListRegionsRequest.builder().build());
+        System.out.println("List of regions: " + response.getItems());
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.4.4</version>
+        <version>1.5.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCrypto.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCrypto.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsCrypto extends AutoCloseable {
 
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoAsync.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsCryptoAsync extends AutoCloseable {
 
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoAsyncClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsCryptoAsyncClient implements KmsCryptoAsync {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsCryptoClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.internal.http.*;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsCryptoClient implements KmsCrypto {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagement.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagement.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsManagement extends AutoCloseable {
 
     /**
@@ -24,7 +24,7 @@ public interface KmsManagement extends AutoCloseable {
     CreateKeyResponse createKey(CreateKeyRequest request);
 
     /**
-     * Generates new cryptographic material for a key. Key must be in an `ENABLED` state to be
+     * Generates new cryptographic material for a key. The key must be in an `ENABLED` state to be
      * rotated.
      *
      * @param request The request object containing the details to send
@@ -91,8 +91,8 @@ public interface KmsManagement extends AutoCloseable {
 
     /**
      * Updates the properties of a key. Specifically, you can update the
-     * `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-     * the key must in an `ACTIVE` or `CREATING` state.
+     * `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+     * the key must in an `ACTIVE` or `CREATING` state to be updated.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementAsync.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsManagementAsync extends AutoCloseable {
 
     /**
@@ -30,7 +30,7 @@ public interface KmsManagementAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<CreateKeyRequest, CreateKeyResponse> handler);
 
     /**
-     * Generates new cryptographic material for a key. Key must be in an `ENABLED` state to be
+     * Generates new cryptographic material for a key. The key must be in an `ENABLED` state to be
      * rotated.
      *
      *
@@ -142,8 +142,8 @@ public interface KmsManagementAsync extends AutoCloseable {
 
     /**
      * Updates the properties of a key. Specifically, you can update the
-     * `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-     * the key must in an `ACTIVE` or `CREATING` state.
+     * `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+     * the key must in an `ACTIVE` or `CREATING` state to be updated.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementAsyncClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsManagementAsyncClient implements KmsManagementAsync {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.internal.http.*;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsManagementClient implements KmsManagement {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementPaginators.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementPaginators.java
@@ -24,7 +24,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.RequiredArgsConstructor
 public class KmsManagementPaginators {
     private final KmsManagement client;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementWaiters.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsManagementWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * <p>
  * The default configuration used is defined by {@link Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.RequiredArgsConstructor
 public class KmsManagementWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVault.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVault.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsVault extends AutoCloseable {
 
     /**
@@ -37,8 +37,8 @@ public interface KmsVault extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Cancels the scheduled deletion of the specified Vault, which must be in PendingDeletion
-     * state. The Vault and all Keys in it will be moved back to their previous states before
+     * Cancels the scheduled deletion of the specified vault. Canceling a scheduled deletion
+     * restores the vault and all keys in it to the respective states they were in before
      * the deletion was scheduled.
      *
      * @param request The request object containing the details to send
@@ -51,7 +51,7 @@ public interface KmsVault extends AutoCloseable {
      * Creates a new vault. The type of vault you create determines key
      * placement, pricing, and available options. Options include storage
      * isolation, a dedicated service endpoint instead of a shared service
-     * endpoint for API calls, and a dedicated HSM or a multitenant HSM.
+     * endpoint for API calls, and a dedicated hardware security module (HSM) or a multitenant HSM.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -69,7 +69,7 @@ public interface KmsVault extends AutoCloseable {
     GetVaultResponse getVault(GetVaultRequest request);
 
     /**
-     * Lists vaults in the specified compartment.
+     * Lists the vaults in the specified compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -78,8 +78,8 @@ public interface KmsVault extends AutoCloseable {
     ListVaultsResponse listVaults(ListVaultsRequest request);
 
     /**
-     * Schedules the deletion of the specified Vault. The Vault and all Keys in it
-     * will be moved to PendingDeletion state and deleted after the retention period.
+     * Schedules the deletion of the specified vault. This sets the state of the vault and all keys in it
+     * to `PENDING_DELETION` and then deletes them after the retention period ends.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -89,8 +89,8 @@ public interface KmsVault extends AutoCloseable {
 
     /**
      * Updates the properties of a vault. Specifically, you can update the
-     * `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-     * the vault must be in an `ACTIVE` or `CREATING` state.
+     * `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+     * the vault must be in an `ACTIVE` or `CREATING` state to be updated.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultAsync.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.keymanagement;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 public interface KmsVaultAsync extends AutoCloseable {
 
     /**
@@ -37,8 +37,8 @@ public interface KmsVaultAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Cancels the scheduled deletion of the specified Vault, which must be in PendingDeletion
-     * state. The Vault and all Keys in it will be moved back to their previous states before
+     * Cancels the scheduled deletion of the specified vault. Canceling a scheduled deletion
+     * restores the vault and all keys in it to the respective states they were in before
      * the deletion was scheduled.
      *
      *
@@ -59,7 +59,7 @@ public interface KmsVaultAsync extends AutoCloseable {
      * Creates a new vault. The type of vault you create determines key
      * placement, pricing, and available options. Options include storage
      * isolation, a dedicated service endpoint instead of a shared service
-     * endpoint for API calls, and a dedicated HSM or a multitenant HSM.
+     * endpoint for API calls, and a dedicated hardware security module (HSM) or a multitenant HSM.
      *
      *
      * @param request The request object containing the details to send
@@ -89,7 +89,7 @@ public interface KmsVaultAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetVaultRequest, GetVaultResponse> handler);
 
     /**
-     * Lists vaults in the specified compartment.
+     * Lists the vaults in the specified compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -104,8 +104,8 @@ public interface KmsVaultAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListVaultsRequest, ListVaultsResponse> handler);
 
     /**
-     * Schedules the deletion of the specified Vault. The Vault and all Keys in it
-     * will be moved to PendingDeletion state and deleted after the retention period.
+     * Schedules the deletion of the specified vault. This sets the state of the vault and all keys in it
+     * to `PENDING_DELETION` and then deletes them after the retention period ends.
      *
      *
      * @param request The request object containing the details to send
@@ -123,8 +123,8 @@ public interface KmsVaultAsync extends AutoCloseable {
 
     /**
      * Updates the properties of a vault. Specifically, you can update the
-     * `displayName` , `freeformTags`, and `definedTags` properties. Furthermore,
-     * the vault must be in an `ACTIVE` or `CREATING` state.
+     * `displayName`, `freeformTags`, and `definedTags` properties. Furthermore,
+     * the vault must be in an `ACTIVE` or `CREATING` state to be updated.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultAsyncClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsVaultAsyncClient implements KmsVaultAsync {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultClient.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.internal.http.*;
 import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class KmsVaultClient implements KmsVault {
     /**

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultPaginators.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultPaginators.java
@@ -24,7 +24,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.RequiredArgsConstructor
 public class KmsVaultPaginators {
     private final KmsVault client;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultWaiters.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/KmsVaultWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.keymanagement.responses.*;
  * <p>
  * The default configuration used is defined by {@link Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.RequiredArgsConstructor
 public class KmsVaultWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CancelVaultDeletionConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CancelVaultDeletionConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class CancelVaultDeletionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class CancelVaultDeletionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("vaults")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class CreateKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class CreateKeyConverter {
         Validate.notNull(request.getCreateKeyDetails(), "createKeyDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("keys");
+                client.getBaseTarget().path("/").path("20180608").path("keys");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateKeyVersionConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateKeyVersionConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class CreateKeyVersionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class CreateKeyVersionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateVaultConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/CreateVaultConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class CreateVaultConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class CreateVaultConverter {
         Validate.notNull(request.getCreateVaultDetails(), "createVaultDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("vaults");
+                client.getBaseTarget().path("/").path("20180608").path("vaults");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/DecryptConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/DecryptConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class DecryptConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class DecryptConverter {
         Validate.notNull(request.getDecryptDataDetails(), "decryptDataDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("decrypt");
+                client.getBaseTarget().path("/").path("20180608").path("decrypt");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/DisableKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/DisableKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class DisableKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class DisableKeyConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/EnableKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/EnableKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class EnableKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class EnableKeyConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/EncryptConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/EncryptConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class EncryptConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class EncryptConverter {
         Validate.notNull(request.getEncryptDataDetails(), "encryptDataDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("encrypt");
+                client.getBaseTarget().path("/").path("20180608").path("encrypt");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GenerateDataEncryptionKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GenerateDataEncryptionKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class GenerateDataEncryptionKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -28,7 +28,7 @@ public class GenerateDataEncryptionKeyConverter {
         Validate.notNull(request.getGenerateKeyDetails(), "generateKeyDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("generateDataEncryptionKey");
+                client.getBaseTarget().path("/").path("20180608").path("generateDataEncryptionKey");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class GetKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class GetKeyConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetKeyVersionConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetKeyVersionConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class GetKeyVersionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -28,7 +28,8 @@ public class GetKeyVersionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetVaultConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/GetVaultConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class GetVaultConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class GetVaultConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("vaults")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListKeyVersionsConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListKeyVersionsConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class ListKeyVersionsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,8 @@ public class ListKeyVersionsConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListKeysConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListKeysConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class ListKeysConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class ListKeysConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("keys");
+                client.getBaseTarget().path("/").path("20180608").path("keys");
 
         target =
                 target.queryParam(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListVaultsConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ListVaultsConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class ListVaultsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class ListVaultsConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20180608").path("vaults");
+                client.getBaseTarget().path("/").path("20180608").path("vaults");
 
         target =
                 target.queryParam(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ScheduleVaultDeletionConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/ScheduleVaultDeletionConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class ScheduleVaultDeletionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,8 @@ public class ScheduleVaultDeletionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("vaults")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/UpdateKeyConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/UpdateKeyConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class UpdateKeyConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -28,7 +28,8 @@ public class UpdateKeyConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("keys")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/UpdateVaultConverter.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/internal/http/UpdateVaultConverter.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.keymanagement.requests.*;
 import com.oracle.bmc.keymanagement.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.extern.slf4j.Slf4j
 public class UpdateVaultConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -28,7 +28,8 @@ public class UpdateVaultConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20180608")
+                        .path("/")
+                        .path("20180608")
                         .path("vaults")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/CreateKeyDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/CreateKeyDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CreateKeyDetails.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/CreateVaultDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/CreateVaultDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/DecryptDataDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/DecryptDataDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/DecryptedData.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/DecryptedData.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DecryptedData.Builder.class)
@@ -67,7 +67,7 @@ public class DecryptedData {
     }
 
     /**
-     * The decrypted data, in the form of a base64-encoded value.
+     * The decrypted data, expressed as a base64-encoded value.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("plaintext")
     String plaintext;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/EncryptDataDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/EncryptDataDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/EncryptedData.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/EncryptedData.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = EncryptedData.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/GenerateKeyDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/GenerateKeyDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/GeneratedKey.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/GeneratedKey.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GeneratedKey.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/Key.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/Key.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Key.Builder.class)
@@ -166,9 +166,9 @@ public class Key {
     String compartmentId;
 
     /**
-     * The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service may be in transitional state
-     * where this or a newer KeyVersion are used intermittently, and currentKeyVersion field is updated once service is guaranteed to
-     * use new KeyVersion for all consequent encrypt operations.
+     * The OCID of the KeyVersion resource used in cryptographic operations. During key rotation, service might be in a transitional state
+     * where this or a newer KeyVersion are used intermittently. The currentKeyVersion field is updated when the service is guaranteed to
+     * use the new KeyVersion for all subsequent encryption operations.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("currentKeyVersion")

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyShape.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyShape.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = KeyShape.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeySummary.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeySummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = KeySummary.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyVersion.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyVersion.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = KeyVersion.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyVersionSummary.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/KeyVersionSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/ScheduleVaultDeletionDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/ScheduleVaultDeletionDetails.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.keymanagement.model;
 
 /**
- * Details for scheduling Vault deletion
+ * Details for scheduling vault deletion
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -60,9 +60,9 @@ public class ScheduleVaultDeletionDetails {
     }
 
     /**
-     * An optional property to indicate the deletion time of the Vault.
-     * The time format should comply with RFC-3339 standards. This time must be between 7 to 30 days from the time
-     * when the request is received. If the property is missing, it will be set to 30 days from request time by default.
+     * An optional property to indicate the deletion time of the vault, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339)
+     * timestamp format. The specified time must be between 7 and 30 days from the time
+     * when the request is received. If this property is missing, it will be set to 30 days from the time of the request by default.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeOfDeletion")

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/UpdateKeyDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/UpdateKeyDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateKeyDetails.Builder.class)

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/UpdateVaultDetails.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/UpdateVaultDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/Vault.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/Vault.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Vault.Builder.class)
@@ -293,7 +293,7 @@ public class Vault {
     java.util.Date timeCreated;
 
     /**
-     * An optional property for the deletion time of the Vault expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+     * An optional property for the deletion time of the vault, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
      * Example: `2018-04-03T21:10:29.600Z`
      *
      **/

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/VaultSummary.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/model/VaultSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.keymanagement.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VaultSummary.Builder.class)
@@ -160,7 +160,7 @@ public class VaultSummary {
     }
 
     /**
-     * The OCID of the compartment that contains this vault.
+     * The OCID of the compartment that contains a particular vault.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CancelVaultDeletionRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CancelVaultDeletionRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CancelVaultDeletionRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateKeyVersionRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateKeyVersionRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateKeyVersionRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateVaultRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/CreateVaultRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateVaultRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/DecryptRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/DecryptRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DecryptRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/DisableKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/DisableKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DisableKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/EnableKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/EnableKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class EnableKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/EncryptRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/EncryptRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class EncryptRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GenerateDataEncryptionKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GenerateDataEncryptionKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GenerateDataEncryptionKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetKeyVersionRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetKeyVersionRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetKeyVersionRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetVaultRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/GetVaultRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetVaultRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListKeyVersionsRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListKeyVersionsRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListKeyVersionsRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListKeysRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListKeysRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListKeysRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListVaultsRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ListVaultsRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListVaultsRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ScheduleVaultDeletionRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/ScheduleVaultDeletionRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ScheduleVaultDeletionRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/UpdateKeyRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/UpdateKeyRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateKeyRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/UpdateVaultRequest.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/requests/UpdateVaultRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.requests;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateVaultRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CancelVaultDeletionResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CancelVaultDeletionResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CancelVaultDeletionResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateKeyVersionResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateKeyVersionResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateKeyVersionResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateVaultResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/CreateVaultResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateVaultResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/DecryptResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/DecryptResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DecryptResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/DisableKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/DisableKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DisableKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/EnableKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/EnableKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class EnableKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/EncryptResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/EncryptResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class EncryptResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GenerateDataEncryptionKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GenerateDataEncryptionKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GenerateDataEncryptionKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetKeyVersionResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetKeyVersionResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetKeyVersionResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetVaultResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/GetVaultResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetVaultResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListKeyVersionsResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListKeyVersionsResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListKeyVersionsResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListKeysResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListKeysResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListKeysResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListVaultsResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ListVaultsResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListVaultsResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ScheduleVaultDeletionResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/ScheduleVaultDeletionResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ScheduleVaultDeletionResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/UpdateKeyResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/UpdateKeyResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateKeyResponse {

--- a/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/UpdateVaultResponse.java
+++ b/bmc-keymanagement/src/main/java/com/oracle/bmc/keymanagement/responses/UpdateVaultResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.keymanagement.responses;
 
 import com.oracle.bmc.keymanagement.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180608")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: release")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateVaultResponse {

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/src/main/java/com/oracle/bmc/monitoring/model/ListMetricsDetails.java
+++ b/bmc-monitoring/src/main/java/com/oracle/bmc/monitoring/model/ListMetricsDetails.java
@@ -5,8 +5,8 @@ package com.oracle.bmc.monitoring.model;
 
 /**
  * The request details for retrieving metric definitions. Specify optional properties to filter the returned results.
- * Use an asterisk (\"\\*\") as a wildcard character, placed anywhere in the string.
- * For example, to search for all metrics with names that begin with \"disk\", specify \"name\" as \"disk\\*\".
+ * Use an asterisk (&#42;) as a wildcard character, placed anywhere in the string.
+ * For example, to search for all metrics with names that begin with \"disk\", specify \"name\" as \"disk&#42;\".
  * If no properties are specified, then all metric definitions within the request scope are returned.
  *
  * <br/>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.4.4</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.4.4</version>
+  <version>1.5.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -23,7 +23,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <jersey.version>2.27</jersey.version>
     <!-- As per https://github.com/google/guava/blob/master/README.md#guava-google-core-libraries-for-java, using
       the Android flavor of guava to support JDK 1.7 -->


### PR DESCRIPTION
### Added

- Support for provider service key names on virtual circuits in the FastConnect service

- Support for customer reference names on cross connects and cross connect groups in the FastConnect service



### Changed

- Use of the SDK with Java 7 is no longer supported 

- `com.oracle.bmc.Region` and `com.oracle.bmc.Realm` enumerations have been converted to classes to allow using the SDK with new unreleased regions and realms. An example of how to do this is available [here](https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/NewRegionAndRealmSupportWithoutSDKUpdate.java)



### Security

- Due to a security vulnerability in a dependency of older versions of the Java SDK, **it is important that you upgrade to this or a later version of the Java SDK**. Jackson-databind version 2.9.6, used by prior versions of the SDK, has known security vulnerabilities. The SDK now uses Jackson-databind version 2.9.8 which fixes these vulnerabilities.


