### PR TITLE
Releasing version 1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.5.6 - 2019-05-21
+### Added
+- Support for returning tags when listing instance configurations, instance pools, or autoscaling configurations in the Compute Autoscaling service
+- Support for getting the namespace of another tenancy than the caller's tenancy in the Object Storage service
+- Support for BGP dynamic routing and providing pre-shared secrets (PSKs) when establishing tunnels in the Networking service
+
 ## 1.5.5 - 2019-05-14
 ### Added
 - Support for the Seoul (ICN) region

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScaling.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScaling.java
@@ -37,7 +37,7 @@ public interface AutoScaling extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Create an AutoScalingConfiguration
+     * Creates an autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -46,7 +46,8 @@ public interface AutoScaling extends AutoCloseable {
             CreateAutoScalingConfigurationRequest request);
 
     /**
-     * Create a Policy for AutoScalingConfiguration
+     * Creates an autoscaling policy for the specified autoscaling configuration.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -54,7 +55,7 @@ public interface AutoScaling extends AutoCloseable {
     CreateAutoScalingPolicyResponse createAutoScalingPolicy(CreateAutoScalingPolicyRequest request);
 
     /**
-     * Deletes an AutoScalingConfiguration
+     * Deletes an autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -63,7 +64,7 @@ public interface AutoScaling extends AutoCloseable {
             DeleteAutoScalingConfigurationRequest request);
 
     /**
-     * Deletes an AutoScalingConfiguration Policy
+     * Deletes an autoscaling policy for the specified autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -71,7 +72,7 @@ public interface AutoScaling extends AutoCloseable {
     DeleteAutoScalingPolicyResponse deleteAutoScalingPolicy(DeleteAutoScalingPolicyRequest request);
 
     /**
-     * Get AutoScalingConfiguration
+     * Gets information about the specified autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -80,7 +81,7 @@ public interface AutoScaling extends AutoCloseable {
             GetAutoScalingConfigurationRequest request);
 
     /**
-     * Get Policy from a specific AutoScalingConfiguration
+     * Gets information about the specified autoscaling policy in the specified autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -88,7 +89,7 @@ public interface AutoScaling extends AutoCloseable {
     GetAutoScalingPolicyResponse getAutoScalingPolicy(GetAutoScalingPolicyRequest request);
 
     /**
-     * Lists AutoScalingConfigurations in the specific compartment.
+     * Lists autoscaling configurations in the specifed compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -98,7 +99,7 @@ public interface AutoScaling extends AutoCloseable {
             ListAutoScalingConfigurationsRequest request);
 
     /**
-     * Lists Policies in an AutoScalingConfiguration.
+     * Lists the autoscaling policies in the specified autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -107,7 +108,9 @@ public interface AutoScaling extends AutoCloseable {
     ListAutoScalingPoliciesResponse listAutoScalingPolicies(ListAutoScalingPoliciesRequest request);
 
     /**
-     * Updates an AutoScalingConfiguration
+     * Updates certain fields on the specified autoscaling configuration, such as the name, the cooldown period,
+     * and whether the autoscaling configuration is enabled.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -116,7 +119,7 @@ public interface AutoScaling extends AutoCloseable {
             UpdateAutoScalingConfigurationRequest request);
 
     /**
-     * Updates a Policy in the specific AutoScalingConfiguration
+     * Updates an autoscaling policy in the specified autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsync.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsync.java
@@ -37,7 +37,7 @@ public interface AutoScalingAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Create an AutoScalingConfiguration
+     * Creates an autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -55,7 +55,8 @@ public interface AutoScalingAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Create a Policy for AutoScalingConfiguration
+     * Creates an autoscaling policy for the specified autoscaling configuration.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -71,7 +72,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes an AutoScalingConfiguration
+     * Deletes an autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -89,7 +90,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Deletes an AutoScalingConfiguration Policy
+     * Deletes an autoscaling policy for the specified autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -105,7 +106,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Get AutoScalingConfiguration
+     * Gets information about the specified autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -121,7 +122,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Get Policy from a specific AutoScalingConfiguration
+     * Gets information about the specified autoscaling policy in the specified autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -137,7 +138,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists AutoScalingConfigurations in the specific compartment.
+     * Lists autoscaling configurations in the specifed compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -156,7 +157,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Lists Policies in an AutoScalingConfiguration.
+     * Lists the autoscaling policies in the specified autoscaling configuration.
      *
      *
      * @param request The request object containing the details to send
@@ -173,7 +174,9 @@ public interface AutoScalingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates an AutoScalingConfiguration
+     * Updates certain fields on the specified autoscaling configuration, such as the name, the cooldown period,
+     * and whether the autoscaling configuration is enabled.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -191,7 +194,7 @@ public interface AutoScalingAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Updates a Policy in the specific AutoScalingConfiguration
+     * Updates an autoscaling policy in the specified autoscaling configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Action.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Action.java
@@ -4,8 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * The action to take if a scale event has been triggered. Positive values indicate scale out
- * and negative value indicate scale in.
+ * The action to take when autoscaling is triggered.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -68,7 +67,7 @@ public class Action {
     }
 
     /**
-     * Action type to take
+     * The type of action to take.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Type {
@@ -112,11 +111,16 @@ public class Action {
         }
     };
     /**
-     * Action type to take
+     * The type of action to take.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     Type type;
 
+    /**
+     * To scale out (increase the number of instances), provide a positive value. To scale in (decrease the number of
+     * instances), provide a negative value.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("value")
     Integer value;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfiguration.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfiguration.java
@@ -4,6 +4,8 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
+ * An autoscaling configuration allows you to dynamically scale the resources in a Compute instance pool.
+ * For more information, see [Autoscaling](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -162,7 +164,7 @@ public class AutoScalingConfiguration {
     }
 
     /**
-     * The OCID of the compartment containing the AutoScalingConfiguration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the autoscaling configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -179,8 +181,7 @@ public class AutoScalingConfiguration {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-     * Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
@@ -197,20 +198,21 @@ public class AutoScalingConfiguration {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The OCID of the AutoScalingConfiguration
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The minimum period of time between scaling actions. The default is 300 seconds.
+     * The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+     * before rescaling. The minimum value is 300 seconds, which is also the default.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("coolDownInSeconds")
     Integer coolDownInSeconds;
 
     /**
-     * If the AutoScalingConfiguration is enabled
+     * Whether the autoscaling configuration is enabled.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
@@ -219,7 +221,10 @@ public class AutoScalingConfiguration {
     Resource resource;
 
     /**
-     * AutoScalingConfiguration policy definitions
+     * Autoscaling policy definitions for the autoscaling configuration. An autoscaling policy defines the criteria that
+     * trigger autoscaling actions and the actions to take.
+     * <p>
+     * Each autoscaling configuration can have one autoscaling policy.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("policies")
@@ -227,6 +232,7 @@ public class AutoScalingConfiguration {
 
     /**
      * The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+     * <p>
      * Example: `2016-08-25T21:10:29.600Z`
      *
      **/

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfigurationSummary.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfigurationSummary.java
@@ -4,6 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
+ * Summary information for an autoscaling configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -78,6 +79,25 @@ public class AutoScalingConfigurationSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -99,6 +119,8 @@ public class AutoScalingConfigurationSummary {
                             coolDownInSeconds,
                             isEnabled,
                             resource,
+                            definedTags,
+                            freeformTags,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -113,6 +135,8 @@ public class AutoScalingConfigurationSummary {
                             .coolDownInSeconds(o.getCoolDownInSeconds())
                             .isEnabled(o.getIsEnabled())
                             .resource(o.getResource())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags())
                             .timeCreated(o.getTimeCreated());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -128,35 +152,35 @@ public class AutoScalingConfigurationSummary {
     }
 
     /**
-     * The OCID of the compartment containing the AutoScalingConfiguration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the autoscaling configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-     * Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The OCID of the AutoScalingConfiguration
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The minimum period of time between scaling actions. The default is 300 seconds.
+     * The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+     * before rescaling. The minimum value is 300 seconds, which is also the default.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("coolDownInSeconds")
     Integer coolDownInSeconds;
 
     /**
-     * If the AutoScalingConfiguration is enabled
+     * Whether the autoscaling configuration is enabled.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
@@ -165,7 +189,28 @@ public class AutoScalingConfigurationSummary {
     Resource resource;
 
     /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
      * The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+     * <p>
      * Example: `2016-08-25T21:10:29.600Z`
      *
      **/

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicy.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicy.java
@@ -4,7 +4,10 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * A Policy defines the rules and actions of an AutoScalingConfiguration. The only supported type is 'threshold'
+ * Autoscaling policies define the criteria that trigger autoscaling actions and the actions to take.
+ * <p>
+ * An autoscaling policy is part of an autoscaling configuration. For more information, see
+ * [Autoscaling](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/autoscalinginstancepools.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -37,27 +40,27 @@ package com.oracle.bmc.autoscaling.model;
 public class AutoScalingPolicy {
 
     /**
-     * The capacity requirements of the Policy
+     * The capacity requirements of the autoscaling policy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("capacity")
     Capacity capacity;
 
     /**
-     * The ID of the policy that is assigned after creation
+     * The ID of the autoscaling policy that is assigned after creation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-     * confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The date and time the AutoScalingConfiguration was created, in the format defined by RFC3339.
+     * The date and time the autoscaling configuration was created, in the format defined by RFC3339.
+     * <p>
      * Example: `2016-08-25T21:10:29.600Z`
      *
      **/

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicySummary.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicySummary.java
@@ -4,6 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
+ * Summary information for an autoscaling policy.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -79,21 +80,20 @@ public class AutoScalingPolicySummary {
     }
 
     /**
-     * The ID of the policy that is assigned after creation
+     * The ID of the autoscaling policy that is assigned after creation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-     * confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Indicates type of Policy
+     * The type of autoscaling policy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("policyType")
     String policyType;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Capacity.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Capacity.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * Capacity boundaries for the pool
+ * Capacity limits for the instance pool.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -76,19 +76,22 @@ public class Capacity {
     }
 
     /**
-     * The maximum size the pool is allowed to increase to
+     * The maximum number of instances the instance pool is allowed to increase to (scale out).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("max")
     Integer max;
 
     /**
-     * The minimum size the pool is allowed to decrease to
+     * The minimum number of instances the instance pool is allowed to decrease to (scale in).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("min")
     Integer min;
 
     /**
-     * The initial size of the pool
+     * The initial number of instances to launch in the instance pool immediately after autoscaling is
+     * enabled. After autoscaling retrieves performance metrics, the number of instances is automatically adjusted from this
+     * initial number to a number that is based on the limits that you set.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("initial")
     Integer initial;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Condition.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Condition.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * A container for metric and action details
+ * A rule that defines a specific autoscaling action to take (scale in or scale out) and the metric that triggers that action.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -92,15 +92,14 @@ public class Condition {
     Action action;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-     * it's changeable. Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Id of the condition that is assigned after creation
+     * ID of the condition that is assigned after creation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingConfigurationDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingConfigurationDetails.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * An AutoScalingConfiguration creation details
+ * Creation details for an autoscaling configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -141,7 +141,8 @@ public class CreateAutoScalingConfigurationDetails {
     }
 
     /**
-     * The OCID of the compartment containing the AutoScalingConfiguration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the autoscaling configuration.
+     * The autoscaling configuration and the instance pool that it manages must be in the same compartment.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -158,8 +159,7 @@ public class CreateAutoScalingConfigurationDetails {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration. Does not have to be unique, and it's changeable.
-     * Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
@@ -176,14 +176,15 @@ public class CreateAutoScalingConfigurationDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The minimum period of time between scaling actions. The default is 300 seconds.
+     * The minimum period of time to wait between scaling actions. The cooldown period gives the system time to stabilize
+     * before rescaling. The minimum value is 300 seconds, which is also the default.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("coolDownInSeconds")
     Integer coolDownInSeconds;
 
     /**
-     * If the AutoScalingConfiguration is enabled
+     * Whether the autoscaling configuration is enabled.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingPolicyDetails.java
@@ -4,7 +4,12 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * An AutoScalingConfiguration Policy creation details
+ * Creation details for an autoscaling policy.
+ * <p>
+ * Each autoscaling configuration can have one autoscaling policy.
+ * <p>
+ * In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
+ * or exceeds a threshold.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -37,14 +42,13 @@ package com.oracle.bmc.autoscaling.model;
 public class CreateAutoScalingPolicyDetails {
 
     /**
-     * The capacity requirements of the Policy
+     * The capacity requirements of the autoscaling policy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("capacity")
     Capacity capacity;
 
     /**
-     * A user-friendly name for the Policy. Does not have to be unique, and it's changeable. Avoid entering
-     * confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateConditionDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateConditionDetails.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * Creation details for Condition in a ThresholdPolicy
+ * Creation details for a condition in a threshold-based autoscaling policy.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -83,8 +83,7 @@ public class CreateConditionDetails {
     Action action;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-     * it's changeable. Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateThresholdPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateThresholdPolicyDetails.java
@@ -4,7 +4,10 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * An AutoScalingConfiguration ThresholdPolicy creation details
+ * Creation details for a threshold-based autoscaling policy.
+ * <p>
+ * In a threshold-based autoscaling policy, an autoscaling action is triggered when a performance metric meets
+ * or exceeds a threshold.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/InstancePoolResource.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/InstancePoolResource.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * An Instance Pool resource
+ * A Compute instance pool.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Metric.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Metric.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * Metric threshold details
+ * Metric and threshold details for triggering an autoscaling action.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Resource.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Resource.java
@@ -4,7 +4,9 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * A resource that the AutoScalingConfiguration manages. The only supported type is 'instancePool'
+ * A resource that is managed by an autoscaling configuration. The only supported type is \"instancePool.\"
+ * <p>
+ * Each instance pool can have one autoscaling configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -37,7 +39,7 @@ package com.oracle.bmc.autoscaling.model;
 public class Resource {
 
     /**
-     * The OCID of resource that the AutoScalingConfiguration will manage.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource that is managed by the autoscaling configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Threshold.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/Threshold.java
@@ -66,11 +66,8 @@ public class Threshold {
     }
 
     /**
-     * Support for the following operators
-     * GT  - Greater than
-     * GTE - Greater than equal to
-     * LT  - Less than
-     * LTE - Less than equal to
+     * The comparison operator to use. Options are greater than (`GT`), greater than or equal to
+     * (`GTE`), less than (`LT`), and less than or equal to (`LTE`).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -119,11 +116,8 @@ public class Threshold {
         }
     };
     /**
-     * Support for the following operators
-     * GT  - Greater than
-     * GTE - Greater than equal to
-     * LT  - Less than
-     * LTE - Less than equal to
+     * The comparison operator to use. Options are greater than (`GT`), greater than or equal to
+     * (`GTE`), less than (`LT`), and less than or equal to (`LTE`).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("operator")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ThresholdPolicy.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ThresholdPolicy.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * A Policy that defines threshold based rules for an AutoScalingConfiguration
+ * An autoscaling policy that defines threshold-based rules for an autoscaling configuration.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingConfigurationDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingConfigurationDetails.java
@@ -130,13 +130,14 @@ public class UpdateAutoScalingConfigurationDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * If the AutoScalingConfiguration is enabled
+     * Whether the autoscaling configuration is enabled.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
 
     /**
-     * The minimum period of time between scaling actions. The default is 300 seconds.
+     * The minimum period of time to wait between scaling actions. The cooldown period gives the system time
+     * to stabilize before rescaling. The minimum value is 300 seconds, which is also the default.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("coolDownInSeconds")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingPolicyDetails.java
@@ -43,7 +43,7 @@ public class UpdateAutoScalingPolicyDetails {
     String displayName;
 
     /**
-     * The capacity requirements of the Policy
+     * The capacity requirements of the autoscaling policy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("capacity")
     Capacity capacity;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateConditionDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateConditionDetails.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.autoscaling.model;
 
 /**
- * Update details for Condition in a ThresholdPolicy
+ * Update details for a condition in a threshold-based autoscaling policy.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -83,8 +83,7 @@ public class UpdateConditionDetails {
     Action action;
 
     /**
-     * A user-friendly name for the AutoScalingConfiguration condition details. Does not have to be unique, and
-     * it's changeable. Avoid entering confidential information.
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/CreateAutoScalingConfigurationRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/CreateAutoScalingConfigurationRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.autoscaling.model.*;
 public class CreateAutoScalingConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * AutoScalingConfiguration creation details
+     * Creation details for an autoscaling configuration.
      */
     private CreateAutoScalingConfigurationDetails createAutoScalingConfigurationDetails;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/CreateAutoScalingPolicyRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/CreateAutoScalingPolicyRequest.java
@@ -11,12 +11,12 @@ import com.oracle.bmc.autoscaling.model.*;
 public class CreateAutoScalingPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
     /**
-     * AutoScalingConfiguration Policy creation details
+     * Creation details for an autoscaling policy.
      */
     private CreateAutoScalingPolicyDetails createAutoScalingPolicyDetails;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/DeleteAutoScalingConfigurationRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/DeleteAutoScalingConfigurationRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.autoscaling.model.*;
 public class DeleteAutoScalingConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/DeleteAutoScalingPolicyRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/DeleteAutoScalingPolicyRequest.java
@@ -11,12 +11,12 @@ import com.oracle.bmc.autoscaling.model.*;
 public class DeleteAutoScalingPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
     /**
-     * The ID of the auto scaling configuration policy.
+     * The ID of the autoscaling policy.
      */
     private String autoScalingPolicyId;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/GetAutoScalingConfigurationRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/GetAutoScalingConfigurationRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.autoscaling.model.*;
 public class GetAutoScalingConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/GetAutoScalingPolicyRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/GetAutoScalingPolicyRequest.java
@@ -11,12 +11,12 @@ import com.oracle.bmc.autoscaling.model.*;
 public class GetAutoScalingPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
     /**
-     * The ID of the auto scaling configuration policy.
+     * The ID of the autoscaling policy.
      */
     private String autoScalingPolicyId;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ListAutoScalingConfigurationsRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ListAutoScalingConfigurationsRequest.java
@@ -30,15 +30,15 @@ public class ListAutoScalingConfigurationsRequest extends com.oracle.bmc.request
     private String opcRequestId;
 
     /**
-     * The maximum number of items to return in a paginated \"List\" call. For information about pagination, see
-     * [List Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     * For list pagination. The maximum number of items to return in a paginated \"List\" call. For important details
+     * about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private Integer limit;
 
     /**
-     * The value of the `opc-next-page` response header from the previous \"List\" call. For information about
-     * pagination, see [List Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+     * details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ListAutoScalingPoliciesRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ListAutoScalingPoliciesRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.autoscaling.model.*;
 public class ListAutoScalingPoliciesRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
@@ -27,15 +27,15 @@ public class ListAutoScalingPoliciesRequest extends com.oracle.bmc.requests.BmcR
     private String opcRequestId;
 
     /**
-     * The maximum number of items to return in a paginated \"List\" call. For information about pagination, see
-     * [List Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     * For list pagination. The maximum number of items to return in a paginated \"List\" call. For important details
+     * about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private Integer limit;
 
     /**
-     * The value of the `opc-next-page` response header from the previous \"List\" call. For information about
-     * pagination, see [List Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+     * details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/UpdateAutoScalingConfigurationRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/UpdateAutoScalingConfigurationRequest.java
@@ -11,12 +11,12 @@ import com.oracle.bmc.autoscaling.model.*;
 public class UpdateAutoScalingConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
     /**
-     * AutoScalingConfiguration update details
+     * Update details for an autoscaling configuration.
      */
     private UpdateAutoScalingConfigurationDetails updateAutoScalingConfigurationDetails;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/UpdateAutoScalingPolicyRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/UpdateAutoScalingPolicyRequest.java
@@ -11,17 +11,17 @@ import com.oracle.bmc.autoscaling.model.*;
 public class UpdateAutoScalingPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the auto scaling configuration.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
      */
     private String autoScalingConfigurationId;
 
     /**
-     * The ID of the auto scaling configuration policy.
+     * The ID of the autoscaling policy.
      */
     private String autoScalingPolicyId;
 
     /**
-     * AutoScalingConfiguration Policy update details
+     * Update details for an autoscaling policy.
      */
     private UpdateAutoScalingPolicyDetails updateAutoScalingPolicyDetails;
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ListAutoScalingConfigurationsResponse.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ListAutoScalingConfigurationsResponse.java
@@ -11,9 +11,8 @@ import com.oracle.bmc.autoscaling.model.*;
 public class ListAutoScalingConfigurationsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ListAutoScalingPoliciesResponse.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ListAutoScalingPoliciesResponse.java
@@ -11,9 +11,8 @@ import com.oracle.bmc.autoscaling.model.*;
 public class ListAutoScalingPoliciesResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,145 +19,145 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/AbstractFederationClientAuthenticationDetailsProviderBuilder.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/AbstractFederationClientAuthenticationDetailsProviderBuilder.java
@@ -159,7 +159,10 @@ public abstract class AbstractFederationClientAuthenticationDetailsProviderBuild
                 region = Region.fromRegionCodeOrId(regionStr);
                 LOG.info("Using region {}", region.getRegionId());
             } catch (IllegalArgumentException e) {
-                LOG.warn("Region not supported by this version of the SDK", e);
+                LOG.warn(
+                        "Region not supported by this version of the SDK, registering region '{}' under OC1",
+                        regionStr,
+                        e);
                 // Proceed by assuming the region id belongs to the OC1 realm.
                 region = Region.register(regionStr, Realm.OC1);
             }

--- a/bmc-common/src/main/java/com/oracle/bmc/internal/EndpointBuilder.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/internal/EndpointBuilder.java
@@ -3,16 +3,19 @@
  */
 package com.oracle.bmc.internal;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 
-import com.google.common.collect.ImmutableMap;
 import com.oracle.bmc.Realm;
 import com.oracle.bmc.Region;
 import com.oracle.bmc.Service;
 
 import lombok.AccessLevel;
-import lombok.Getter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * EndpointBuilder provides a wrapper to construct the appropriate
@@ -20,9 +23,12 @@ import lombok.RequiredArgsConstructor;
  * if not, a default template will be used.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public class EndpointBuilder {
     public static final String DEFAULT_ENDPOINT_TEMPLATE =
             "https://{serviceEndpointPrefix}.{region}.{secondLevelDomain}";
+
+    private static final Map<String, String> OVERRIDE_REGION_IDS = new HashMap<>();
 
     /**
      * Creates the service endpoint using the {@link DefaultEndpointConfiguration}
@@ -33,16 +39,19 @@ public class EndpointBuilder {
      * @param realm The realm this region belongs to.
      * @return The endpoint (protocol + FQDN) for this service.
      */
-    public static String createEndpoint(Service service, String regionId, Realm realm) {
+    public static String createEndpoint(
+            @NonNull Service service, @NonNull String regionId, @NonNull Realm realm) {
         final String endpointTemplateToUse;
-        if (StringUtils.isNotBlank(service.getServiceEndpointTemplate())) {
-            endpointTemplateToUse = service.getServiceEndpointTemplate();
-        } else {
-            endpointTemplateToUse = DEFAULT_ENDPOINT_TEMPLATE;
+        synchronized (OVERRIDE_REGION_IDS) {
+            if (StringUtils.isNotBlank(service.getServiceEndpointTemplate())) {
+                endpointTemplateToUse = service.getServiceEndpointTemplate();
+            } else {
+                endpointTemplateToUse = DEFAULT_ENDPOINT_TEMPLATE;
+            }
         }
 
         return DefaultEndpointConfiguration.builder(endpointTemplateToUse)
-                .regionId(regionId)
+                .regionId(OVERRIDE_REGION_IDS.getOrDefault(regionId, regionId))
                 .serviceEndpointPrefix(service.getServiceEndpointPrefix())
                 .secondLevelDomain(realm.getSecondLevelDomain())
                 .build();
@@ -56,7 +65,23 @@ public class EndpointBuilder {
      * @param region The region
      * @return The endpoint (protocol + FQDN) for this service.
      */
-    public static String createEndpoint(Service service, Region region) {
+    public static String createEndpoint(@NonNull Service service, @NonNull Region region) {
         return createEndpoint(service, region.getRegionId(), region.getRealm());
+    }
+
+    /**
+     * Temporary ability to override the region for a given regionId.
+     * <p>
+     * This will most likely be removed at a later point in time.  It is not intended
+     * for use outside of the SDK.
+     * @param regionId The value obtained from {@link Region#getRegionId()}.
+     * @param overrideRegionId The alternative regionId to use.
+     */
+    public static void overrideRegionId(
+            @NonNull String regionId, @NonNull String overrideRegionId) {
+        synchronized (OVERRIDE_REGION_IDS) {
+            LOG.warn("Overriding regionId for regionId '{}' to '{}'", regionId, overrideRegionId);
+            OVERRIDE_REGION_IDS.put(regionId, overrideRegionId);
+        }
     }
 }

--- a/bmc-common/src/test/java/com/oracle/bmc/internal/EndpointBuilderTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/internal/EndpointBuilderTest.java
@@ -4,7 +4,6 @@
 package com.oracle.bmc.internal;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
@@ -52,5 +51,38 @@ public class EndpointBuilderTest {
         assertEquals(
                 "http://foobar.us-phoenix-1.oraclecloud.com",
                 EndpointBuilder.createEndpoint(testService, Region.US_PHOENIX_1));
+    }
+
+    @Test
+    public void createEndpoint_withOverrideRegionId() {
+        Region fakeRegion = Region.register("createEndpoint-withOverrideRegionId", Realm.OC1);
+        Service testServiceWithCustomTemplate =
+                Services.serviceBuilder()
+                        .serviceEndpointPrefix("foobar")
+                        .serviceName("EndpointBuilderTest4.1")
+                        .serviceEndpointTemplate(
+                                "http://{serviceEndpointPrefix}.{region}.{secondLevelDomain}")
+                        .build();
+        Service testServiceWithDefaultTemplate =
+                Services.serviceBuilder()
+                        .serviceEndpointPrefix("foobar")
+                        .serviceName("EndpointBuilderTest4.2")
+                        .build();
+
+        assertEquals(
+                "http://foobar.createendpoint-withoverrideregionid.oraclecloud.com",
+                EndpointBuilder.createEndpoint(testServiceWithCustomTemplate, fakeRegion));
+        assertEquals(
+                "https://foobar.createendpoint-withoverrideregionid.oraclecloud.com",
+                EndpointBuilder.createEndpoint(testServiceWithDefaultTemplate, fakeRegion));
+
+        EndpointBuilder.overrideRegionId(fakeRegion.getRegionId(), "fake");
+
+        assertEquals(
+                "http://foobar.fake.oraclecloud.com",
+                EndpointBuilder.createEndpoint(testServiceWithCustomTemplate, fakeRegion));
+        assertEquals(
+                "https://foobar.fake.oraclecloud.com",
+                EndpointBuilder.createEndpoint(testServiceWithDefaultTemplate, fakeRegion));
     }
 }

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
@@ -166,7 +166,7 @@ public interface Blockstorage extends AutoCloseable {
     DeleteBootVolumeBackupResponse deleteBootVolumeBackup(DeleteBootVolumeBackupRequest request);
 
     /**
-     * Remove kms for the specific boot volume. If the volume doesn't use KMS, then do nothing.
+     * Removes the KMS key for the specified boot volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -222,7 +222,7 @@ public interface Blockstorage extends AutoCloseable {
     DeleteVolumeGroupBackupResponse deleteVolumeGroupBackup(DeleteVolumeGroupBackupRequest request);
 
     /**
-     * Remove kms for the specific volume. If the volume doesn't use KMS, then do nothing.
+     * Removes the KMS key for the specified volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -247,7 +247,7 @@ public interface Blockstorage extends AutoCloseable {
     GetBootVolumeBackupResponse getBootVolumeBackup(GetBootVolumeBackupRequest request);
 
     /**
-     * Gets kms key id for the specified boot volume.
+     * Gets the KMS key ID for the specified boot volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -317,7 +317,7 @@ public interface Blockstorage extends AutoCloseable {
     GetVolumeGroupBackupResponse getVolumeGroupBackup(GetVolumeGroupBackupRequest request);
 
     /**
-     * Gets kms key id for the specified volume.
+     * Gets the KMS key ID for the specified volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -409,7 +409,7 @@ public interface Blockstorage extends AutoCloseable {
     UpdateBootVolumeBackupResponse updateBootVolumeBackup(UpdateBootVolumeBackupRequest request);
 
     /**
-     * Update kms key id for the specific volume.
+     * Updates the KMS key ID for the specified volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -460,7 +460,7 @@ public interface Blockstorage extends AutoCloseable {
     UpdateVolumeGroupBackupResponse updateVolumeGroupBackup(UpdateVolumeGroupBackupRequest request);
 
     /**
-     * Update kms key id for the specific volume.
+     * Updates the KMS key ID for the specified volume.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
@@ -243,7 +243,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Remove kms for the specific boot volume. If the volume doesn't use KMS, then do nothing.
+     * Removes the KMS key for the specified boot volume.
      *
      *
      * @param request The request object containing the details to send
@@ -347,7 +347,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Remove kms for the specific volume. If the volume doesn't use KMS, then do nothing.
+     * Removes the KMS key for the specified volume.
      *
      *
      * @param request The request object containing the details to send
@@ -395,7 +395,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets kms key id for the specified boot volume.
+     * Gets the KMS key ID for the specified boot volume.
      *
      *
      * @param request The request object containing the details to send
@@ -527,7 +527,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets kms key id for the specified volume.
+     * Gets the KMS key ID for the specified volume.
      *
      *
      * @param request The request object containing the details to send
@@ -692,7 +692,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update kms key id for the specific volume.
+     * Updates the KMS key ID for the specified volume.
      *
      *
      * @param request The request object containing the details to send
@@ -782,7 +782,7 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update kms key id for the specific volume.
+     * Updates the KMS key ID for the specified volume.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -37,16 +37,16 @@ public interface VirtualNetwork extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Enables the specified service on the specified gateway. In other words, enables the service
-     * gateway to send traffic to the specified service. You must also set up a route rule with the
-     * service's `cidrBlock` as the rule's destination CIDR and the gateway as the rule's target.
-     * See {@link RouteTable}.
+     * Adds the specified {@link Service} to the list of enabled
+     * `Service` objects for the specified gateway. You must also set up a route rule with the
+     * `cidrBlock` of the `Service` as the rule's destination and the service gateway as the rule's
+     * target. See {@link RouteTable}.
      * <p>
-     **Note:** The `AttachServiceId` operation is an easy way to enable an individual service on
+     **Note:** The `AttachServiceId` operation is an easy way to add an individual `Service` to
      * the service gateway. Compare it with
-     * {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}, which also
-     * lets you enable an individual service. However, with `UpdateServiceGateway`, you must specify
-     * the *entire* list of services you want enabled on the service gateway.
+     * {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}, which replaces
+     * the entire existing list of enabled `Service` objects with the list that you provide in the
+     * `Update` call.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -796,19 +796,18 @@ public interface VirtualNetwork extends AutoCloseable {
     DeleteVirtualCircuitResponse deleteVirtualCircuit(DeleteVirtualCircuitRequest request);
 
     /**
-     * Disables the specified service on the specified gateway. In other words, stops the service
-     * gateway from sending traffic to the specified service. You do not need to remove any route
-     * rules that specify this service's `cidrBlock` as the destination CIDR. However, consider
-     * removing the rules if your intent is to permanently disable use of the service through this
+     * Removes the specified {@link Service} from the list of enabled
+     * `Service` objects for the specified gateway. You do not need to remove any route
+     * rules that specify this `Service` object's `cidrBlock` as the destination CIDR. However, consider
+     * removing the rules if your intent is to permanently disable use of the `Service` through this
      * service gateway.
      * <p>
-     **Note:** The `DetachServiceId` operation is an easy way to disable an individual service on
+     **Note:** The `DetachServiceId` operation is an easy way to remove an individual `Service` from
      * the service gateway. Compare it with
-     * {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}, which also
-     * lets you disable an individual service. However, with `UpdateServiceGateway`, you must specify
-     * the *entire* list of services you want enabled on the service gateway. `UpdateServiceGateway`
-     * also lets you block all traffic through the service gateway without having to disable each of
-     * the individual services.
+     * {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}, which replaces
+     * the entire existing list of enabled `Service` objects with the list that you provide in the
+     * `Update` call. `UpdateServiceGateway` also lets you block all traffic through the service
+     * gateway without having to remove each of the individual `Service` objects.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -937,6 +936,26 @@ public interface VirtualNetwork extends AutoCloseable {
             GetIPSecConnectionDeviceStatusRequest request);
 
     /**
+     * Gets the specified IPSec connection's specified tunnel basic information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetIPSecConnectionTunnelResponse getIPSecConnectionTunnel(
+            GetIPSecConnectionTunnelRequest request);
+
+    /**
+     * Gets the specified IPSec connection's specific tunnel's shared secret.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetIPSecConnectionTunnelSharedSecretResponse getIPSecConnectionTunnelSharedSecret(
+            GetIPSecConnectionTunnelSharedSecretRequest request);
+
+    /**
      * Gets the specified internet gateway's information.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1051,7 +1070,7 @@ public interface VirtualNetwork extends AutoCloseable {
     GetSecurityListResponse getSecurityList(GetSecurityListRequest request);
 
     /**
-     * Gets the specified service's information.
+     * Gets the specified {@link Service} object.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1226,6 +1245,16 @@ public interface VirtualNetwork extends AutoCloseable {
                     ListFastConnectProviderVirtualCircuitBandwidthShapesRequest request);
 
     /**
+     * Gets the lists of tunnel information for the specified IPSec connection.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListIPSecConnectionTunnelsResponse listIPSecConnectionTunnels(
+            ListIPSecConnectionTunnelsRequest request);
+
+    /**
      * Lists the IPSec connections for the specified compartment. You can filter the
      * results by DRG or CPE.
      *
@@ -1356,7 +1385,8 @@ public interface VirtualNetwork extends AutoCloseable {
     ListServiceGatewaysResponse listServiceGateways(ListServiceGatewaysRequest request);
 
     /**
-     * Lists the available services that you can access through a service gateway in this region.
+     * Lists the available {@link Service} objects that you can enable for a
+     * service gateway in this region.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1472,14 +1502,33 @@ public interface VirtualNetwork extends AutoCloseable {
     UpdateDrgAttachmentResponse updateDrgAttachment(UpdateDrgAttachmentRequest request);
 
     /**
-     * Updates the display name or tags for the specified IPSec connection.
-     * Avoid entering confidential information.
+     * Updates the specified IPSec connection.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
      */
     UpdateIPSecConnectionResponse updateIPSecConnection(UpdateIPSecConnectionRequest request);
+
+    /**
+     * Update an IPsecConnection tunnel
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateIPSecConnectionTunnelResponse updateIPSecConnectionTunnel(
+            UpdateIPSecConnectionTunnelRequest request);
+
+    /**
+     * update shared secret for specifed Ipsec connection's specified tunnel
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateIPSecConnectionTunnelSharedSecretResponse updateIPSecConnectionTunnelSharedSecret(
+            UpdateIPSecConnectionTunnelSharedSecretRequest request);
 
     /**
      * Updates the specified internet gateway. You can disable/enable it, or change its display name

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -37,16 +37,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Enables the specified service on the specified gateway. In other words, enables the service
-     * gateway to send traffic to the specified service. You must also set up a route rule with the
-     * service's `cidrBlock` as the rule's destination CIDR and the gateway as the rule's target.
-     * See {@link RouteTable}.
+     * Adds the specified {@link Service} to the list of enabled
+     * `Service` objects for the specified gateway. You must also set up a route rule with the
+     * `cidrBlock` of the `Service` as the rule's destination and the service gateway as the rule's
+     * target. See {@link RouteTable}.
      * <p>
-     **Note:** The `AttachServiceId` operation is an easy way to enable an individual service on
+     **Note:** The `AttachServiceId` operation is an easy way to add an individual `Service` to
      * the service gateway. Compare it with
-     * {@link #updateServiceGateway(UpdateServiceGatewayRequest, Consumer, Consumer) updateServiceGateway}, which also
-     * lets you enable an individual service. However, with `UpdateServiceGateway`, you must specify
-     * the *entire* list of services you want enabled on the service gateway.
+     * {@link #updateServiceGateway(UpdateServiceGatewayRequest, Consumer, Consumer) updateServiceGateway}, which replaces
+     * the entire existing list of enabled `Service` objects with the list that you provide in the
+     * `Update` call.
      *
      *
      * @param request The request object containing the details to send
@@ -1119,19 +1119,18 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Disables the specified service on the specified gateway. In other words, stops the service
-     * gateway from sending traffic to the specified service. You do not need to remove any route
-     * rules that specify this service's `cidrBlock` as the destination CIDR. However, consider
-     * removing the rules if your intent is to permanently disable use of the service through this
+     * Removes the specified {@link Service} from the list of enabled
+     * `Service` objects for the specified gateway. You do not need to remove any route
+     * rules that specify this `Service` object's `cidrBlock` as the destination CIDR. However, consider
+     * removing the rules if your intent is to permanently disable use of the `Service` through this
      * service gateway.
      * <p>
-     **Note:** The `DetachServiceId` operation is an easy way to disable an individual service on
+     **Note:** The `DetachServiceId` operation is an easy way to remove an individual `Service` from
      * the service gateway. Compare it with
-     * {@link #updateServiceGateway(UpdateServiceGatewayRequest, Consumer, Consumer) updateServiceGateway}, which also
-     * lets you disable an individual service. However, with `UpdateServiceGateway`, you must specify
-     * the *entire* list of services you want enabled on the service gateway. `UpdateServiceGateway`
-     * also lets you block all traffic through the service gateway without having to disable each of
-     * the individual services.
+     * {@link #updateServiceGateway(UpdateServiceGatewayRequest, Consumer, Consumer) updateServiceGateway}, which replaces
+     * the entire existing list of enabled `Service` objects with the list that you provide in the
+     * `Update` call. `UpdateServiceGateway` also lets you block all traffic through the service
+     * gateway without having to remove each of the individual `Service` objects.
      *
      *
      * @param request The request object containing the details to send
@@ -1369,6 +1368,42 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Gets the specified IPSec connection's specified tunnel basic information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetIPSecConnectionTunnelResponse> getIPSecConnectionTunnel(
+            GetIPSecConnectionTunnelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+                    handler);
+
+    /**
+     * Gets the specified IPSec connection's specific tunnel's shared secret.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetIPSecConnectionTunnelSharedSecretResponse>
+            getIPSecConnectionTunnelSharedSecret(
+                    GetIPSecConnectionTunnelSharedSecretRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetIPSecConnectionTunnelSharedSecretRequest,
+                                    GetIPSecConnectionTunnelSharedSecretResponse>
+                            handler);
+
+    /**
      * Gets the specified internet gateway's information.
      *
      * @param request The request object containing the details to send
@@ -1555,7 +1590,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the specified service's information.
+     * Gets the specified {@link Service} object.
      *
      *
      * @param request The request object containing the details to send
@@ -1855,6 +1890,23 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Gets the lists of tunnel information for the specified IPSec connection.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListIPSecConnectionTunnelsResponse> listIPSecConnectionTunnels(
+            ListIPSecConnectionTunnelsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListIPSecConnectionTunnelsRequest, ListIPSecConnectionTunnelsResponse>
+                    handler);
+
+    /**
      * Lists the IPSec connections for the specified compartment. You can filter the
      * results by DRG or CPE.
      *
@@ -2060,7 +2112,8 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists the available services that you can access through a service gateway in this region.
+     * Lists the available {@link Service} objects that you can enable for a
+     * service gateway in this region.
      *
      *
      * @param request The request object containing the details to send
@@ -2265,8 +2318,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates the display name or tags for the specified IPSec connection.
-     * Avoid entering confidential information.
+     * Updates the specified IPSec connection.
      *
      *
      * @param request The request object containing the details to send
@@ -2281,6 +2333,42 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateIPSecConnectionRequest, UpdateIPSecConnectionResponse>
                     handler);
+
+    /**
+     * Update an IPsecConnection tunnel
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateIPSecConnectionTunnelResponse> updateIPSecConnectionTunnel(
+            UpdateIPSecConnectionTunnelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateIPSecConnectionTunnelRequest, UpdateIPSecConnectionTunnelResponse>
+                    handler);
+
+    /**
+     * update shared secret for specifed Ipsec connection's specified tunnel
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateIPSecConnectionTunnelSharedSecretResponse>
+            updateIPSecConnectionTunnelSharedSecret(
+                    UpdateIPSecConnectionTunnelSharedSecretRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateIPSecConnectionTunnelSharedSecretRequest,
+                                    UpdateIPSecConnectionTunnelSharedSecretResponse>
+                            handler);
 
     /**
      * Updates the specified internet gateway. You can disable/enable it, or change its display name

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
@@ -4975,6 +4975,163 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetIPSecConnectionTunnelResponse> getIPSecConnectionTunnel(
+            final GetIPSecConnectionTunnelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+                    handler) {
+        LOG.trace("Called async getIPSecConnectionTunnel");
+        final GetIPSecConnectionTunnelRequest interceptedRequest =
+                GetIPSecConnectionTunnelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetIPSecConnectionTunnelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>
+                transformer = GetIPSecConnectionTunnelConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetIPSecConnectionTunnelSharedSecretResponse>
+            getIPSecConnectionTunnelSharedSecret(
+                    final GetIPSecConnectionTunnelSharedSecretRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetIPSecConnectionTunnelSharedSecretRequest,
+                                    GetIPSecConnectionTunnelSharedSecretResponse>
+                            handler) {
+        LOG.trace("Called async getIPSecConnectionTunnelSharedSecret");
+        final GetIPSecConnectionTunnelSharedSecretRequest interceptedRequest =
+                GetIPSecConnectionTunnelSharedSecretConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetIPSecConnectionTunnelSharedSecretConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetIPSecConnectionTunnelSharedSecretResponse>
+                transformer = GetIPSecConnectionTunnelSharedSecretConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetIPSecConnectionTunnelSharedSecretRequest,
+                        GetIPSecConnectionTunnelSharedSecretResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetIPSecConnectionTunnelSharedSecretRequest,
+                            GetIPSecConnectionTunnelSharedSecretResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetIPSecConnectionTunnelSharedSecretResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetInternetGatewayResponse> getInternetGateway(
             final GetInternetGatewayRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -7029,6 +7186,84 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListIPSecConnectionTunnelsResponse>
+            listIPSecConnectionTunnels(
+                    final ListIPSecConnectionTunnelsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListIPSecConnectionTunnelsRequest,
+                                    ListIPSecConnectionTunnelsResponse>
+                            handler) {
+        LOG.trace("Called async listIPSecConnectionTunnels");
+        final ListIPSecConnectionTunnelsRequest interceptedRequest =
+                ListIPSecConnectionTunnelsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListIPSecConnectionTunnelsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>
+                transformer = ListIPSecConnectionTunnelsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListIPSecConnectionTunnelsRequest, ListIPSecConnectionTunnelsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListIPSecConnectionTunnelsRequest, ListIPSecConnectionTunnelsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListIPSecConnectionsResponse> listIPSecConnections(
             final ListIPSecConnectionsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -8848,6 +9083,198 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
                             return client.put(
                                     ib,
                                     interceptedRequest.getUpdateIPSecConnectionDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateIPSecConnectionTunnelResponse>
+            updateIPSecConnectionTunnel(
+                    final UpdateIPSecConnectionTunnelRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateIPSecConnectionTunnelRequest,
+                                    UpdateIPSecConnectionTunnelResponse>
+                            handler) {
+        LOG.trace("Called async updateIPSecConnectionTunnel");
+        final UpdateIPSecConnectionTunnelRequest interceptedRequest =
+                UpdateIPSecConnectionTunnelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateIPSecConnectionTunnelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>
+                transformer = UpdateIPSecConnectionTunnelConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateIPSecConnectionTunnelRequest, UpdateIPSecConnectionTunnelResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateIPSecConnectionTunnelRequest,
+                            UpdateIPSecConnectionTunnelResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateIPSecConnectionTunnelDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateIPSecConnectionTunnelDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateIPSecConnectionTunnelDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateIPSecConnectionTunnelSharedSecretResponse>
+            updateIPSecConnectionTunnelSharedSecret(
+                    final UpdateIPSecConnectionTunnelSharedSecretRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateIPSecConnectionTunnelSharedSecretRequest,
+                                    UpdateIPSecConnectionTunnelSharedSecretResponse>
+                            handler) {
+        LOG.trace("Called async updateIPSecConnectionTunnelSharedSecret");
+        final UpdateIPSecConnectionTunnelSharedSecretRequest interceptedRequest =
+                UpdateIPSecConnectionTunnelSharedSecretConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateIPSecConnectionTunnelSharedSecretConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelSharedSecretResponse>
+                transformer = UpdateIPSecConnectionTunnelSharedSecretConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateIPSecConnectionTunnelSharedSecretRequest,
+                        UpdateIPSecConnectionTunnelSharedSecretResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateIPSecConnectionTunnelSharedSecretRequest,
+                            UpdateIPSecConnectionTunnelSharedSecretResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest
+                                            .getUpdateIPSecConnectionTunnelSharedSecretDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateIPSecConnectionTunnelSharedSecretDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelSharedSecretResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest
+                                            .getUpdateIPSecConnectionTunnelSharedSecretDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
@@ -1857,6 +1857,59 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public GetIPSecConnectionTunnelResponse getIPSecConnectionTunnel(
+            GetIPSecConnectionTunnelRequest request) {
+        LOG.trace("Called getIPSecConnectionTunnel");
+        request = GetIPSecConnectionTunnelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetIPSecConnectionTunnelConverter.fromRequest(client, request);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>
+                transformer = GetIPSecConnectionTunnelConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response = client.get(ib, request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public GetIPSecConnectionTunnelSharedSecretResponse getIPSecConnectionTunnelSharedSecret(
+            GetIPSecConnectionTunnelSharedSecretRequest request) {
+        LOG.trace("Called getIPSecConnectionTunnelSharedSecret");
+        request = GetIPSecConnectionTunnelSharedSecretConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetIPSecConnectionTunnelSharedSecretConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetIPSecConnectionTunnelSharedSecretResponse>
+                transformer = GetIPSecConnectionTunnelSharedSecretConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response = client.get(ib, request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
     public GetInternetGatewayResponse getInternetGateway(GetInternetGatewayRequest request) {
         LOG.trace("Called getInternetGateway");
         request = GetInternetGatewayConverter.interceptRequest(request);
@@ -2557,6 +2610,33 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public ListIPSecConnectionTunnelsResponse listIPSecConnectionTunnels(
+            ListIPSecConnectionTunnelsRequest request) {
+        LOG.trace("Called listIPSecConnectionTunnels");
+        request = ListIPSecConnectionTunnelsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListIPSecConnectionTunnelsConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>
+                transformer = ListIPSecConnectionTunnelsConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response = client.get(ib, request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
     public ListIPSecConnectionsResponse listIPSecConnections(ListIPSecConnectionsRequest request) {
         LOG.trace("Called listIPSecConnections");
         request = ListIPSecConnectionsConverter.interceptRequest(request);
@@ -3135,6 +3215,65 @@ public class VirtualNetworkClient implements VirtualNetwork {
             try {
                 javax.ws.rs.core.Response response =
                         client.put(ib, request.getUpdateIPSecConnectionDetails(), request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public UpdateIPSecConnectionTunnelResponse updateIPSecConnectionTunnel(
+            UpdateIPSecConnectionTunnelRequest request) {
+        LOG.trace("Called updateIPSecConnectionTunnel");
+        request = UpdateIPSecConnectionTunnelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateIPSecConnectionTunnelConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>
+                transformer = UpdateIPSecConnectionTunnelConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response =
+                        client.put(ib, request.getUpdateIPSecConnectionTunnelDetails(), request);
+                return transformer.apply(response);
+            } catch (com.oracle.bmc.model.BmcException e) {
+                if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS
+                        && canRetryRequestIfRefreshableAuthTokenUsed(e)) {
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public UpdateIPSecConnectionTunnelSharedSecretResponse updateIPSecConnectionTunnelSharedSecret(
+            UpdateIPSecConnectionTunnelSharedSecretRequest request) {
+        LOG.trace("Called updateIPSecConnectionTunnelSharedSecret");
+        request = UpdateIPSecConnectionTunnelSharedSecretConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateIPSecConnectionTunnelSharedSecretConverter.fromRequest(client, request);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelSharedSecretResponse>
+                transformer = UpdateIPSecConnectionTunnelSharedSecretConverter.fromResponse();
+
+        int attempts = 0;
+        while (true) {
+            try {
+                javax.ws.rs.core.Response response =
+                        client.put(
+                                ib,
+                                request.getUpdateIPSecConnectionTunnelSharedSecretDetails(),
+                                request);
                 return transformer.apply(response);
             } catch (com.oracle.bmc.model.BmcException e) {
                 if (++attempts < MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkPaginators.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkPaginators.java
@@ -1201,6 +1201,123 @@ public class VirtualNetworkPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listIPSecConnectionTunnels operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListIPSecConnectionTunnelsResponse> listIPSecConnectionTunnelsResponseIterator(
+            final ListIPSecConnectionTunnelsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListIPSecConnectionTunnelsRequest.Builder, ListIPSecConnectionTunnelsRequest,
+                ListIPSecConnectionTunnelsResponse>(
+                new com.google.common.base.Supplier<ListIPSecConnectionTunnelsRequest.Builder>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsRequest.Builder get() {
+                        return ListIPSecConnectionTunnelsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListIPSecConnectionTunnelsResponse, String>() {
+                    @Override
+                    public String apply(ListIPSecConnectionTunnelsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListIPSecConnectionTunnelsRequest.Builder>,
+                        ListIPSecConnectionTunnelsRequest>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListIPSecConnectionTunnelsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListIPSecConnectionTunnelsRequest, ListIPSecConnectionTunnelsResponse>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsResponse apply(
+                            ListIPSecConnectionTunnelsRequest request) {
+                        return client.listIPSecConnectionTunnels(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.core.model.IPSecConnectionTunnel} objects
+     * contained in responses from the listIPSecConnectionTunnels operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.core.model.IPSecConnectionTunnel} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.core.model.IPSecConnectionTunnel>
+            listIPSecConnectionTunnelsRecordIterator(
+                    final ListIPSecConnectionTunnelsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListIPSecConnectionTunnelsRequest.Builder, ListIPSecConnectionTunnelsRequest,
+                ListIPSecConnectionTunnelsResponse,
+                com.oracle.bmc.core.model.IPSecConnectionTunnel>(
+                new com.google.common.base.Supplier<ListIPSecConnectionTunnelsRequest.Builder>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsRequest.Builder get() {
+                        return ListIPSecConnectionTunnelsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListIPSecConnectionTunnelsResponse, String>() {
+                    @Override
+                    public String apply(ListIPSecConnectionTunnelsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListIPSecConnectionTunnelsRequest.Builder>,
+                        ListIPSecConnectionTunnelsRequest>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListIPSecConnectionTunnelsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListIPSecConnectionTunnelsRequest, ListIPSecConnectionTunnelsResponse>() {
+                    @Override
+                    public ListIPSecConnectionTunnelsResponse apply(
+                            ListIPSecConnectionTunnelsRequest request) {
+                        return client.listIPSecConnectionTunnels(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListIPSecConnectionTunnelsResponse,
+                        java.util.List<com.oracle.bmc.core.model.IPSecConnectionTunnel>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.core.model.IPSecConnectionTunnel> apply(
+                            ListIPSecConnectionTunnelsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listIPSecConnections operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
@@ -630,6 +630,117 @@ public class VirtualNetworkWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+            forIPSecConnectionTunnel(
+                    GetIPSecConnectionTunnelRequest request,
+                    com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forIPSecConnectionTunnel(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link TerminationStrategy} to use
+     * @param delayStrategy the {@link DelayStrategy} to use
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+            forIPSecConnectionTunnel(
+                    GetIPSecConnectionTunnelRequest request,
+                    com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forIPSecConnectionTunnel(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link TerminationStrategy} to use
+     * @param delayStrategy the {@link DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+            forIPSecConnectionTunnel(
+                    GetIPSecConnectionTunnelRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forIPSecConnectionTunnel(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for IPSecConnectionTunnel.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetIPSecConnectionTunnelRequest, GetIPSecConnectionTunnelResponse>
+            forIPSecConnectionTunnel(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetIPSecConnectionTunnelRequest request,
+                    final com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetIPSecConnectionTunnelRequest,
+                                GetIPSecConnectionTunnelResponse>() {
+                            @Override
+                            public GetIPSecConnectionTunnelResponse apply(
+                                    GetIPSecConnectionTunnelRequest request) {
+                                return client.getIPSecConnectionTunnel(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetIPSecConnectionTunnelResponse>() {
+                            @Override
+                            public boolean apply(GetIPSecConnectionTunnelResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getIPSecConnectionTunnel().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.core.model.IPSecConnectionTunnel.LifecycleState
+                                        .Terminated)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link Waiter} using default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetInternetGatewayRequest, GetInternetGatewayResponse>
             forInternetGateway(
                     GetInternetGatewayRequest request,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetIPSecConnectionTunnelConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetIPSecConnectionTunnelConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetIPSecConnectionTunnelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetIPSecConnectionTunnelRequest interceptRequest(
+            GetIPSecConnectionTunnelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetIPSecConnectionTunnelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getIpscId(), "ipscId must not be blank");
+        Validate.notBlank(request.getTunnelId(), "tunnelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("ipsecConnections")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIpscId()))
+                        .path("tunnels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTunnelId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetIPSecConnectionTunnelResponse>() {
+                            @Override
+                            public GetIPSecConnectionTunnelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetIPSecConnectionTunnelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        IPSecConnectionTunnel>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        IPSecConnectionTunnel.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<IPSecConnectionTunnel>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetIPSecConnectionTunnelResponse.Builder builder =
+                                        GetIPSecConnectionTunnelResponse.builder();
+
+                                builder.iPSecConnectionTunnel(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetIPSecConnectionTunnelResponse responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetIPSecConnectionTunnelSharedSecretConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetIPSecConnectionTunnelSharedSecretConverter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetIPSecConnectionTunnelSharedSecretConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetIPSecConnectionTunnelSharedSecretRequest interceptRequest(
+            GetIPSecConnectionTunnelSharedSecretRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetIPSecConnectionTunnelSharedSecretRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getIpscId(), "ipscId must not be blank");
+        Validate.notBlank(request.getTunnelId(), "tunnelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("ipsecConnections")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIpscId()))
+                        .path("tunnels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTunnelId()))
+                        .path("sharedSecret");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetIPSecConnectionTunnelSharedSecretResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetIPSecConnectionTunnelSharedSecretResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GetIPSecConnectionTunnelSharedSecretResponse>() {
+                            @Override
+                            public GetIPSecConnectionTunnelSharedSecretResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetIPSecConnectionTunnelSharedSecretResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        IPSecConnectionTunnelSharedSecret>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        IPSecConnectionTunnelSharedSecret.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                IPSecConnectionTunnelSharedSecret>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetIPSecConnectionTunnelSharedSecretResponse.Builder builder =
+                                        GetIPSecConnectionTunnelSharedSecretResponse.builder();
+
+                                builder.iPSecConnectionTunnelSharedSecret(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetIPSecConnectionTunnelSharedSecretResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListIPSecConnectionTunnelsConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListIPSecConnectionTunnelsConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListIPSecConnectionTunnelsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListIPSecConnectionTunnelsRequest interceptRequest(
+            ListIPSecConnectionTunnelsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ListIPSecConnectionTunnelsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getIpscId(), "ipscId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("ipsecConnections")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIpscId()))
+                        .path("tunnels");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListIPSecConnectionTunnelsResponse>() {
+                            @Override
+                            public ListIPSecConnectionTunnelsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListIPSecConnectionTunnelsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<IPSecConnectionTunnel>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        IPSecConnectionTunnel>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<IPSecConnectionTunnel>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListIPSecConnectionTunnelsResponse.Builder builder =
+                                        ListIPSecConnectionTunnelsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListIPSecConnectionTunnelsResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateIPSecConnectionTunnelConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateIPSecConnectionTunnelConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateIPSecConnectionTunnelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateIPSecConnectionTunnelRequest interceptRequest(
+            UpdateIPSecConnectionTunnelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateIPSecConnectionTunnelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getIpscId(), "ipscId must not be blank");
+        Validate.notBlank(request.getTunnelId(), "tunnelId must not be blank");
+        Validate.notNull(
+                request.getUpdateIPSecConnectionTunnelDetails(),
+                "updateIPSecConnectionTunnelDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("ipsecConnections")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIpscId()))
+                        .path("tunnels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTunnelId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelResponse>() {
+                            @Override
+                            public UpdateIPSecConnectionTunnelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateIPSecConnectionTunnelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        IPSecConnectionTunnel>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        IPSecConnectionTunnel.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<IPSecConnectionTunnel>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateIPSecConnectionTunnelResponse.Builder builder =
+                                        UpdateIPSecConnectionTunnelResponse.builder();
+
+                                builder.iPSecConnectionTunnel(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateIPSecConnectionTunnelResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateIPSecConnectionTunnelSharedSecretConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateIPSecConnectionTunnelSharedSecretConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateIPSecConnectionTunnelSharedSecretConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateIPSecConnectionTunnelSharedSecretRequest interceptRequest(
+            UpdateIPSecConnectionTunnelSharedSecretRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateIPSecConnectionTunnelSharedSecretRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getIpscId(), "ipscId must not be blank");
+        Validate.notBlank(request.getTunnelId(), "tunnelId must not be blank");
+        Validate.notNull(
+                request.getUpdateIPSecConnectionTunnelSharedSecretDetails(),
+                "updateIPSecConnectionTunnelSharedSecretDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("ipsecConnections")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIpscId()))
+                        .path("tunnels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTunnelId()))
+                        .path("sharedSecret");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelSharedSecretResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateIPSecConnectionTunnelSharedSecretResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                UpdateIPSecConnectionTunnelSharedSecretResponse>() {
+                            @Override
+                            public UpdateIPSecConnectionTunnelSharedSecretResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateIPSecConnectionTunnelSharedSecretResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        IPSecConnectionTunnelSharedSecret>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        IPSecConnectionTunnelSharedSecret.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                IPSecConnectionTunnelSharedSecret>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateIPSecConnectionTunnelSharedSecretResponse.Builder builder =
+                                        UpdateIPSecConnectionTunnelSharedSecretResponse.builder();
+
+                                builder.iPSecConnectionTunnelSharedSecret(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateIPSecConnectionTunnelSharedSecretResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BgpSessionInfo.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BgpSessionInfo.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Information needed to establish a BGP Session on an interface.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BgpSessionInfo.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BgpSessionInfo {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+        private String oracleInterfaceIp;
+
+        public Builder oracleInterfaceIp(String oracleInterfaceIp) {
+            this.oracleInterfaceIp = oracleInterfaceIp;
+            this.__explicitlySet__.add("oracleInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+        private String customerInterfaceIp;
+
+        public Builder customerInterfaceIp(String customerInterfaceIp) {
+            this.customerInterfaceIp = customerInterfaceIp;
+            this.__explicitlySet__.add("customerInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("oracleBgpAsn")
+        private String oracleBgpAsn;
+
+        public Builder oracleBgpAsn(String oracleBgpAsn) {
+            this.oracleBgpAsn = oracleBgpAsn;
+            this.__explicitlySet__.add("oracleBgpAsn");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+        private String customerBgpAsn;
+
+        public Builder customerBgpAsn(String customerBgpAsn) {
+            this.customerBgpAsn = customerBgpAsn;
+            this.__explicitlySet__.add("customerBgpAsn");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpState")
+        private BgpState bgpState;
+
+        public Builder bgpState(BgpState bgpState) {
+            this.bgpState = bgpState;
+            this.__explicitlySet__.add("bgpState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BgpSessionInfo build() {
+            BgpSessionInfo __instance__ =
+                    new BgpSessionInfo(
+                            oracleInterfaceIp,
+                            customerInterfaceIp,
+                            oracleBgpAsn,
+                            customerBgpAsn,
+                            bgpState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BgpSessionInfo o) {
+            Builder copiedBuilder =
+                    oracleInterfaceIp(o.getOracleInterfaceIp())
+                            .customerInterfaceIp(o.getCustomerInterfaceIp())
+                            .oracleBgpAsn(o.getOracleBgpAsn())
+                            .customerBgpAsn(o.getCustomerBgpAsn())
+                            .bgpState(o.getBgpState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the IPv4 Address used in the BGP peering session for the Oracle router. Example: 10.0.0.1/31
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+    String oracleInterfaceIp;
+
+    /**
+     * This is the IPv4 Address used in the BGP peering session for the non-Oracle router. Example: 10.0.0.2/31
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+    String customerInterfaceIp;
+
+    /**
+     * This is the value of the Oracle Bgp ASN in asplain format, as a string. Example: 1587232876 (4 byte ASN) or 12345 (2 byte ASN)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oracleBgpAsn")
+    String oracleBgpAsn;
+
+    /**
+     * This is the value of the remote Bgp ASN in asplain format, as a string. Example: 1587232876 (4 byte ASN) or 12345 (2 byte ASN)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+    String customerBgpAsn;
+    /**
+     * the state of the BGP.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum BgpState {
+        Up("UP"),
+        Down("DOWN"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, BgpState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BgpState v : BgpState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        BgpState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BgpState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'BgpState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * the state of the BGP.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpState")
+    BgpState bgpState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeKmsKey.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeKmsKey.java
@@ -58,7 +58,7 @@ public class BootVolumeKmsKey {
     }
 
     /**
-     * Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+     * The OCID of the KMS key associated with this volume. If volume is not using KMS, then the `kmsKeyId` will be a null string.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
@@ -106,6 +106,16 @@ public class CreateIPSecConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("tunnelConfiguration")
+        private java.util.List<CreateIPSecConnectionTunnelDetails> tunnelConfiguration;
+
+        public Builder tunnelConfiguration(
+                java.util.List<CreateIPSecConnectionTunnelDetails> tunnelConfiguration) {
+            this.tunnelConfiguration = tunnelConfiguration;
+            this.__explicitlySet__.add("tunnelConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -120,7 +130,8 @@ public class CreateIPSecConnectionDetails {
                             freeformTags,
                             cpeLocalIdentifier,
                             cpeLocalIdentifierType,
-                            staticRoutes);
+                            staticRoutes,
+                            tunnelConfiguration);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -136,7 +147,8 @@ public class CreateIPSecConnectionDetails {
                             .freeformTags(o.getFreeformTags())
                             .cpeLocalIdentifier(o.getCpeLocalIdentifier())
                             .cpeLocalIdentifierType(o.getCpeLocalIdentifierType())
-                            .staticRoutes(o.getStaticRoutes());
+                            .staticRoutes(o.getStaticRoutes())
+                            .tunnelConfiguration(o.getTunnelConfiguration());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -256,14 +268,23 @@ public class CreateIPSecConnectionDetails {
     CpeLocalIdentifierType cpeLocalIdentifierType;
 
     /**
-     * Static routes to the CPE. At least one route must be included. A static route's CIDR must not be a
+     * Static routes to the CPE. A static route's CIDR must not be a
      * multicast address or class E address.
+     * <p>
+     *
      * <p>
      * Example: `10.0.1.0/24`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("staticRoutes")
     java.util.List<String> staticRoutes;
+
+    /**
+     * array of tunnel parameters to create tunnels for IPSecConnection.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tunnelConfiguration")
+    java.util.List<CreateIPSecConnectionTunnelDetails> tunnelConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionTunnelDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionTunnelDetails.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * details need to create an IPSecConnection tunnel.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateIPSecConnectionTunnelDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateIPSecConnectionTunnelDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("routing")
+        private Routing routing;
+
+        public Builder routing(Routing routing) {
+            this.routing = routing;
+            this.__explicitlySet__.add("routing");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+        private String sharedSecret;
+
+        public Builder sharedSecret(String sharedSecret) {
+            this.sharedSecret = sharedSecret;
+            this.__explicitlySet__.add("sharedSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionConfig")
+        private CreateIPSecTunnelBgpSessionDetails bgpSessionConfig;
+
+        public Builder bgpSessionConfig(CreateIPSecTunnelBgpSessionDetails bgpSessionConfig) {
+            this.bgpSessionConfig = bgpSessionConfig;
+            this.__explicitlySet__.add("bgpSessionConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateIPSecConnectionTunnelDetails build() {
+            CreateIPSecConnectionTunnelDetails __instance__ =
+                    new CreateIPSecConnectionTunnelDetails(
+                            displayName, routing, sharedSecret, bgpSessionConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateIPSecConnectionTunnelDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .routing(o.getRouting())
+                            .sharedSecret(o.getSharedSecret())
+                            .bgpSessionConfig(o.getBgpSessionConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP.
+     **/
+    public enum Routing {
+        Bgp("BGP"),
+        Static("STATIC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Routing> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Routing v : Routing.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Routing(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Routing create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid Routing: " + key);
+        }
+    };
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routing")
+    Routing routing;
+
+    /**
+     * The shared secret of the IPSec tunnel.
+     * <p>
+     * Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+    String sharedSecret;
+
+    /**
+     * Information needed to establish a BGP Session on an interface.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionConfig")
+    CreateIPSecTunnelBgpSessionDetails bgpSessionConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecTunnelBgpSessionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecTunnelBgpSessionDetails.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Details to create an IPSec Tunnel's BGP session paramaters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateIPSecTunnelBgpSessionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateIPSecTunnelBgpSessionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+        private String oracleInterfaceIp;
+
+        public Builder oracleInterfaceIp(String oracleInterfaceIp) {
+            this.oracleInterfaceIp = oracleInterfaceIp;
+            this.__explicitlySet__.add("oracleInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+        private String customerInterfaceIp;
+
+        public Builder customerInterfaceIp(String customerInterfaceIp) {
+            this.customerInterfaceIp = customerInterfaceIp;
+            this.__explicitlySet__.add("customerInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+        private String customerBgpAsn;
+
+        public Builder customerBgpAsn(String customerBgpAsn) {
+            this.customerBgpAsn = customerBgpAsn;
+            this.__explicitlySet__.add("customerBgpAsn");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateIPSecTunnelBgpSessionDetails build() {
+            CreateIPSecTunnelBgpSessionDetails __instance__ =
+                    new CreateIPSecTunnelBgpSessionDetails(
+                            oracleInterfaceIp, customerInterfaceIp, customerBgpAsn);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateIPSecTunnelBgpSessionDetails o) {
+            Builder copiedBuilder =
+                    oracleInterfaceIp(o.getOracleInterfaceIp())
+                            .customerInterfaceIp(o.getCustomerInterfaceIp())
+                            .customerBgpAsn(o.getCustomerBgpAsn());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The IPv4 Address used in the BGP peering session for the Oracle router. Example: 10.0.0.1/31.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+    String oracleInterfaceIp;
+
+    /**
+     * The IPv4 Address used in the BGP peering session for the non-Oracle router. Example: 10.0.0.2/31.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+    String customerInterfaceIp;
+
+    /**
+     * The value of the remote Bgp ASN in asplain format, as a string. Example: 1587232876 (4 byte ASN) or 12345 (2 byte ASN).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+    String customerBgpAsn;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInstancePoolDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateInstancePoolDetails.java
@@ -176,14 +176,18 @@ public class CreateInstancePoolDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The OCID of the instance configuration associated to the instance pool.
+     * The OCID of the instance configuration associated with the instance pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceConfigurationId")
     String instanceConfigurationId;
 
     /**
-     * The placement configurations for the instance pool.
-     * There should be 1 placement configuration for each desired AD.
+     * The placement configurations for the instance pool. Provide one placement configuration for
+     * each availability domain.
+     * <p>
+     * To use the instance pool with a regional subnet, provide a placement configuration for
+     * each availability domain, and include the regional subnet in each placement
+     * configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("placementConfigurations")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateServiceGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateServiceGatewayDetails.java
@@ -113,7 +113,7 @@ public class CreateServiceGatewayDetails {
     }
 
     /**
-     * The [OCID] (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)  of the compartment to contain the service gateway.
+     * The [OCID] (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to contain the service gateway.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -149,7 +149,16 @@ public class CreateServiceGatewayDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * List of the service OCIDs. These are the services that will be enabled on the service gateway. This list can be empty.
+     * List of the OCIDs of the {@link Service} objects to
+     * enable for the service gateway. This list can be empty if you don't want to enable any
+     * `Service` objects when you create the gateway. You can enable a `Service`
+     * object later by using either {@link #attachServiceId(AttachServiceIdRequest) attachServiceId}
+     * or {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}.
+     * <p>
+     * For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+     * as the rule's destination and the service gateway as the rule's target. See
+     * {@link RouteTable}.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")
     java.util.List<ServiceIdRequestDetails> services;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
@@ -139,7 +139,7 @@ public class CrossConnectGroup {
     String compartmentId;
 
     /**
-     * The display name of A user-friendly name. Does not have to be unique, and it's changeable.
+     * The display name of a user-friendly name. Does not have to be unique, and it's changeable.
      * Avoid entering confidential information.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
@@ -136,8 +136,8 @@ public class EgressSecurityRule {
      * IP address range in CIDR notation. For example: `192.168.1.0/24`
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
-     *     setting up a security list rule for traffic destined for a particular service through
-     *     a service gateway. For example: `oci-phx-objectstorage`
+     *     setting up a security list rule for traffic destined for a particular `Service` through
+     *     a service gateway. For example: `oci-phx-objectstorage`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("destination")
@@ -151,7 +151,7 @@ public class EgressSecurityRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic destined for a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -206,7 +206,7 @@ public class EgressSecurityRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic destined for a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("destinationType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
@@ -6,8 +6,7 @@ package com.oracle.bmc.core.model;
 /**
  * A connection between a DRG and CPE. This connection consists of multiple IPSec
  * tunnels. Creating this connection is one of the steps required when setting up
- * an IPSec VPN. For more information, see
- * [IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+ * an IPSec VPN. For more information, see [IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
@@ -370,8 +369,10 @@ public class IPSecConnection {
     CpeLocalIdentifierType cpeLocalIdentifierType;
 
     /**
-     * Static routes to the CPE. At least one route must be included. The CIDR must not be a
+     * Static routes to the CPE. The CIDR must not be a
      * multicast address or class E address.
+     * <p>
+     *
      * <p>
      * Example: `10.0.1.0/24`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnel.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnel.java
@@ -1,0 +1,395 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * information about IPSecConnection tunnel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = IPSecConnectionTunnel.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class IPSecConnectionTunnel {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpnIp")
+        private String vpnIp;
+
+        public Builder vpnIp(String vpnIp) {
+            this.vpnIp = vpnIp;
+            this.__explicitlySet__.add("vpnIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpeIp")
+        private String cpeIp;
+
+        public Builder cpeIp(String cpeIp) {
+            this.cpeIp = cpeIp;
+            this.__explicitlySet__.add("cpeIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionInfo")
+        private BgpSessionInfo bgpSessionInfo;
+
+        public Builder bgpSessionInfo(BgpSessionInfo bgpSessionInfo) {
+            this.bgpSessionInfo = bgpSessionInfo;
+            this.__explicitlySet__.add("bgpSessionInfo");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("routing")
+        private Routing routing;
+
+        public Builder routing(Routing routing) {
+            this.routing = routing;
+            this.__explicitlySet__.add("routing");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStatusUpdated")
+        private java.util.Date timeStatusUpdated;
+
+        public Builder timeStatusUpdated(java.util.Date timeStatusUpdated) {
+            this.timeStatusUpdated = timeStatusUpdated;
+            this.__explicitlySet__.add("timeStatusUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public IPSecConnectionTunnel build() {
+            IPSecConnectionTunnel __instance__ =
+                    new IPSecConnectionTunnel(
+                            compartmentId,
+                            id,
+                            vpnIp,
+                            cpeIp,
+                            status,
+                            lifecycleState,
+                            displayName,
+                            bgpSessionInfo,
+                            routing,
+                            timeCreated,
+                            timeStatusUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(IPSecConnectionTunnel o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .id(o.getId())
+                            .vpnIp(o.getVpnIp())
+                            .cpeIp(o.getCpeIp())
+                            .status(o.getStatus())
+                            .lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .bgpSessionInfo(o.getBgpSessionInfo())
+                            .routing(o.getRouting())
+                            .timeCreated(o.getTimeCreated())
+                            .timeStatusUpdated(o.getTimeStatusUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment containing the tunnel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The tunnel's Oracle ID (OCID).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The IP address of Oracle's VPN headend.
+     * <p>
+     * Example: `129.146.17.50`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpnIp")
+    String vpnIp;
+
+    /**
+     * The IP address of Cpe headend.
+     * <p>
+     * Example: `129.146.17.50`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpeIp")
+    String cpeIp;
+    /**
+     * The tunnel's current state.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Status {
+        Up("UP"),
+        Down("DOWN"),
+        DownForMaintenance("DOWN_FOR_MAINTENANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The tunnel's current state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+    /**
+     * The IPSec connection's tunnel's lifecycle state.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The IPSec connection's tunnel's lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Information needed to establish a BGP Session on an interface.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionInfo")
+    BgpSessionInfo bgpSessionInfo;
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP dynamic routing
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Routing {
+        Bgp("BGP"),
+        Static("STATIC"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Routing> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Routing v : Routing.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Routing(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Routing create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Routing', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP dynamic routing
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routing")
+    Routing routing;
+
+    /**
+     * The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * When the status of the tunnel last changed, in the format defined by RFC3339.
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStatusUpdated")
+    java.util.Date timeStatusUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnelSharedSecret.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnelSharedSecret.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The shared secret of a IPSec connection's specified tunnel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = IPSecConnectionTunnelSharedSecret.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class IPSecConnectionTunnelSharedSecret {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+        private String sharedSecret;
+
+        public Builder sharedSecret(String sharedSecret) {
+            this.sharedSecret = sharedSecret;
+            this.__explicitlySet__.add("sharedSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public IPSecConnectionTunnelSharedSecret build() {
+            IPSecConnectionTunnelSharedSecret __instance__ =
+                    new IPSecConnectionTunnelSharedSecret(sharedSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(IPSecConnectionTunnelSharedSecret o) {
+            Builder copiedBuilder = sharedSecret(o.getSharedSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shared secret of the IPSec tunnel.
+     * <p>
+     * Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+    String sharedSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
@@ -171,8 +171,8 @@ public class IngressSecurityRule {
      * IP address range in CIDR notation. For example: `192.168.1.0/24`
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
-     *     setting up a security list rule for traffic coming from a particular service through
-     *     a service gateway. For example: `oci-phx-objectstorage`
+     *     setting up a security list rule for traffic coming from a particular `Service` through
+     *     a service gateway. For example: `oci-phx-objectstorage`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("source")
@@ -184,7 +184,7 @@ public class IngressSecurityRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic coming from a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -237,7 +237,7 @@ public class IngressSecurityRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic coming from a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfiguration.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfiguration.java
@@ -184,6 +184,11 @@ public class InstanceConfiguration {
     @com.fasterxml.jackson.annotation.JsonProperty("instanceDetails")
     InstanceConfigurationInstanceDetails instanceDetails;
 
+    /**
+     * The required details when using the {@link #launchInstanceConfiguration(LaunchInstanceConfigurationRequest) launchInstanceConfiguration} operation.
+     * These attributes are optional when using the {@link #createInstanceConfiguration(CreateInstanceConfigurationRequest) createInstanceConfiguration} operation.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("deferredFields")
     java.util.List<String> deferredFields;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVnicDetails.java
@@ -4,7 +4,8 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Please see {@link CreateVnicDetails}
+ * Contains the properties of the VNIC for an instance configuration. See {@link CreateVnicDetails}
+ * and [Instance Configurations](https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm#config) for more information.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -117,6 +118,11 @@ public class InstanceConfigurationCreateVnicDetails {
         return new Builder();
     }
 
+    /**
+     * Whether the VNIC should be assigned a public IP address. See the `assignPublicIp` attribute of {@link CreateVnicDetails}
+     * for more information.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("assignPublicIp")
     Boolean assignPublicIp;
 
@@ -128,15 +134,35 @@ public class InstanceConfigurationCreateVnicDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
+    /**
+     * The hostname for the VNIC's primary private IP.
+     * See the `hostnameLabel` attribute of {@link CreateVnicDetails} for more information.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("hostnameLabel")
     String hostnameLabel;
 
+    /**
+     * A private IP address of your choice to assign to the VNIC.
+     * See the `privateIp` attribute of {@link CreateVnicDetails} for more information.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("privateIp")
     String privateIp;
 
+    /**
+     * Whether the source/destination check is disabled on the VNIC.
+     * See the `skipSourceDestCheck` attribute of {@link CreateVnicDetails} for more information.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("skipSourceDestCheck")
     Boolean skipSourceDestCheck;
 
+    /**
+     * The OCID of the subnet to create the VNIC in.
+     * See the `subnetId` attribute of {@link CreateVnicDetails} for more information.
+     *
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationSummary.java
@@ -61,12 +61,32 @@ public class InstanceConfigurationSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public InstanceConfigurationSummary build() {
             InstanceConfigurationSummary __instance__ =
-                    new InstanceConfigurationSummary(compartmentId, displayName, id, timeCreated);
+                    new InstanceConfigurationSummary(
+                            compartmentId, displayName, id, timeCreated, definedTags, freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -77,7 +97,9 @@ public class InstanceConfigurationSummary {
                     compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .id(o.getId())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -118,6 +140,27 @@ public class InstanceConfigurationSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePoolSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePoolSummary.java
@@ -96,6 +96,25 @@ public class InstancePoolSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -109,7 +128,9 @@ public class InstancePoolSummary {
                             lifecycleState,
                             availabilityDomains,
                             size,
-                            timeCreated);
+                            timeCreated,
+                            definedTags,
+                            freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -124,7 +145,9 @@ public class InstancePoolSummary {
                             .lifecycleState(o.getLifecycleState())
                             .availabilityDomains(o.getAvailabilityDomains())
                             .size(o.getSize())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -238,6 +261,27 @@ public class InstancePoolSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
@@ -4,9 +4,10 @@
 package com.oracle.bmc.core.model;
 
 /**
- * A *private IP* is a conceptual term that refers to a private IP address and related properties.
+ * A *private IP* is a conceptual term that refers to an IPv4 private IP address and related properties.
  * The `privateIp` object is the API representation of a private IP.
  * <p>
+ *
  * Each instance has a *primary private IP* that is automatically created and
  * assigned to the primary VNIC during instance launch. If you add a secondary
  * VNIC to the instance, it also automatically gets a primary private IP. You

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
@@ -97,6 +97,7 @@ public class RouteRule {
      * A destination IP address range in CIDR notation. Matching packets will
      * be routed to the indicated network entity (the target).
      * <p>
+     *
      * Example: `0.0.0.0/0`
      *
      **/
@@ -112,8 +113,8 @@ public class RouteRule {
      * IP address range in CIDR notation. For example: `192.168.1.0/24`
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
-     *     setting up a route rule for traffic destined for a particular service through
-     *     a service gateway. For example: `oci-phx-objectstorage`
+     *     setting up a route rule for traffic destined for a particular `Service` through
+     *     a service gateway. For example: `oci-phx-objectstorage`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("destination")
@@ -125,7 +126,7 @@ public class RouteRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic destined for a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -178,7 +179,7 @@ public class RouteRule {
      * <p>
      * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
      *     {@link Service} (the rule is for traffic destined for a
-     *     particular service through a service gateway).
+     *     particular `Service` through a service gateway).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("destinationType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Service.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Service.java
@@ -4,7 +4,12 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Information about a service that is accessible through a service gateway.
+ * An object that represents one or multiple Oracle services that you can enable for a
+ * {@link ServiceGateway}. In the User Guide topic
+ * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm), the
+ * term *service CIDR label* is used to refer to the string that represents the regional public
+ * IP address ranges of the Oracle service or services covered by a given `Service` object. That
+ * unique string is the value of the `Service` object's `cidrBlock` attribute.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -89,29 +94,42 @@ public class Service {
     }
 
     /**
-     * A string that represents the public endpoints for the service. When you set up a route rule
-     * to route traffic to the service gateway, use this value as the destination CIDR block for
-     * the rule. See {@link RouteTable}.
+     * A string that represents the regional public IP address ranges for the Oracle service or
+     * services covered by this `Service` object. Also known as the `Service` object's *service
+     * CIDR label*.
+     * <p>
+     * When you set up a route rule to route traffic to the service gateway, use this value as the
+     * rule's destination. See {@link RouteTable}. Also, when you set up
+     * a security list rule to cover traffic with the service gateway, use the `cidrBlock` value
+     * as the rule's destination (for an egress rule) or the source (for an ingress rule).
+     * See {@link SecurityList}.
+     * <p>
+     * Example: `oci-phx-objectstorage`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
     String cidrBlock;
 
     /**
-     * Description of the service.
+     * Description of the Oracle service or services covered by this `Service` object.
+     * <p>
+     * Example: `OCI PHX Object Storage`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The service's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The `Service` object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Name of the service. This name can change and is not guaranteed to be unique.
+     * Name of the `Service` object. This name can change and is not guaranteed to be unique.
+     * <p>
+     * Example: `OCI PHX Object Storage`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceGateway.java
@@ -4,13 +4,13 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Represents a router that connects the edge of a VCN with public Oracle Cloud Infrastructure
- * services such as Object Storage. Traffic leaving the VCN and destined for a supported public
- * service (see {@link #listServices(ListServicesRequest) listServices}) is routed through the
- * service gateway and does not traverse the internet. The instances in the VCN do not need to
- * have public IP addresses nor be in a public subnet. The VCN does not need an internet gateway
+ * Represents a router that lets your VCN privately access specific Oracle services such as Object
+ * Storage without exposing the VCN to the public internet. Traffic leaving the VCN and destined
+ * for a supported Oracle service (see {@link #listServices(ListServicesRequest) listServices}) is
+ * routed through the service gateway and does not traverse the internet. The instances in the VCN
+ * do not need to have public IP addresses nor be in a public subnet. The VCN does not need an internet gateway
  * for this traffic. For more information, see
- * [Access to Object Storage: Service Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm).
+ * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
@@ -222,6 +222,7 @@ public class ServiceGateway {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the service gateway.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -280,9 +281,10 @@ public class ServiceGateway {
     LifecycleState lifecycleState;
 
     /**
-     * List of the services enabled on this service gateway. The list can be empty.
-     * You can enable a particular service by using
-     * {@link #attachServiceId(AttachServiceIdRequest) attachServiceId}.
+     * List of the {@link Service} objects enabled for this service gateway.
+     * The list can be empty. You can enable a particular `Service` by using
+     * {@link #attachServiceId(AttachServiceIdRequest) attachServiceId} or
+     * {@link #updateServiceGateway(UpdateServiceGatewayRequest) updateServiceGateway}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdRequestDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdRequestDetails.java
@@ -59,7 +59,7 @@ public class ServiceIdRequestDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the service.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the {@link Service}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelConfig.java
@@ -4,7 +4,11 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Specific connection details for an IPSec tunnel.
+ * Deprecated. For tunnel information, instead see:
+ * <p>
+ * {@link IPSecConnectionTunnel}
+ *   * {@link IPSecConnectionTunnelSharedSecret}
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -89,7 +93,7 @@ public class TunnelConfig {
     /**
      * The shared secret of the IPSec tunnel.
      * <p>
-     * Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+     * Example: `EXAMPLEToUis6j1c.p8G.dVQxcmdfMO0yXMLi.lZTbYCMDGu4V8o`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelStatus.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/TunnelStatus.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Specific connection details for an IPSec tunnel.
+ * Deprecated. For tunnel information, instead see {@link IPSecConnectionTunnel}.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeKmsKeyDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeKmsKeyDetails.java
@@ -60,10 +60,9 @@ public class UpdateBootVolumeKmsKeyDetails {
     }
 
     /**
-     * The new kms key which will be used to protect the specific volume.
-     * This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-     * Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-     * Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+     * The OCID of the new KMS key which will be used to protect the specified volume.
+     * This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+     * Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionTunnelDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionTunnelDetails.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Details to modify an IPSecConnection Tunnel paramaters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateIPSecConnectionTunnelDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateIPSecConnectionTunnelDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("routing")
+        private Routing routing;
+
+        public Builder routing(Routing routing) {
+            this.routing = routing;
+            this.__explicitlySet__.add("routing");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionConfig")
+        private UpdateIPSecTunnelBgpSessionDetails bgpSessionConfig;
+
+        public Builder bgpSessionConfig(UpdateIPSecTunnelBgpSessionDetails bgpSessionConfig) {
+            this.bgpSessionConfig = bgpSessionConfig;
+            this.__explicitlySet__.add("bgpSessionConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateIPSecConnectionTunnelDetails build() {
+            UpdateIPSecConnectionTunnelDetails __instance__ =
+                    new UpdateIPSecConnectionTunnelDetails(displayName, routing, bgpSessionConfig);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateIPSecConnectionTunnelDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .routing(o.getRouting())
+                            .bgpSessionConfig(o.getBgpSessionConfig());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable. Avoid
+     * entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP.
+     *
+     **/
+    public enum Routing {
+        Bgp("BGP"),
+        Static("STATIC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Routing> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Routing v : Routing.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Routing(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Routing create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid Routing: " + key);
+        }
+    };
+    /**
+     * the routing strategy used for this tunnel, either static route or BGP.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routing")
+    Routing routing;
+
+    /**
+     * Information needed to establish a BGP Session on an interface.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bgpSessionConfig")
+    UpdateIPSecTunnelBgpSessionDetails bgpSessionConfig;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionTunnelSharedSecretDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionTunnelSharedSecretDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateIPSecConnectionTunnelSharedSecretDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateIPSecConnectionTunnelSharedSecretDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+        private String sharedSecret;
+
+        public Builder sharedSecret(String sharedSecret) {
+            this.sharedSecret = sharedSecret;
+            this.__explicitlySet__.add("sharedSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateIPSecConnectionTunnelSharedSecretDetails build() {
+            UpdateIPSecConnectionTunnelSharedSecretDetails __instance__ =
+                    new UpdateIPSecConnectionTunnelSharedSecretDetails(sharedSecret);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateIPSecConnectionTunnelSharedSecretDetails o) {
+            Builder copiedBuilder = sharedSecret(o.getSharedSecret());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shared secret of the IPSec tunnel.
+     * <p>
+     * Example: `vFG2IF6TWq4UToUiLSRDoJEUs6j1c.p8G.dVQxiMfMO0yXMLi.lZTbYIWhGu4V8o`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sharedSecret")
+    String sharedSecret;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecTunnelBgpSessionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecTunnelBgpSessionDetails.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Details to modify an IPSec Tunnel's BGP session paramaters.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateIPSecTunnelBgpSessionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateIPSecTunnelBgpSessionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+        private String oracleInterfaceIp;
+
+        public Builder oracleInterfaceIp(String oracleInterfaceIp) {
+            this.oracleInterfaceIp = oracleInterfaceIp;
+            this.__explicitlySet__.add("oracleInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+        private String customerInterfaceIp;
+
+        public Builder customerInterfaceIp(String customerInterfaceIp) {
+            this.customerInterfaceIp = customerInterfaceIp;
+            this.__explicitlySet__.add("customerInterfaceIp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+        private String customerBgpAsn;
+
+        public Builder customerBgpAsn(String customerBgpAsn) {
+            this.customerBgpAsn = customerBgpAsn;
+            this.__explicitlySet__.add("customerBgpAsn");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateIPSecTunnelBgpSessionDetails build() {
+            UpdateIPSecTunnelBgpSessionDetails __instance__ =
+                    new UpdateIPSecTunnelBgpSessionDetails(
+                            oracleInterfaceIp, customerInterfaceIp, customerBgpAsn);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateIPSecTunnelBgpSessionDetails o) {
+            Builder copiedBuilder =
+                    oracleInterfaceIp(o.getOracleInterfaceIp())
+                            .customerInterfaceIp(o.getCustomerInterfaceIp())
+                            .customerBgpAsn(o.getCustomerBgpAsn());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The IPv4 Address used in the BGP peering session for the Oracle router. Example: 10.0.0.1/31.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oracleInterfaceIp")
+    String oracleInterfaceIp;
+
+    /**
+     * The IPv4 Address used in the BGP peering session for the non-Oracle router. Example: 10.0.0.2/31.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerInterfaceIp")
+    String customerInterfaceIp;
+
+    /**
+     * The value of the remote BGP ASN in asplain format, as a string. Example: 1587232876 (4 byte ASN) or 12345 (2 byte ASN).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerBgpAsn")
+    String customerBgpAsn;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstancePoolDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstancePoolDetails.java
@@ -154,8 +154,12 @@ public class UpdateInstancePoolDetails {
     String instanceConfigurationId;
 
     /**
-     * The placement configurations for the instance pool.
-     * There should be 1 placement configuration for each desired AD.
+     * The placement configurations for the instance pool. Provide one placement configuration for
+     * each availability domain.
+     * <p>
+     * To use the instance pool with a regional subnet, provide a placement configuration for
+     * each availability domain, and include the regional subnet in each placement
+     * configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("placementConfigurations")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateServiceGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateServiceGatewayDetails.java
@@ -142,16 +142,16 @@ public class UpdateServiceGatewayDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * List of all the services you want enabled on this service gateway. Sending an empty list
+     * List of all the `Service` objects you want enabled on this service gateway. Sending an empty list
      * means you want to disable all services. Omitting this parameter entirely keeps the
      * existing list of services intact.
      * <p>
-     * You can also enable or disable a particular service by using
-     * {@link #attachServiceId(AttachServiceIdRequest) attachServiceId} and
+     * You can also enable or disable a particular `Service` by using
+     * {@link #attachServiceId(AttachServiceIdRequest) attachServiceId} or
      * {@link #detachServiceId(DetachServiceIdRequest) detachServiceId}.
      * <p>
-     * For each enabled service, make sure there's a route rule with the service's `cidrBlock`
-     * as the rule's destination CIDR and the service gateway as the rule's target. See
+     * For each enabled `Service`, make sure there's a route rule with the `Service` object's `cidrBlock`
+     * as the rule's destination and the service gateway as the rule's target. See
      * {@link RouteTable}.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeKmsKeyDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeKmsKeyDetails.java
@@ -59,10 +59,9 @@ public class UpdateVolumeKmsKeyDetails {
     }
 
     /**
-     * The new kms key which will be used to protect the specific volume.
-     * This key has to be a valid kms key ocid, and user must have key delegation policy to allow them to access this key.
-     * Even if this new kms key is the same as the previous kms key id, block storage service will use it to regenerate a new volume encryption key.
-     * Example: `{\"kmsKeyId\": \"ocid1.key.region1.sea.afnl2n7daag4s.abzwkljs6uevhlgcznhmh7oiatyrxngrywc3tje3uk3g77hzmewqiieuk75f\"}`
+     * The OCID of the new KMS key which will be used to protect the specified volume.
+     * This key has to be a valid KMS key OCID, and the user must have key delegation policy to allow them to access this key.
+     * Even if the new KMS key is the same as the previous KMS key ID, the Block Volume service will use it to regenerate a new volume encryption key.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeKmsKey.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeKmsKey.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Kms key id associated with this volume.
+ * The KMS key OCID associated with this volume.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -58,7 +58,7 @@ public class VolumeKmsKey {
     }
 
     /**
-     * Kms key id associated with this volume. If volume is not using KMS, then kmsKeyId will be null string.
+     * The KMS key OCID associated with this volume. If the volume is not using KMS, then the `kmsKeyId` will be a null string.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateInstancePoolRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateInstancePoolRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.core.model.*;
 public class CreateInstancePoolRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * Instance Pool creation details
+     * Instance pool creation details
      */
     private CreateInstancePoolDetails createInstancePoolDetails;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelRequest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetIPSecConnectionTunnelRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the IPSec connection.
+     */
+    private String ipscId;
+
+    /**
+     * The OCID of the IPSec connection's tunnel.
+     */
+    private String tunnelId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetIPSecConnectionTunnelRequest o) {
+            ipscId(o.getIpscId());
+            tunnelId(o.getTunnelId());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetIPSecConnectionTunnelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetIPSecConnectionTunnelRequest
+         */
+        public GetIPSecConnectionTunnelRequest build() {
+            GetIPSecConnectionTunnelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelSharedSecretRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelSharedSecretRequest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetIPSecConnectionTunnelSharedSecretRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the IPSec connection.
+     */
+    private String ipscId;
+
+    /**
+     * The OCID of the IPSec connection's tunnel.
+     */
+    private String tunnelId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetIPSecConnectionTunnelSharedSecretRequest o) {
+            ipscId(o.getIpscId());
+            tunnelId(o.getTunnelId());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetIPSecConnectionTunnelSharedSecretRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetIPSecConnectionTunnelSharedSecretRequest
+         */
+        public GetIPSecConnectionTunnelSharedSecretRequest build() {
+            GetIPSecConnectionTunnelSharedSecretRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListIPSecConnectionTunnelsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListIPSecConnectionTunnelsRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListIPSecConnectionTunnelsRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the IPSec connection.
+     */
+    private String ipscId;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListIPSecConnectionTunnelsRequest o) {
+            ipscId(o.getIpscId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListIPSecConnectionTunnelsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListIPSecConnectionTunnelsRequest
+         */
+        public ListIPSecConnectionTunnelsRequest build() {
+            ListIPSecConnectionTunnelsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateBootVolumeKmsKeyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateBootVolumeKmsKeyRequest.java
@@ -16,7 +16,7 @@ public class UpdateBootVolumeKmsKeyRequest extends com.oracle.bmc.requests.BmcRe
     private String bootVolumeId;
 
     /**
-     * Update kms key id for the specific boot volume.
+     * Updates the KMS key ID for the specified boot volume.
      */
     private UpdateBootVolumeKmsKeyDetails updateBootVolumeKmsKeyDetails;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelRequest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateIPSecConnectionTunnelRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the IPSec connection.
+     */
+    private String ipscId;
+
+    /**
+     * The OCID of the IPSec connection's tunnel.
+     */
+    private String tunnelId;
+
+    /**
+     * Details object for updating a IPSecConnection tunnel's details.
+     */
+    private UpdateIPSecConnectionTunnelDetails updateIPSecConnectionTunnelDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateIPSecConnectionTunnelRequest o) {
+            ipscId(o.getIpscId());
+            tunnelId(o.getTunnelId());
+            updateIPSecConnectionTunnelDetails(o.getUpdateIPSecConnectionTunnelDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateIPSecConnectionTunnelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateIPSecConnectionTunnelRequest
+         */
+        public UpdateIPSecConnectionTunnelRequest build() {
+            UpdateIPSecConnectionTunnelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelSharedSecretRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelSharedSecretRequest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateIPSecConnectionTunnelSharedSecretRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the IPSec connection.
+     */
+    private String ipscId;
+
+    /**
+     * The OCID of the IPSec connection's tunnel.
+     */
+    private String tunnelId;
+
+    /**
+     * Details object for updating a IPSec connection tunnel's sharedSecret.
+     */
+    private UpdateIPSecConnectionTunnelSharedSecretDetails
+            updateIPSecConnectionTunnelSharedSecretDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateIPSecConnectionTunnelSharedSecretRequest o) {
+            ipscId(o.getIpscId());
+            tunnelId(o.getTunnelId());
+            updateIPSecConnectionTunnelSharedSecretDetails(
+                    o.getUpdateIPSecConnectionTunnelSharedSecretDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateIPSecConnectionTunnelSharedSecretRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateIPSecConnectionTunnelSharedSecretRequest
+         */
+        public UpdateIPSecConnectionTunnelSharedSecretRequest build() {
+            UpdateIPSecConnectionTunnelSharedSecretRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeKmsKeyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeKmsKeyRequest.java
@@ -16,7 +16,7 @@ public class UpdateVolumeKmsKeyRequest extends com.oracle.bmc.requests.BmcReques
     private String volumeId;
 
     /**
-     * Update kms key id for the specific volume.
+     * Update the KMS key ID for the specified volume.
      */
     private UpdateVolumeKmsKeyDetails updateVolumeKmsKeyDetails;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetIPSecConnectionTunnelResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetIPSecConnectionTunnelResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetIPSecConnectionTunnelResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned IPSecConnectionTunnel instance.
+     */
+    private IPSecConnectionTunnel iPSecConnectionTunnel;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetIPSecConnectionTunnelResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            iPSecConnectionTunnel(o.getIPSecConnectionTunnel());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetIPSecConnectionTunnelSharedSecretResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetIPSecConnectionTunnelSharedSecretResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetIPSecConnectionTunnelSharedSecretResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned IPSecConnectionTunnelSharedSecret instance.
+     */
+    private IPSecConnectionTunnelSharedSecret iPSecConnectionTunnelSharedSecret;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetIPSecConnectionTunnelSharedSecretResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            iPSecConnectionTunnelSharedSecret(o.getIPSecConnectionTunnelSharedSecret());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListIPSecConnectionTunnelsResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListIPSecConnectionTunnelsResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListIPSecConnectionTunnelsResponse {
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of
+     * results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of IPSecConnectionTunnel instances.
+     */
+    private java.util.List<IPSecConnectionTunnel> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListIPSecConnectionTunnelsResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateIPSecConnectionTunnelResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateIPSecConnectionTunnelResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateIPSecConnectionTunnelResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned IPSecConnectionTunnel instance.
+     */
+    private IPSecConnectionTunnel iPSecConnectionTunnel;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateIPSecConnectionTunnelResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            iPSecConnectionTunnel(o.getIPSecConnectionTunnel());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateIPSecConnectionTunnelSharedSecretResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateIPSecConnectionTunnelSharedSecretResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateIPSecConnectionTunnelSharedSecretResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned IPSecConnectionTunnelSharedSecret instance.
+     */
+    private IPSecConnectionTunnelSharedSecret iPSecConnectionTunnelSharedSecret;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateIPSecConnectionTunnelSharedSecretResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            iPSecConnectionTunnelSharedSecret(o.getIPSecConnectionTunnelSharedSecret());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/ObjectStorageGetNamespaceExample.java
+++ b/bmc-examples/src/main/java/ObjectStorageGetNamespaceExample.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+
+/**
+ * This class provides a basic example of how to get Object Storage namespace of a tenancy that is not their own. This
+ * is useful in cross-tenant Object Storage operations. Object Storage namespace can be retrieved using the
+ * compartment id of the target tenancy if the user has necessary permissions to access that tenancy.
+ *
+ * For example if Tenant A wants to access Tenant B's object storage namespace then Tenant A has to define
+ * a policy similar to following:
+ *
+ * DEFINE TENANCY TenantB AS <TenantB OCID>
+ * ENDORSE GROUP <TenantA user group OCID> TO {TENANCY_INSPECT} IN TENANCY TenantB
+ *
+ * and Tenant B should add a policy similar to following:
+ *
+ * DEFINE TENANCY TenantA AS <TenantA OCID>
+ * DEFINE GROUP TenantAGroup AS <TenantA user group OCID>
+ * ADMIT GROUP TenantAGroup OF TENANCY TenantA TO {TENANCY_INSPECT} IN TENANCY
+ *
+ * This example covers only GetNamespace operation across tenants. Additional permissions will be required to
+ * perform more Object Storage operations.
+ *
+ */
+public class ObjectStorageGetNamespaceExample {
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     * <ul>
+     *   <li>The first argument is the OCID of the compartment for which we will get the namespace</li>
+     * </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new IllegalArgumentException(
+                    "Unexpected number of arguments received. Consult the script header comments for expected arguments");
+        }
+
+        final String compartmentId = args[0];
+
+        final ConfigFileReader.ConfigFile configFile =
+                ConfigFileReader.parse(CONFIG_LOCATION, CONFIG_PROFILE);
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+        ObjectStorageClient objectStorageClient = new ObjectStorageClient(provider);
+        objectStorageClient.setRegion(Region.US_PHOENIX_1);
+
+        // Construct GetNamespaceRequest with the given compartmentId.
+        GetNamespaceRequest getNamespaceRequest =
+                GetNamespaceRequest.builder().compartmentId(compartmentId).build();
+        String namespace = objectStorageClient.getNamespace(getNamespaceRequest).getValue();
+
+        System.out.println(
+                String.format(
+                        "Object Storage namespace for compartment [%s] is [%s]",
+                        compartmentId,
+                        namespace));
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
@@ -155,6 +155,8 @@ public interface ObjectStorage extends AutoCloseable {
      * the tenancy name in all lower-case letters. You cannot edit a namespace.
      * <p>
      * GetNamespace returns the name of the Object Storage namespace for the user making the request.
+     * If an optional compartmentId query parameter is provided, GetNamespace returns the namespace name of the corresponding
+     * tenancy, provided the user has access to it.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
@@ -245,6 +245,8 @@ public interface ObjectStorageAsync extends AutoCloseable {
      * the tenancy name in all lower-case letters. You cannot edit a namespace.
      * <p>
      * GetNamespace returns the name of the Object Storage namespace for the user making the request.
+     * If an optional compartmentId query parameter is provided, GetNamespace returns the namespace name of the corresponding
+     * tenancy, provided the user has access to it.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
@@ -31,6 +31,7 @@ public class ObjectStorageAsyncClient implements ObjectStorageAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("OBJECTSTORAGE")
                     .serviceEndpointPrefix("objectstorage")
+                    .serviceEndpointTemplate("https://objectstorage.{region}.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
@@ -18,6 +18,7 @@ public class ObjectStorageClient implements ObjectStorage {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("OBJECTSTORAGE")
                     .serviceEndpointPrefix("objectstorage")
+                    .serviceEndpointTemplate("https://objectstorage.{region}.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/GetNamespaceConverter.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/GetNamespaceConverter.java
@@ -27,6 +27,14 @@ public class GetNamespaceConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/").path("n");
 
+        if (request.getCompartmentId() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetNamespaceRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetNamespaceRequest.java
@@ -15,6 +15,13 @@ public class GetNamespaceRequest extends com.oracle.bmc.requests.BmcRequest {
      */
     private String opcClientRequestId;
 
+    /**
+     * This is an optional field representing the tenancy OCID or the compartment OCID within the tenancy whose Object Storage namespace
+     * name has to be retrieved.
+     *
+     */
+    private String compartmentId;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -37,6 +44,7 @@ public class GetNamespaceRequest extends com.oracle.bmc.requests.BmcRequest {
          */
         public Builder copy(GetNamespaceRequest o) {
             opcClientRequestId(o.getOpcClientRequestId());
+            compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             return this;
         }

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/PutObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/PutObjectRequest.java
@@ -65,7 +65,12 @@ public class PutObjectRequest extends com.oracle.bmc.requests.BmcRequest {
     private String expect;
 
     /**
-     * The base-64 encoded MD5 hash of the body.
+     * The base-64 encoded MD5 hash of the body. If the Content-MD5 header is present, Object Storage performs an integrity check
+     * on the body of the HTTP request by computing the MD5 hash for the body and comparing it to the MD5 hash supplied in the header.
+     * If the two hashes do not match, the object is rejected and an HTTP-400 Unmatched Content MD5 error is returned with the message:
+     * <p>
+     * \"The computed MD5 of the request body (ACTUAL_MD5) does not match the Content-MD5 header (HEADER_MD5)\"
+     *
      */
     private String contentMD5;
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/UploadPartRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/UploadPartRequest.java
@@ -75,7 +75,12 @@ public class UploadPartRequest extends com.oracle.bmc.requests.BmcRequest {
     private String expect;
 
     /**
-     * The base-64 encoded MD5 hash of the body.
+     * The base-64 encoded MD5 hash of the body. If the Content-MD5 header is present, Object Storage performs an integrity check
+     * on the body of the HTTP request by computing the MD5 hash for the body and comparing it to the MD5 hash supplied in the header.
+     * If the two hashes do not match, the object is rejected and an HTTP-400 Unmatched Content MD5 error is returned with the message:
+     * <p>
+     * \"The computed MD5 of the request body (ACTUAL_MD5) does not match the Content-MD5 header (HEADER_MD5)\"
+     *
      */
     private String contentMD5;
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.5</version>
+    <version>1.5.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.5.5</version>
+  <version>1.5.6</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -286,7 +286,7 @@
           <configuration>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java17</artifactId>
+              <artifactId>java18</artifactId>
               <version>1.0</version>
             </signature>
           </configuration>


### PR DESCRIPTION
### Added

- Support for returning tags when listing instance configurations, instance pools, or autoscaling configurations in the Compute Autoscaling service

- Support for getting the namespace of another tenancy than the caller's tenancy in the Object Storage service

- Support for BGP dynamic routing and providing pre-shared secrets (PSKs) when establishing tunnels in the Networking service
