### PR TITLE
Releasing version 1.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.5.12 - 2019-07-02
+### Added
+- Support for moving images, instance configurations, and instance pools across compartments in Core Services
+- Support for moving autoscaling configurations across compartments in the Compute Autoscaling service
+
+### Fixed
+- Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
+
 ## 1.5.11 - 2019-06-25
 ### Added
 - Support for moving senders across compartments in the Email service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-apache-connector-provider/src/main/java/com/oracle/bmc/http/ApacheConfigurator.java
+++ b/bmc-addons/bmc-apache-connector-provider/src/main/java/com/oracle/bmc/http/ApacheConfigurator.java
@@ -5,6 +5,8 @@ package com.oracle.bmc.http;
 
 import com.oracle.bmc.http.internal.ContentLengthFilter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.config.RequestConfig;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -58,9 +60,14 @@ public class ApacheConfigurator implements ClientConfigurator {
     }
 
     protected void setConnectorProvider(ClientBuilder builder) {
-        LOG.info("Setting connector provider to ApacheConnectorProviders");
+        LOG.info("Setting connector provider to ApacheConnectorProvider");
 
         final ClientConfig clientConfig = new ClientConfig();
+        // Disable the default behavior to auto compress and deflate the request/response content based on the
+        // content-encoding.
+        final RequestConfig requestConfig =
+                RequestConfig.custom().setContentCompressionEnabled(false).build();
+        clientConfig.property(ApacheClientProperties.REQUEST_CONFIG, requestConfig);
         clientConfig.connectorProvider(new ApacheConnectorProvider());
 
         // Decorate config with any configured client config decorators

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScaling.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScaling.java
@@ -37,6 +37,21 @@ public interface AutoScaling extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves an autoscaling configuration into a different compartment within the same tenancy. For information
+     * about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     * When you move an autoscaling configuration to a different compartment, associated resources such as instance
+     * pools are not moved.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeAutoScalingConfigurationCompartmentResponse changeAutoScalingConfigurationCompartment(
+            ChangeAutoScalingConfigurationCompartmentRequest request);
+
+    /**
      * Creates an autoscaling configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsync.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsync.java
@@ -37,6 +37,30 @@ public interface AutoScalingAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves an autoscaling configuration into a different compartment within the same tenancy. For information
+     * about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     * When you move an autoscaling configuration to a different compartment, associated resources such as instance
+     * pools are not moved.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeAutoScalingConfigurationCompartmentResponse>
+            changeAutoScalingConfigurationCompartment(
+                    ChangeAutoScalingConfigurationCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeAutoScalingConfigurationCompartmentRequest,
+                                    ChangeAutoScalingConfigurationCompartmentResponse>
+                            handler);
+
+    /**
      * Creates an autoscaling configuration.
      *
      * @param request The request object containing the details to send

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsyncClient.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingAsyncClient.java
@@ -303,6 +303,103 @@ public class AutoScalingAsyncClient implements AutoScalingAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeAutoScalingConfigurationCompartmentResponse>
+            changeAutoScalingConfigurationCompartment(
+                    final ChangeAutoScalingConfigurationCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeAutoScalingConfigurationCompartmentRequest,
+                                    ChangeAutoScalingConfigurationCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeAutoScalingConfigurationCompartment");
+        final ChangeAutoScalingConfigurationCompartmentRequest interceptedRequest =
+                ChangeAutoScalingConfigurationCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeAutoScalingConfigurationCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeAutoScalingConfigurationCompartmentResponse>
+                transformer = ChangeAutoScalingConfigurationCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeAutoScalingConfigurationCompartmentRequest,
+                        ChangeAutoScalingConfigurationCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeAutoScalingConfigurationCompartmentRequest,
+                            ChangeAutoScalingConfigurationCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeAutoScalingConfigurationCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateAutoScalingConfigurationResponse>
             createAutoScalingConfiguration(
                     final CreateAutoScalingConfigurationRequest request,

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingClient.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/AutoScalingClient.java
@@ -306,6 +306,43 @@ public class AutoScalingClient implements AutoScaling {
     }
 
     @Override
+    public ChangeAutoScalingConfigurationCompartmentResponse
+            changeAutoScalingConfigurationCompartment(
+                    ChangeAutoScalingConfigurationCompartmentRequest request) {
+        LOG.trace("Called changeAutoScalingConfigurationCompartment");
+        final ChangeAutoScalingConfigurationCompartmentRequest interceptedRequest =
+                ChangeAutoScalingConfigurationCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeAutoScalingConfigurationCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeAutoScalingConfigurationCompartmentResponse>
+                transformer = ChangeAutoScalingConfigurationCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateAutoScalingConfigurationResponse createAutoScalingConfiguration(
             CreateAutoScalingConfigurationRequest request) {
         LOG.trace("Called createAutoScalingConfiguration");

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/internal/http/ChangeAutoScalingConfigurationCompartmentConverter.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/internal/http/ChangeAutoScalingConfigurationCompartmentConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.autoscaling.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.autoscaling.model.*;
+import com.oracle.bmc.autoscaling.requests.*;
+import com.oracle.bmc.autoscaling.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.extern.slf4j.Slf4j
+public class ChangeAutoScalingConfigurationCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeAutoScalingConfigurationCompartmentRequest interceptRequest(
+            ChangeAutoScalingConfigurationCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeAutoScalingConfigurationCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutoScalingConfigurationId(),
+                "autoScalingConfigurationId must not be blank");
+        Validate.notNull(
+                request.getChangeCompartmentDetails(), "changeCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181001")
+                        .path("autoScalingConfigurations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutoScalingConfigurationId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeAutoScalingConfigurationCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeAutoScalingConfigurationCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ChangeAutoScalingConfigurationCompartmentResponse>() {
+                            @Override
+                            public ChangeAutoScalingConfigurationCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeAutoScalingConfigurationCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeAutoScalingConfigurationCompartmentResponse.Builder builder =
+                                        ChangeAutoScalingConfigurationCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeAutoScalingConfigurationCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ChangeAutoScalingCompartmentDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ChangeAutoScalingCompartmentDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ * The configuration details for the move operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeAutoScalingCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeAutoScalingCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeAutoScalingCompartmentDetails build() {
+            ChangeAutoScalingCompartmentDetails __instance__ =
+                    new ChangeAutoScalingCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeAutoScalingCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the autoscaling configuration to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingConfigurationDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingConfigurationDetails.java
@@ -142,7 +142,6 @@ public class CreateAutoScalingConfigurationDetails {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the autoscaling configuration.
-     * The autoscaling configuration and the instance pool that it manages must be in the same compartment.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ChangeAutoScalingConfigurationCompartmentRequest.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/requests/ChangeAutoScalingConfigurationCompartmentRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.autoscaling.requests;
+
+import com.oracle.bmc.autoscaling.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeAutoScalingConfigurationCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the autoscaling configuration.
+     */
+    private String autoScalingConfigurationId;
+
+    /**
+     * Request to change the compartment of given autoscaling configuration.
+     */
+    private ChangeAutoScalingCompartmentDetails changeCompartmentDetails;
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeAutoScalingConfigurationCompartmentRequest o) {
+            autoScalingConfigurationId(o.getAutoScalingConfigurationId());
+            changeCompartmentDetails(o.getChangeCompartmentDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeAutoScalingConfigurationCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeAutoScalingConfigurationCompartmentRequest
+         */
+        public ChangeAutoScalingConfigurationCompartmentRequest build() {
+            ChangeAutoScalingConfigurationCompartmentRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ChangeAutoScalingConfigurationCompartmentResponse.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/responses/ChangeAutoScalingConfigurationCompartmentResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.autoscaling.responses;
+
+import com.oracle.bmc.autoscaling.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeAutoScalingConfigurationCompartmentResponse {
+
+    /**
+     * The resulting etag of the autoscaling configuration affected by this operation.
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeAutoScalingConfigurationCompartmentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,151 +19,151 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
@@ -92,6 +92,17 @@ public interface Compute extends AutoCloseable {
     CaptureConsoleHistoryResponse captureConsoleHistory(CaptureConsoleHistoryRequest request);
 
     /**
+     * Moves an image into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeImageCompartmentResponse changeImageCompartment(ChangeImageCompartmentRequest request);
+
+    /**
      * Create a subscription for listing resource version for a compartment. It will take some time to propagate to all regions.
      *
      * @param request The request object containing the details to send

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
@@ -119,6 +119,25 @@ public interface ComputeAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Moves an image into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeImageCompartmentResponse> changeImageCompartment(
+            ChangeImageCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeImageCompartmentRequest, ChangeImageCompartmentResponse>
+                    handler);
+
+    /**
      * Create a subscription for listing resource version for a compartment. It will take some time to propagate to all regions.
      *
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
@@ -658,6 +658,97 @@ public class ComputeAsyncClient implements ComputeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeImageCompartmentResponse> changeImageCompartment(
+            final ChangeImageCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeImageCompartmentRequest, ChangeImageCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeImageCompartment");
+        final ChangeImageCompartmentRequest interceptedRequest =
+                ChangeImageCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeImageCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeImageCompartmentResponse>
+                transformer = ChangeImageCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeImageCompartmentRequest, ChangeImageCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeImageCompartmentRequest, ChangeImageCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeImageCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeImageCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeImageCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeImageCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateAppCatalogSubscriptionResponse>
             createAppCatalogSubscription(
                     final CreateAppCatalogSubscriptionRequest request,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
@@ -508,6 +508,39 @@ public class ComputeClient implements Compute {
     }
 
     @Override
+    public ChangeImageCompartmentResponse changeImageCompartment(
+            ChangeImageCompartmentRequest request) {
+        LOG.trace("Called changeImageCompartment");
+        final ChangeImageCompartmentRequest interceptedRequest =
+                ChangeImageCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeImageCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ChangeImageCompartmentResponse>
+                transformer = ChangeImageCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeImageCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateAppCatalogSubscriptionResponse createAppCatalogSubscription(
             CreateAppCatalogSubscriptionRequest request) {
         LOG.trace("Called createAppCatalogSubscription");

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagement.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagement.java
@@ -47,6 +47,40 @@ public interface ComputeManagement extends AutoCloseable {
     AttachLoadBalancerResponse attachLoadBalancer(AttachLoadBalancerRequest request);
 
     /**
+     * Moves an instance configuration into a different compartment within the same tenancy.
+     * For information about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     **Important:** Most of the properties for an existing instance configuration, including the compartment,
+     * cannot be modified after you create the instance configuration. Although you can move an instance configuration
+     * to a different compartment, you will not be able to use the instance configuration to manage instance pools
+     * in the new compartment. If you want to update an instance configuration to point to a different compartment,
+     * you should instead create a new instance configuration in the target compartment using
+     * [CreateInstanceConfiguration](https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/InstanceConfiguration/CreateInstanceConfiguration).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeInstanceConfigurationCompartmentResponse changeInstanceConfigurationCompartment(
+            ChangeInstanceConfigurationCompartmentRequest request);
+
+    /**
+     * Moves an instance pool into a different compartment within the same tenancy. For
+     * information about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     * When you move an instance pool to a different compartment, associated resources such as the instances in
+     * the pool, boot volumes, VNICs, and autoscaling configurations are not moved.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeInstancePoolCompartmentResponse changeInstancePoolCompartment(
+            ChangeInstancePoolCompartmentRequest request);
+
+    /**
      * Creates an instance configuration
      *
      * @param request The request object containing the details to send

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementAsync.java
@@ -54,6 +54,58 @@ public interface ComputeManagementAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Moves an instance configuration into a different compartment within the same tenancy.
+     * For information about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     **Important:** Most of the properties for an existing instance configuration, including the compartment,
+     * cannot be modified after you create the instance configuration. Although you can move an instance configuration
+     * to a different compartment, you will not be able to use the instance configuration to manage instance pools
+     * in the new compartment. If you want to update an instance configuration to point to a different compartment,
+     * you should instead create a new instance configuration in the target compartment using
+     * [CreateInstanceConfiguration](https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/InstanceConfiguration/CreateInstanceConfiguration).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeInstanceConfigurationCompartmentResponse>
+            changeInstanceConfigurationCompartment(
+                    ChangeInstanceConfigurationCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeInstanceConfigurationCompartmentRequest,
+                                    ChangeInstanceConfigurationCompartmentResponse>
+                            handler);
+
+    /**
+     * Moves an instance pool into a different compartment within the same tenancy. For
+     * information about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     * <p>
+     * When you move an instance pool to a different compartment, associated resources such as the instances in
+     * the pool, boot volumes, VNICs, and autoscaling configurations are not moved.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeInstancePoolCompartmentResponse>
+            changeInstancePoolCompartment(
+                    ChangeInstancePoolCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeInstancePoolCompartmentRequest,
+                                    ChangeInstancePoolCompartmentResponse>
+                            handler);
+
+    /**
      * Creates an instance configuration
      *
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementAsyncClient.java
@@ -393,6 +393,198 @@ public class ComputeManagementAsyncClient implements ComputeManagementAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeInstanceConfigurationCompartmentResponse>
+            changeInstanceConfigurationCompartment(
+                    final ChangeInstanceConfigurationCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeInstanceConfigurationCompartmentRequest,
+                                    ChangeInstanceConfigurationCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeInstanceConfigurationCompartment");
+        final ChangeInstanceConfigurationCompartmentRequest interceptedRequest =
+                ChangeInstanceConfigurationCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeInstanceConfigurationCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstanceConfigurationCompartmentResponse>
+                transformer = ChangeInstanceConfigurationCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeInstanceConfigurationCompartmentRequest,
+                        ChangeInstanceConfigurationCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeInstanceConfigurationCompartmentRequest,
+                            ChangeInstanceConfigurationCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeInstanceConfigurationCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeInstanceConfigurationCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeInstanceConfigurationCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeInstanceConfigurationCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeInstancePoolCompartmentResponse>
+            changeInstancePoolCompartment(
+                    final ChangeInstancePoolCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeInstancePoolCompartmentRequest,
+                                    ChangeInstancePoolCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeInstancePoolCompartment");
+        final ChangeInstancePoolCompartmentRequest interceptedRequest =
+                ChangeInstancePoolCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeInstancePoolCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstancePoolCompartmentResponse>
+                transformer = ChangeInstancePoolCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeInstancePoolCompartmentRequest, ChangeInstancePoolCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeInstancePoolCompartmentRequest,
+                            ChangeInstancePoolCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeInstancePoolCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeInstancePoolCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeInstancePoolCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeInstancePoolCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateInstanceConfigurationResponse>
             createInstanceConfiguration(
                     final CreateInstanceConfigurationRequest request,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeManagementClient.java
@@ -412,6 +412,77 @@ public class ComputeManagementClient implements ComputeManagement {
     }
 
     @Override
+    public ChangeInstanceConfigurationCompartmentResponse changeInstanceConfigurationCompartment(
+            ChangeInstanceConfigurationCompartmentRequest request) {
+        LOG.trace("Called changeInstanceConfigurationCompartment");
+        final ChangeInstanceConfigurationCompartmentRequest interceptedRequest =
+                ChangeInstanceConfigurationCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeInstanceConfigurationCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstanceConfigurationCompartmentResponse>
+                transformer = ChangeInstanceConfigurationCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeInstanceConfigurationCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangeInstancePoolCompartmentResponse changeInstancePoolCompartment(
+            ChangeInstancePoolCompartmentRequest request) {
+        LOG.trace("Called changeInstancePoolCompartment");
+        final ChangeInstancePoolCompartmentRequest interceptedRequest =
+                ChangeInstancePoolCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeInstancePoolCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstancePoolCompartmentResponse>
+                transformer = ChangeInstancePoolCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeInstancePoolCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateInstanceConfigurationResponse createInstanceConfiguration(
             CreateInstanceConfigurationRequest request) {
         LOG.trace("Called createInstanceConfiguration");

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -82,18 +82,6 @@ public interface VirtualNetwork extends AutoCloseable {
             BulkDeleteVirtualCircuitPublicPrefixesRequest request);
 
     /**
-     * Moves a service gateway into a different compartment within the same tenancy. For information
-     * about moving resources between compartments, see
-     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
-     *
-     * @param request The request object containing the details to send
-     * @return A response object containing details about the completed operation
-     * @throws BmcException when an error occurs.
-     */
-    ChangeServiceGatewayCompartmentResponse changeServiceGatewayCompartment(
-            ChangeServiceGatewayCompartmentRequest request);
-
-    /**
      * Moves a NAT gateway into a different compartment within the same tenancy. For information
      * about moving resources between compartments, see
      * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
@@ -104,6 +92,18 @@ public interface VirtualNetwork extends AutoCloseable {
      */
     ChangeNatGatewayCompartmentResponse changeNatGatewayCompartment(
             ChangeNatGatewayCompartmentRequest request);
+
+    /**
+     * Moves a service gateway into a different compartment within the same tenancy. For information
+     * about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeServiceGatewayCompartmentResponse changeServiceGatewayCompartment(
+            ChangeServiceGatewayCompartmentRequest request);
 
     /**
      * Connects this local peering gateway (LPG) to another one in the same region.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -106,6 +106,25 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Moves a NAT gateway into a different compartment within the same tenancy. For information
+     * about moving resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeNatGatewayCompartmentResponse> changeNatGatewayCompartment(
+            ChangeNatGatewayCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeNatGatewayCompartmentRequest, ChangeNatGatewayCompartmentResponse>
+                    handler);
+
+    /**
      * Moves a service gateway into a different compartment within the same tenancy. For information
      * about moving resources between compartments, see
      * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
@@ -125,25 +144,6 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                                     ChangeServiceGatewayCompartmentRequest,
                                     ChangeServiceGatewayCompartmentResponse>
                             handler);
-
-    /**
-     * Moves a NAT gateway into a different compartment within the same tenancy. For information
-     * about moving resources between compartments, see
-     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
-     *
-     *
-     * @param request The request object containing the details to send
-     * @param handler The request handler to invoke upon completion, may be null.
-     * @return A Future that can be used to get the response if no AsyncHandler was
-     *         provided. Note, if you provide an AsyncHandler and use the Future, some
-     *         types of responses (like java.io.InputStream) may not be able to be read in
-     *         both places as the underlying stream may only be consumed once.
-     */
-    java.util.concurrent.Future<ChangeNatGatewayCompartmentResponse> changeNatGatewayCompartment(
-            ChangeNatGatewayCompartmentRequest request,
-            com.oracle.bmc.responses.AsyncHandler<
-                            ChangeNatGatewayCompartmentRequest, ChangeNatGatewayCompartmentResponse>
-                    handler);
 
     /**
      * Connects this local peering gateway (LPG) to another one in the same region.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
@@ -589,6 +589,100 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeNatGatewayCompartmentResponse>
+            changeNatGatewayCompartment(
+                    final ChangeNatGatewayCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeNatGatewayCompartmentRequest,
+                                    ChangeNatGatewayCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeNatGatewayCompartment");
+        final ChangeNatGatewayCompartmentRequest interceptedRequest =
+                ChangeNatGatewayCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeNatGatewayCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeNatGatewayCompartmentResponse>
+                transformer = ChangeNatGatewayCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeNatGatewayCompartmentRequest, ChangeNatGatewayCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeNatGatewayCompartmentRequest,
+                            ChangeNatGatewayCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeNatGatewayCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeNatGatewayCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeNatGatewayCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeNatGatewayCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeServiceGatewayCompartmentResponse>
             changeServiceGatewayCompartment(
                     final ChangeServiceGatewayCompartmentRequest request,
@@ -672,99 +766,6 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getChangeServiceGatewayCompartmentDetails(),
-                                    interceptedRequest,
-                                    onSuccess,
-                                    onError);
-                        }
-                    });
-        } else {
-            return new com.oracle.bmc.util.internal.TransformingFuture<>(
-                    responseFuture, transformer);
-        }
-    }
-
-    public java.util.concurrent.Future<ChangeNatGatewayCompartmentResponse>
-            changeNatGatewayCompartment(
-                    final ChangeNatGatewayCompartmentRequest request,
-                    final com.oracle.bmc.responses.AsyncHandler<
-                                    ChangeNatGatewayCompartmentRequest,
-                                    ChangeNatGatewayCompartmentResponse>
-                            handler) {
-        LOG.trace("Called async changeNatGatewayCompartment");
-        final ChangeNatGatewayCompartmentRequest interceptedRequest =
-                ChangeNatGatewayCompartmentConverter.interceptRequest(request);
-        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
-                ChangeNatGatewayCompartmentConverter.fromRequest(client, interceptedRequest);
-        final com.google.common.base.Function<
-                        javax.ws.rs.core.Response, ChangeNatGatewayCompartmentResponse>
-                transformer = ChangeNatGatewayCompartmentConverter.fromResponse();
-
-        com.oracle.bmc.responses.AsyncHandler<
-                        ChangeNatGatewayCompartmentRequest, ChangeNatGatewayCompartmentResponse>
-                handlerToUse = handler;
-        if (handler != null
-                && this.authenticationDetailsProvider
-                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
-            handlerToUse =
-                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
-                            ChangeNatGatewayCompartmentRequest,
-                            ChangeNatGatewayCompartmentResponse>(
-                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
-                                    this.authenticationDetailsProvider,
-                            handler) {
-                        @Override
-                        public void retryCall() {
-                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
-                                    onSuccess =
-                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
-                                                    this, transformer, interceptedRequest);
-                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
-                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
-                                            this, interceptedRequest);
-                            client.post(
-                                    ib,
-                                    interceptedRequest.getChangeNatGatewayCompartmentDetails(),
-                                    interceptedRequest,
-                                    onSuccess,
-                                    onError);
-                        }
-                    };
-        }
-
-        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
-                (handler == null)
-                        ? null
-                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
-                                handlerToUse, transformer, interceptedRequest);
-        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
-                (handler == null)
-                        ? null
-                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
-                                handlerToUse, interceptedRequest);
-
-        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
-                client.post(
-                        ib,
-                        interceptedRequest.getChangeNatGatewayCompartmentDetails(),
-                        interceptedRequest,
-                        onSuccess,
-                        onError);
-
-        if (this.authenticationDetailsProvider
-                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
-            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
-                    javax.ws.rs.core.Response, ChangeNatGatewayCompartmentResponse>(
-                    responseFuture,
-                    transformer,
-                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
-                            this.authenticationDetailsProvider,
-                    new com.google.common.base.Supplier<
-                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
-                        @Override
-                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
-                            return client.post(
-                                    ib,
-                                    interceptedRequest.getChangeNatGatewayCompartmentDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
@@ -484,40 +484,6 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
-    public ChangeServiceGatewayCompartmentResponse changeServiceGatewayCompartment(
-            ChangeServiceGatewayCompartmentRequest request) {
-        LOG.trace("Called changeServiceGatewayCompartment");
-        final ChangeServiceGatewayCompartmentRequest interceptedRequest =
-                ChangeServiceGatewayCompartmentConverter.interceptRequest(request);
-        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
-                ChangeServiceGatewayCompartmentConverter.fromRequest(client, interceptedRequest);
-        com.google.common.base.Function<
-                        javax.ws.rs.core.Response, ChangeServiceGatewayCompartmentResponse>
-                transformer = ChangeServiceGatewayCompartmentConverter.fromResponse();
-
-        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
-                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
-        return retrier.execute(
-                interceptedRequest,
-                retryRequest -> {
-                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
-                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
-                                    authenticationDetailsProvider);
-                    return tokenRefreshRetrier.execute(
-                            retryRequest,
-                            retriedRequest -> {
-                                javax.ws.rs.core.Response response =
-                                        client.post(
-                                                ib,
-                                                retriedRequest
-                                                        .getChangeServiceGatewayCompartmentDetails(),
-                                                retriedRequest);
-                                return transformer.apply(response);
-                            });
-                });
-    }
-
     public ChangeNatGatewayCompartmentResponse changeNatGatewayCompartment(
             ChangeNatGatewayCompartmentRequest request) {
         LOG.trace("Called changeNatGatewayCompartment");
@@ -546,6 +512,41 @@ public class VirtualNetworkClient implements VirtualNetwork {
                                                 ib,
                                                 retriedRequest
                                                         .getChangeNatGatewayCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangeServiceGatewayCompartmentResponse changeServiceGatewayCompartment(
+            ChangeServiceGatewayCompartmentRequest request) {
+        LOG.trace("Called changeServiceGatewayCompartment");
+        final ChangeServiceGatewayCompartmentRequest interceptedRequest =
+                ChangeServiceGatewayCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeServiceGatewayCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeServiceGatewayCompartmentResponse>
+                transformer = ChangeServiceGatewayCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeServiceGatewayCompartmentDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeImageCompartmentConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeImageCompartmentConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeImageCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeImageCompartmentRequest interceptRequest(
+            ChangeImageCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ChangeImageCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getImageId(), "imageId must not be blank");
+        Validate.notNull(
+                request.getChangeImageCompartmentDetails(),
+                "changeImageCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("images")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getImageId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeImageCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeImageCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ChangeImageCompartmentResponse>() {
+                            @Override
+                            public ChangeImageCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeImageCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeImageCompartmentResponse.Builder builder =
+                                        ChangeImageCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeImageCompartmentResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeInstanceConfigurationCompartmentConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeInstanceConfigurationCompartmentConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeInstanceConfigurationCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeInstanceConfigurationCompartmentRequest interceptRequest(
+            ChangeInstanceConfigurationCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeInstanceConfigurationCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getInstanceConfigurationId(), "instanceConfigurationId must not be blank");
+        Validate.notNull(
+                request.getChangeInstanceConfigurationCompartmentDetails(),
+                "changeInstanceConfigurationCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("instanceConfigurations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getInstanceConfigurationId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeInstanceConfigurationCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstanceConfigurationCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ChangeInstanceConfigurationCompartmentResponse>() {
+                            @Override
+                            public ChangeInstanceConfigurationCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeInstanceConfigurationCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeInstanceConfigurationCompartmentResponse.Builder builder =
+                                        ChangeInstanceConfigurationCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeInstanceConfigurationCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeInstancePoolCompartmentConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeInstancePoolCompartmentConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeInstancePoolCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeInstancePoolCompartmentRequest interceptRequest(
+            ChangeInstancePoolCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeInstancePoolCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getInstancePoolId(), "instancePoolId must not be blank");
+        Validate.notNull(
+                request.getChangeInstancePoolCompartmentDetails(),
+                "changeInstancePoolCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("instancePools")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getInstancePoolId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeInstancePoolCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeInstancePoolCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ChangeInstancePoolCompartmentResponse>() {
+                            @Override
+                            public ChangeInstancePoolCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeInstancePoolCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeInstancePoolCompartmentResponse.Builder builder =
+                                        ChangeInstancePoolCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeInstancePoolCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeImageCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeImageCompartmentDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The configuration details for the move operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeImageCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeImageCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeImageCompartmentDetails build() {
+            ChangeImageCompartmentDetails __instance__ =
+                    new ChangeImageCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeImageCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the image to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInstanceConfigurationCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInstanceConfigurationCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The configuration details for the move operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeInstanceConfigurationCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeInstanceConfigurationCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeInstanceConfigurationCompartmentDetails build() {
+            ChangeInstanceConfigurationCompartmentDetails __instance__ =
+                    new ChangeInstanceConfigurationCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeInstanceConfigurationCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+     * move the instance configuration to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInstancePoolCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInstancePoolCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The configuration details for the move operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeInstancePoolCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeInstancePoolCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeInstancePoolCompartmentDetails build() {
+            ChangeInstancePoolCompartmentDetails __instance__ =
+                    new ChangeInstancePoolCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeInstancePoolCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+     * move the instance pool to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
@@ -422,7 +422,8 @@ public class Image {
     InstanceAgentFeatures agentFeatures;
 
     /**
-     * Image size (1 MB = 1048576 bytes)
+     * The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+     * Note this is not the same as the size of the image when it was exported or the actual size of the image.
      * <p>
      * Example: `47694`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfiguration.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfiguration.java
@@ -4,7 +4,9 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Instance Configuration
+ * An instance configuration is a template that defines the settings to use when creating Compute instances
+ * as part of an instance pool. For more information about instance pools and instance configurations, see
+ * [Managing Compute Instances](https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationInstanceSourceViaImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationInstanceSourceViaImageDetails.java
@@ -86,7 +86,7 @@ public class InstanceConfigurationInstanceSourceViaImageDetails
     }
 
     /**
-     * The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+     * The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeSizeInGBs")
     Long bootVolumeSizeInGBs;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationSummary.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Instance Configuration Summary
+ * Summary information for an instance configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -121,14 +121,14 @@ public class InstanceConfigurationSummary {
     String compartmentId;
 
     /**
-     * A user-friendly name for the instance configuration
+     * A user-friendly name for the instance configuration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The OCID of the instance configuration
+     * The OCID of the instance configuration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePool.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePool.java
@@ -4,7 +4,10 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Instance Pool
+ * An instance pool is a group of instances within the same region that are created based off of the same
+ * instance configuration. For more information about instance pools and instance configurations, see
+ * [Managing Compute Instances](https://docs.cloud.oracle.com/Content/Compute/Concepts/instancemanagement.htm).
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePoolSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstancePoolSummary.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Condensed InstancePool data when listing instance pools.
+ * Summary information for an instance pool.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -162,13 +162,13 @@ public class InstancePoolSummary {
     }
 
     /**
-     * The OCID of the instance pool
+     * The OCID of the instance pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The OCID of the compartment containing the instance pool
+     * The OCID of the compartment containing the instance pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeImageCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeImageCompartmentRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeImageCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
+     */
+    private String imageId;
+
+    /**
+     * Request to change the compartment of a given image.
+     */
+    private ChangeImageCompartmentDetails changeImageCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeImageCompartmentRequest o) {
+            imageId(o.getImageId());
+            changeImageCompartmentDetails(o.getChangeImageCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeImageCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeImageCompartmentRequest
+         */
+        public ChangeImageCompartmentRequest build() {
+            ChangeImageCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeInstanceConfigurationCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeInstanceConfigurationCompartmentRequest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeInstanceConfigurationCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the instance configuration.
+     */
+    private String instanceConfigurationId;
+
+    /**
+     * Request to change the compartment of given instance configuration.
+     */
+    private ChangeInstanceConfigurationCompartmentDetails
+            changeInstanceConfigurationCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeInstanceConfigurationCompartmentRequest o) {
+            instanceConfigurationId(o.getInstanceConfigurationId());
+            changeInstanceConfigurationCompartmentDetails(
+                    o.getChangeInstanceConfigurationCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeInstanceConfigurationCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeInstanceConfigurationCompartmentRequest
+         */
+        public ChangeInstanceConfigurationCompartmentRequest build() {
+            ChangeInstanceConfigurationCompartmentRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeInstancePoolCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeInstancePoolCompartmentRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeInstancePoolCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the instance pool.
+     */
+    private String instancePoolId;
+
+    /**
+     * Request to change the compartment of given instance pool.
+     */
+    private ChangeInstancePoolCompartmentDetails changeInstancePoolCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeInstancePoolCompartmentRequest o) {
+            instancePoolId(o.getInstancePoolId());
+            changeInstancePoolCompartmentDetails(o.getChangeInstancePoolCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeInstancePoolCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeInstancePoolCompartmentRequest
+         */
+        public ChangeInstancePoolCompartmentRequest build() {
+            ChangeInstancePoolCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteImageRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteImageRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteImageRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the image.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
      */
     private String imageId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ExportImageRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ExportImageRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.core.model.*;
 public class ExportImageRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the image.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
      */
     private String imageId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetImageRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetImageRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.core.model.*;
 public class GetImageRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the image.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
      */
     private String imageId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListShapesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListShapesRequest.java
@@ -42,7 +42,7 @@ public class ListShapesRequest extends com.oracle.bmc.requests.BmcRequest {
     private String page;
 
     /**
-     * The OCID of an image.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an image.
      */
     private String imageId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateImageRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateImageRequest.java
@@ -11,7 +11,7 @@ import com.oracle.bmc.core.model.*;
 public class UpdateImageRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the image.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
      */
     private String imageId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeImageCompartmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeImageCompartmentResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeImageCompartmentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeImageCompartmentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeInstanceConfigurationCompartmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeInstanceConfigurationCompartmentResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeInstanceConfigurationCompartmentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeInstanceConfigurationCompartmentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeInstancePoolCompartmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeInstancePoolCompartmentResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeInstancePoolCompartmentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeInstancePoolCompartmentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateImageResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateImageResponse.java
@@ -24,7 +24,7 @@ public class CreateImageResponse {
     private String opcRequestId;
 
     /**
-     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
      * with this ID to track the status of the request.
      *
      */

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ExportImageResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ExportImageResponse.java
@@ -24,7 +24,7 @@ public class ExportImageResponse {
     private String opcRequestId;
 
     /**
-     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
      * with this ID to track the status of the request.
      *
      */

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/LaunchInstanceResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/LaunchInstanceResponse.java
@@ -24,7 +24,7 @@ public class LaunchInstanceResponse {
     private String opcRequestId;
 
     /**
-     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
      * with this ID to track the status of the request.
      *
      */

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdmin.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdmin.java
@@ -49,7 +49,7 @@ public interface StreamAdmin extends AutoCloseable {
 
     /**
      * Deletes a stream and its content. Stream contents are deleted immediately. The service retains records of the stream itself for 90 days after deletion.
-     * The `lifeCycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
+     * The `lifecycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
      * To verify that a stream has been deleted, make a {@link #getStream(GetStreamRequest) getStream} request. If the call returns the stream's
      * lifecycle state as `DELETED`, then the stream has been deleted. If the call returns a \"404 Not Found\" error, that means all records of the
      * stream have been deleted.

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminAsync.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminAsync.java
@@ -56,7 +56,7 @@ public interface StreamAdminAsync extends AutoCloseable {
 
     /**
      * Deletes a stream and its content. Stream contents are deleted immediately. The service retains records of the stream itself for 90 days after deletion.
-     * The `lifeCycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
+     * The `lifecycleState` parameter of the `Stream` object changes to `DELETING` and the stream becomes inaccessible for read or write operations.
      * To verify that a stream has been deleted, make a {@link #getStream(GetStreamRequest, Consumer, Consumer) getStream} request. If the call returns the stream's
      * lifecycle state as `DELETED`, then the stream has been deleted. If the call returns a \"404 Not Found\" error, that means all records of the
      * stream have been deleted.

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminAsyncClient.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminAsyncClient.java
@@ -31,8 +31,7 @@ public class StreamAdminAsyncClient implements StreamAdminAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("STREAMADMIN")
                     .serviceEndpointPrefix("streams")
-                    .serviceEndpointTemplate(
-                            "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://streaming.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminClient.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAdminClient.java
@@ -18,8 +18,7 @@ public class StreamAdminClient implements StreamAdmin {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("STREAMADMIN")
                     .serviceEndpointPrefix("streams")
-                    .serviceEndpointTemplate(
-                            "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://streaming.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAsyncClient.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamAsyncClient.java
@@ -31,8 +31,7 @@ public class StreamAsyncClient implements StreamAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("STREAM")
                     .serviceEndpointPrefix("streams")
-                    .serviceEndpointTemplate(
-                            "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://streaming.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamClient.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/StreamClient.java
@@ -18,8 +18,7 @@ public class StreamClient implements Stream {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("STREAM")
                     .serviceEndpointPrefix("streams")
-                    .serviceEndpointTemplate(
-                            "https://streams.{region}.streaming.oci.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://streaming.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-streaming/src/main/java/com/oracle/bmc/streaming/responses/ListStreamsResponse.java
+++ b/bmc-streaming/src/main/java/com/oracle/bmc/streaming/responses/ListStreamsResponse.java
@@ -11,12 +11,12 @@ import com.oracle.bmc.streaming.model.*;
 public class ListStreamsResponse {
 
     /**
-     * Pagination token
+     * For list pagination. When this header appears in the response, additional pages of results remain. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String opcNextPage;
 
     /**
-     * Pagination token
+     * For list pagination. When this header appears in the response, previous pages of results exist. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String opcPrevPage;
 

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.5.11</version>
+  <version>1.5.12</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for moving images, instance configurations, and instance pools across compartments in Core Services

- Support for moving autoscaling configurations across compartments in the Compute Autoscaling service



### Fixed

- Fixed a bug where the Streaming service's endpoints in Tokyo, Seoul, and future regions were not reachable from the SDK
