### PR TITLE
Releasing version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.6.0 - 2019-08-13
+### Added
+- Support for the Data Transfer service
+- Support for the Zurich (ZRH) region
+
+### Breaking changes
+- Breaking changes were made in the Web Application Acceleration and Security (WAAS) service:
+    - `Certificate_subjectName` class was renamed to `CertificateIssuerName`
+    - `Certificate_subjectName` class was renamed to `CertificateSubjectName`
+    - `WafLog#timestamp` type was changed from `String` to `java.util.Date`
+    - `WorkRequestOperationTypes#PurgeWaasPolicy` enum was removed
+    - `ListCertificatesRequest#lifecycleState` and `ListWaasPoliciesRequest#lifecycleState` type was changed from `String` to `com.oracle.bmc.waas.model.LifecycleStates`
+    - The `etag` parameter was removed from the following classes:
+        - `AcceptRecommendationsResponse`
+        - `DeleteWaasPolicyResponse`
+        - `UpdateAccessRulesResponse`
+        - `UpdateCaptchasResponse`
+        - `UpdateDeviceFingerprintChallengeResponse`
+        - `UpdateGoodBotsResponse`
+        - `UpdateHumanInteractionChallengeResponse`
+        - `UpdateJsChallengeResponse`
+        - `UpdatePolicyConfigResponse`
+        - `UpdateProtectionRulesResponse`
+        - `UpdateProtectionSettingsResponse`
+        - `UpdateThreatFeedsResponse`
+        - `UpdateWaasPolicyResponse`
+        - `UpdateWafAddressRateLimitingResponse`
+        - `UpdateWafConfigResponse`
+        - `UpdateWhitelistsResponse`
+
 ## 1.5.17 - 2019-08-06
 ### Added
 - Support for IPv6 load balancers in the Load Balancing service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,169 +19,175 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
+        <optional>false</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-dts</artifactId>
+        <version>1.6.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -36,6 +36,7 @@ public final class Region implements Serializable, Comparable<Region> {
     public static final Region CA_TORONTO_1 = register("ca-toronto-1", Realm.OC1);
     // regionCode for FRA shouldn't be needed, but left for backwards compat
     public static final Region EU_FRANKFURT_1 = register("eu-frankfurt-1", Realm.OC1, "fra");
+    public static final Region EU_ZURICH_1 = register("eu-zurich-1", Realm.OC1);
     // regionCode for LHR shouldn't be needed, but left for backwards compat
     public static final Region UK_LONDON_1 = register("uk-london-1", Realm.OC1, "lhr");
     public static final Region US_ASHBURN_1 = register("us-ashburn-1", Realm.OC1, "iad");

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.oracle.oci.sdk</groupId>
+    <artifactId>oci-java-sdk</artifactId>
+    <version>1.6.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>oci-java-sdk-dts</artifactId>
+  <name>Oracle Cloud Infrastructure SDK - Dts</name>
+  <description>This project contains the SDK used for Oracle Cloud Infrastructure Dts</description>
+  <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface ShippingVendors extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Lists available shipping vendors for Transfer Package delivery
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListShippingVendorsResponse listShippingVendors(ListShippingVendorsRequest request);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface ShippingVendorsAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Lists available shipping vendors for Transfer Package delivery
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListShippingVendorsResponse> listShippingVendors(
+            ListShippingVendorsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListShippingVendorsRequest, ListShippingVendorsResponse>
+                    handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for ShippingVendors service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ShippingVendorsAsyncClient implements ShippingVendorsAsync {
+    /**
+     * Service instance for ShippingVendors.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("SHIPPINGVENDORS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ShippingVendorsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, ShippingVendorsAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ShippingVendorsAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ShippingVendorsAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListShippingVendorsResponse> listShippingVendors(
+            final ListShippingVendorsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListShippingVendorsRequest, ListShippingVendorsResponse>
+                    handler) {
+        LOG.trace("Called async listShippingVendors");
+        final ListShippingVendorsRequest interceptedRequest =
+                ListShippingVendorsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListShippingVendorsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListShippingVendorsResponse>
+                transformer = ListShippingVendorsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListShippingVendorsRequest, ListShippingVendorsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListShippingVendorsRequest, ListShippingVendorsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListShippingVendorsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ShippingVendorsClient implements ShippingVendors {
+    /**
+     * Service instance for ShippingVendors.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("SHIPPINGVENDORS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ShippingVendorsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, ShippingVendorsClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ShippingVendorsClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ShippingVendorsClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public ListShippingVendorsResponse listShippingVendors(ListShippingVendorsRequest request) {
+        LOG.trace("Called listShippingVendors");
+        final ListShippingVendorsRequest interceptedRequest =
+                ListShippingVendorsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListShippingVendorsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListShippingVendorsResponse>
+                transformer = ListShippingVendorsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferAppliance extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create a new Transfer Appliance
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferApplianceResponse createTransferAppliance(CreateTransferApplianceRequest request);
+
+    /**
+     * Creates an X.509 certificate from a public key
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferApplianceAdminCredentialsResponse createTransferApplianceAdminCredentials(
+            CreateTransferApplianceAdminCredentialsRequest request);
+
+    /**
+     * deletes a transfer Appliance
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteTransferApplianceResponse deleteTransferAppliance(DeleteTransferApplianceRequest request);
+
+    /**
+     * Describes a transfer appliance in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferApplianceResponse getTransferAppliance(GetTransferApplianceRequest request);
+
+    /**
+     * Gets the x.509 certificate for the Transfer Appliance's dedicated Certificate Authority (CA)
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferApplianceCertificateAuthorityCertificateResponse
+            getTransferApplianceCertificateAuthorityCertificate(
+                    GetTransferApplianceCertificateAuthorityCertificateRequest request);
+
+    /**
+     * Describes a transfer appliance encryptionPassphrase in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferApplianceEncryptionPassphraseResponse getTransferApplianceEncryptionPassphrase(
+            GetTransferApplianceEncryptionPassphraseRequest request);
+
+    /**
+     * Lists Transfer Appliances associated with a transferJob
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListTransferAppliancesResponse listTransferAppliances(ListTransferAppliancesRequest request);
+
+    /**
+     * Updates a Transfer Appliance
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateTransferApplianceResponse updateTransferAppliance(UpdateTransferApplianceRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    TransferApplianceWaiters getWaiters();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferApplianceAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create a new Transfer Appliance
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferApplianceResponse> createTransferAppliance(
+            CreateTransferApplianceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferApplianceRequest, CreateTransferApplianceResponse>
+                    handler);
+
+    /**
+     * Creates an X.509 certificate from a public key
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferApplianceAdminCredentialsResponse>
+            createTransferApplianceAdminCredentials(
+                    CreateTransferApplianceAdminCredentialsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    CreateTransferApplianceAdminCredentialsRequest,
+                                    CreateTransferApplianceAdminCredentialsResponse>
+                            handler);
+
+    /**
+     * deletes a transfer Appliance
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteTransferApplianceResponse> deleteTransferAppliance(
+            DeleteTransferApplianceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferApplianceRequest, DeleteTransferApplianceResponse>
+                    handler);
+
+    /**
+     * Describes a transfer appliance in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferApplianceResponse> getTransferAppliance(
+            GetTransferApplianceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferApplianceRequest, GetTransferApplianceResponse>
+                    handler);
+
+    /**
+     * Gets the x.509 certificate for the Transfer Appliance's dedicated Certificate Authority (CA)
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferApplianceCertificateAuthorityCertificateResponse>
+            getTransferApplianceCertificateAuthorityCertificate(
+                    GetTransferApplianceCertificateAuthorityCertificateRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceCertificateAuthorityCertificateRequest,
+                                    GetTransferApplianceCertificateAuthorityCertificateResponse>
+                            handler);
+
+    /**
+     * Describes a transfer appliance encryptionPassphrase in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferApplianceEncryptionPassphraseResponse>
+            getTransferApplianceEncryptionPassphrase(
+                    GetTransferApplianceEncryptionPassphraseRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceEncryptionPassphraseRequest,
+                                    GetTransferApplianceEncryptionPassphraseResponse>
+                            handler);
+
+    /**
+     * Lists Transfer Appliances associated with a transferJob
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListTransferAppliancesResponse> listTransferAppliances(
+            ListTransferAppliancesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferAppliancesRequest, ListTransferAppliancesResponse>
+                    handler);
+
+    /**
+     * Updates a Transfer Appliance
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateTransferApplianceResponse> updateTransferAppliance(
+            UpdateTransferApplianceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferApplianceRequest, UpdateTransferApplianceResponse>
+                    handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
@@ -1,0 +1,977 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for TransferAppliance service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferApplianceAsyncClient implements TransferApplianceAsync {
+    /**
+     * Service instance for TransferAppliance.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERAPPLIANCE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, TransferApplianceAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferApplianceAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferApplianceAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferApplianceResponse> createTransferAppliance(
+            final CreateTransferApplianceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferApplianceRequest, CreateTransferApplianceResponse>
+                    handler) {
+        LOG.trace("Called async createTransferAppliance");
+        final CreateTransferApplianceRequest interceptedRequest =
+                CreateTransferApplianceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceResponse>
+                transformer = CreateTransferApplianceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateTransferApplianceRequest, CreateTransferApplianceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferApplianceRequest, CreateTransferApplianceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferApplianceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateTransferApplianceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferApplianceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferApplianceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferApplianceAdminCredentialsResponse>
+            createTransferApplianceAdminCredentials(
+                    final CreateTransferApplianceAdminCredentialsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    CreateTransferApplianceAdminCredentialsRequest,
+                                    CreateTransferApplianceAdminCredentialsResponse>
+                            handler) {
+        LOG.trace("Called async createTransferApplianceAdminCredentials");
+        final CreateTransferApplianceAdminCredentialsRequest interceptedRequest =
+                CreateTransferApplianceAdminCredentialsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceAdminCredentialsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceAdminCredentialsResponse>
+                transformer = CreateTransferApplianceAdminCredentialsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateTransferApplianceAdminCredentialsRequest,
+                        CreateTransferApplianceAdminCredentialsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferApplianceAdminCredentialsRequest,
+                            CreateTransferApplianceAdminCredentialsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getAdminPublicKey(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getAdminPublicKey(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferApplianceAdminCredentialsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getAdminPublicKey(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteTransferApplianceResponse> deleteTransferAppliance(
+            final DeleteTransferApplianceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferApplianceRequest, DeleteTransferApplianceResponse>
+                    handler) {
+        LOG.trace("Called async deleteTransferAppliance");
+        final DeleteTransferApplianceRequest interceptedRequest =
+                DeleteTransferApplianceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferApplianceResponse>
+                transformer = DeleteTransferApplianceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteTransferApplianceRequest, DeleteTransferApplianceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteTransferApplianceRequest, DeleteTransferApplianceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteTransferApplianceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferApplianceResponse> getTransferAppliance(
+            final GetTransferApplianceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferApplianceRequest, GetTransferApplianceResponse>
+                    handler) {
+        LOG.trace("Called async getTransferAppliance");
+        final GetTransferApplianceRequest interceptedRequest =
+                GetTransferApplianceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceResponse>
+                transformer = GetTransferApplianceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetTransferApplianceRequest, GetTransferApplianceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferApplianceRequest, GetTransferApplianceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferApplianceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferApplianceCertificateAuthorityCertificateResponse>
+            getTransferApplianceCertificateAuthorityCertificate(
+                    final GetTransferApplianceCertificateAuthorityCertificateRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceCertificateAuthorityCertificateRequest,
+                                    GetTransferApplianceCertificateAuthorityCertificateResponse>
+                            handler) {
+        LOG.trace("Called async getTransferApplianceCertificateAuthorityCertificate");
+        final GetTransferApplianceCertificateAuthorityCertificateRequest interceptedRequest =
+                GetTransferApplianceCertificateAuthorityCertificateConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceCertificateAuthorityCertificateConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetTransferApplianceCertificateAuthorityCertificateResponse>
+                transformer =
+                        GetTransferApplianceCertificateAuthorityCertificateConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetTransferApplianceCertificateAuthorityCertificateRequest,
+                        GetTransferApplianceCertificateAuthorityCertificateResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferApplianceCertificateAuthorityCertificateRequest,
+                            GetTransferApplianceCertificateAuthorityCertificateResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    GetTransferApplianceCertificateAuthorityCertificateResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferApplianceEncryptionPassphraseResponse>
+            getTransferApplianceEncryptionPassphrase(
+                    final GetTransferApplianceEncryptionPassphraseRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceEncryptionPassphraseRequest,
+                                    GetTransferApplianceEncryptionPassphraseResponse>
+                            handler) {
+        LOG.trace("Called async getTransferApplianceEncryptionPassphrase");
+        final GetTransferApplianceEncryptionPassphraseRequest interceptedRequest =
+                GetTransferApplianceEncryptionPassphraseConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceEncryptionPassphraseConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEncryptionPassphraseResponse>
+                transformer = GetTransferApplianceEncryptionPassphraseConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetTransferApplianceEncryptionPassphraseRequest,
+                        GetTransferApplianceEncryptionPassphraseResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferApplianceEncryptionPassphraseRequest,
+                            GetTransferApplianceEncryptionPassphraseResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferApplianceEncryptionPassphraseResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListTransferAppliancesResponse> listTransferAppliances(
+            final ListTransferAppliancesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferAppliancesRequest, ListTransferAppliancesResponse>
+                    handler) {
+        LOG.trace("Called async listTransferAppliances");
+        final ListTransferAppliancesRequest interceptedRequest =
+                ListTransferAppliancesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferAppliancesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferAppliancesResponse>
+                transformer = ListTransferAppliancesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListTransferAppliancesRequest, ListTransferAppliancesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListTransferAppliancesRequest, ListTransferAppliancesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListTransferAppliancesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateTransferApplianceResponse> updateTransferAppliance(
+            final UpdateTransferApplianceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferApplianceRequest, UpdateTransferApplianceResponse>
+                    handler) {
+        LOG.trace("Called async updateTransferAppliance");
+        final UpdateTransferApplianceRequest interceptedRequest =
+                UpdateTransferApplianceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferApplianceResponse>
+                transformer = UpdateTransferApplianceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateTransferApplianceRequest, UpdateTransferApplianceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateTransferApplianceRequest, UpdateTransferApplianceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferApplianceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateTransferApplianceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateTransferApplianceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferApplianceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
@@ -1,0 +1,634 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferApplianceClient implements TransferAppliance {
+    /**
+     * Service instance for TransferAppliance.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERAPPLIANCE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final TransferApplianceWaiters waiters;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public TransferApplianceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("TransferAppliance-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new TransferApplianceWaiters(executorService, this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, TransferApplianceClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferApplianceClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferApplianceClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public CreateTransferApplianceResponse createTransferAppliance(
+            CreateTransferApplianceRequest request) {
+        LOG.trace("Called createTransferAppliance");
+        final CreateTransferApplianceRequest interceptedRequest =
+                CreateTransferApplianceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferApplianceResponse>
+                transformer = CreateTransferApplianceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateTransferApplianceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateTransferApplianceAdminCredentialsResponse createTransferApplianceAdminCredentials(
+            CreateTransferApplianceAdminCredentialsRequest request) {
+        LOG.trace("Called createTransferApplianceAdminCredentials");
+        final CreateTransferApplianceAdminCredentialsRequest interceptedRequest =
+                CreateTransferApplianceAdminCredentialsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceAdminCredentialsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceAdminCredentialsResponse>
+                transformer = CreateTransferApplianceAdminCredentialsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAdminPublicKey(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteTransferApplianceResponse deleteTransferAppliance(
+            DeleteTransferApplianceRequest request) {
+        LOG.trace("Called deleteTransferAppliance");
+        final DeleteTransferApplianceRequest interceptedRequest =
+                DeleteTransferApplianceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferApplianceResponse>
+                transformer = DeleteTransferApplianceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferApplianceResponse getTransferAppliance(GetTransferApplianceRequest request) {
+        LOG.trace("Called getTransferAppliance");
+        final GetTransferApplianceRequest interceptedRequest =
+                GetTransferApplianceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferApplianceResponse>
+                transformer = GetTransferApplianceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferApplianceCertificateAuthorityCertificateResponse
+            getTransferApplianceCertificateAuthorityCertificate(
+                    GetTransferApplianceCertificateAuthorityCertificateRequest request) {
+        LOG.trace("Called getTransferApplianceCertificateAuthorityCertificate");
+        final GetTransferApplianceCertificateAuthorityCertificateRequest interceptedRequest =
+                GetTransferApplianceCertificateAuthorityCertificateConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceCertificateAuthorityCertificateConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetTransferApplianceCertificateAuthorityCertificateResponse>
+                transformer =
+                        GetTransferApplianceCertificateAuthorityCertificateConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferApplianceEncryptionPassphraseResponse
+            getTransferApplianceEncryptionPassphrase(
+                    GetTransferApplianceEncryptionPassphraseRequest request) {
+        LOG.trace("Called getTransferApplianceEncryptionPassphrase");
+        final GetTransferApplianceEncryptionPassphraseRequest interceptedRequest =
+                GetTransferApplianceEncryptionPassphraseConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceEncryptionPassphraseConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEncryptionPassphraseResponse>
+                transformer = GetTransferApplianceEncryptionPassphraseConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListTransferAppliancesResponse listTransferAppliances(
+            ListTransferAppliancesRequest request) {
+        LOG.trace("Called listTransferAppliances");
+        final ListTransferAppliancesRequest interceptedRequest =
+                ListTransferAppliancesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferAppliancesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferAppliancesResponse>
+                transformer = ListTransferAppliancesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateTransferApplianceResponse updateTransferAppliance(
+            UpdateTransferApplianceRequest request) {
+        LOG.trace("Called updateTransferAppliance");
+        final UpdateTransferApplianceRequest interceptedRequest =
+                UpdateTransferApplianceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferApplianceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferApplianceResponse>
+                transformer = UpdateTransferApplianceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateTransferApplianceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public TransferApplianceWaiters getWaiters() {
+        return waiters;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferApplianceEntitlement extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferApplianceEntitlementResponse createTransferApplianceEntitlement(
+            CreateTransferApplianceEntitlementRequest request);
+
+    /**
+     * Describes the Transfer Appliance Entitlement in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferApplianceEntitlementResponse getTransferApplianceEntitlement(
+            GetTransferApplianceEntitlementRequest request);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferApplianceEntitlementAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferApplianceEntitlementResponse>
+            createTransferApplianceEntitlement(
+                    CreateTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    CreateTransferApplianceEntitlementRequest,
+                                    CreateTransferApplianceEntitlementResponse>
+                            handler);
+
+    /**
+     * Describes the Transfer Appliance Entitlement in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferApplianceEntitlementResponse>
+            getTransferApplianceEntitlement(
+                    GetTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceEntitlementRequest,
+                                    GetTransferApplianceEntitlementResponse>
+                            handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
@@ -1,0 +1,482 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for TransferApplianceEntitlement service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferApplianceEntitlementAsyncClient implements TransferApplianceEntitlementAsync {
+    /**
+     * Service instance for TransferApplianceEntitlement.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERAPPLIANCEENTITLEMENT")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceEntitlementAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, TransferApplianceEntitlementAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferApplianceEntitlementAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferApplianceEntitlementAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferApplianceEntitlementResponse>
+            createTransferApplianceEntitlement(
+                    final CreateTransferApplianceEntitlementRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    CreateTransferApplianceEntitlementRequest,
+                                    CreateTransferApplianceEntitlementResponse>
+                            handler) {
+        LOG.trace("Called async createTransferApplianceEntitlement");
+        final CreateTransferApplianceEntitlementRequest interceptedRequest =
+                CreateTransferApplianceEntitlementConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceEntitlementResponse>
+                transformer = CreateTransferApplianceEntitlementConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateTransferApplianceEntitlementRequest,
+                        CreateTransferApplianceEntitlementResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferApplianceEntitlementRequest,
+                            CreateTransferApplianceEntitlementResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getCreateTransferApplianceEntitlementDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateTransferApplianceEntitlementDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferApplianceEntitlementResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getCreateTransferApplianceEntitlementDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferApplianceEntitlementResponse>
+            getTransferApplianceEntitlement(
+                    final GetTransferApplianceEntitlementRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetTransferApplianceEntitlementRequest,
+                                    GetTransferApplianceEntitlementResponse>
+                            handler) {
+        LOG.trace("Called async getTransferApplianceEntitlement");
+        final GetTransferApplianceEntitlementRequest interceptedRequest =
+                GetTransferApplianceEntitlementConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>
+                transformer = GetTransferApplianceEntitlementConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetTransferApplianceEntitlementRequest,
+                        GetTransferApplianceEntitlementResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferApplianceEntitlementRequest,
+                            GetTransferApplianceEntitlementResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
@@ -1,0 +1,369 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferApplianceEntitlementClient implements TransferApplianceEntitlement {
+    /**
+     * Service instance for TransferApplianceEntitlement.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERAPPLIANCEENTITLEMENT")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, TransferApplianceEntitlementClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferApplianceEntitlementClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferApplianceEntitlementClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public CreateTransferApplianceEntitlementResponse createTransferApplianceEntitlement(
+            CreateTransferApplianceEntitlementRequest request) {
+        LOG.trace("Called createTransferApplianceEntitlement");
+        final CreateTransferApplianceEntitlementRequest interceptedRequest =
+                CreateTransferApplianceEntitlementConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceEntitlementResponse>
+                transformer = CreateTransferApplianceEntitlementConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getCreateTransferApplianceEntitlementDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferApplianceEntitlementResponse getTransferApplianceEntitlement(
+            GetTransferApplianceEntitlementRequest request) {
+        LOG.trace("Called getTransferApplianceEntitlement");
+        final GetTransferApplianceEntitlementRequest interceptedRequest =
+                GetTransferApplianceEntitlementConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>
+                transformer = GetTransferApplianceEntitlementConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of TransferAppliance.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.RequiredArgsConstructor
+public class TransferApplianceWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final TransferAppliance client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferApplianceRequest, GetTransferApplianceResponse>
+            forTransferAppliance(
+                    GetTransferApplianceRequest request,
+                    com.oracle.bmc.dts.model.TransferAppliance.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forTransferAppliance(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferApplianceRequest, GetTransferApplianceResponse>
+            forTransferAppliance(
+                    GetTransferApplianceRequest request,
+                    com.oracle.bmc.dts.model.TransferAppliance.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forTransferAppliance(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferApplianceRequest, GetTransferApplianceResponse>
+            forTransferAppliance(
+                    GetTransferApplianceRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dts.model.TransferAppliance.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forTransferAppliance(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for TransferAppliance.
+    private com.oracle.bmc.waiter.Waiter<GetTransferApplianceRequest, GetTransferApplianceResponse>
+            forTransferAppliance(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetTransferApplianceRequest request,
+                    final com.oracle.bmc.dts.model.TransferAppliance.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.dts.model.TransferAppliance.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetTransferApplianceRequest, GetTransferApplianceResponse>() {
+                            @Override
+                            public GetTransferApplianceResponse apply(
+                                    GetTransferApplianceRequest request) {
+                                return client.getTransferAppliance(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetTransferApplianceResponse>() {
+                            @Override
+                            public boolean apply(GetTransferApplianceResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getTransferAppliance().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dts.model.TransferAppliance.LifecycleState.Deleted)),
+                request);
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferDevice extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create a new Transfer Device
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferDeviceResponse createTransferDevice(CreateTransferDeviceRequest request);
+
+    /**
+     * deletes a transfer Device
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteTransferDeviceResponse deleteTransferDevice(DeleteTransferDeviceRequest request);
+
+    /**
+     * Describes a transfer package in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferDeviceResponse getTransferDevice(GetTransferDeviceRequest request);
+
+    /**
+     * Lists Transfer Devices associated with a transferJob
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListTransferDevicesResponse listTransferDevices(ListTransferDevicesRequest request);
+
+    /**
+     * Updates a Transfer Device
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateTransferDeviceResponse updateTransferDevice(UpdateTransferDeviceRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    TransferDeviceWaiters getWaiters();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferDeviceAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create a new Transfer Device
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferDeviceResponse> createTransferDevice(
+            CreateTransferDeviceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferDeviceRequest, CreateTransferDeviceResponse>
+                    handler);
+
+    /**
+     * deletes a transfer Device
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteTransferDeviceResponse> deleteTransferDevice(
+            DeleteTransferDeviceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferDeviceRequest, DeleteTransferDeviceResponse>
+                    handler);
+
+    /**
+     * Describes a transfer package in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferDeviceResponse> getTransferDevice(
+            GetTransferDeviceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferDeviceRequest, GetTransferDeviceResponse>
+                    handler);
+
+    /**
+     * Lists Transfer Devices associated with a transferJob
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListTransferDevicesResponse> listTransferDevices(
+            ListTransferDevicesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferDevicesRequest, ListTransferDevicesResponse>
+                    handler);
+
+    /**
+     * Updates a Transfer Device
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateTransferDeviceResponse> updateTransferDevice(
+            UpdateTransferDeviceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferDeviceRequest, UpdateTransferDeviceResponse>
+                    handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
@@ -1,0 +1,713 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for TransferDevice service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferDeviceAsyncClient implements TransferDeviceAsync {
+    /**
+     * Service instance for TransferDevice.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERDEVICE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferDeviceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, TransferDeviceAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferDeviceAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferDeviceAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferDeviceResponse> createTransferDevice(
+            final CreateTransferDeviceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferDeviceRequest, CreateTransferDeviceResponse>
+                    handler) {
+        LOG.trace("Called async createTransferDevice");
+        final CreateTransferDeviceRequest interceptedRequest =
+                CreateTransferDeviceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferDeviceResponse>
+                transformer = CreateTransferDeviceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateTransferDeviceRequest, CreateTransferDeviceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferDeviceRequest, CreateTransferDeviceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferDeviceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateTransferDeviceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferDeviceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferDeviceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteTransferDeviceResponse> deleteTransferDevice(
+            final DeleteTransferDeviceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferDeviceRequest, DeleteTransferDeviceResponse>
+                    handler) {
+        LOG.trace("Called async deleteTransferDevice");
+        final DeleteTransferDeviceRequest interceptedRequest =
+                DeleteTransferDeviceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferDeviceResponse>
+                transformer = DeleteTransferDeviceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteTransferDeviceRequest, DeleteTransferDeviceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteTransferDeviceRequest, DeleteTransferDeviceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteTransferDeviceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferDeviceResponse> getTransferDevice(
+            final GetTransferDeviceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferDeviceRequest, GetTransferDeviceResponse>
+                    handler) {
+        LOG.trace("Called async getTransferDevice");
+        final GetTransferDeviceRequest interceptedRequest =
+                GetTransferDeviceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferDeviceResponse>
+                transformer = GetTransferDeviceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetTransferDeviceRequest, GetTransferDeviceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferDeviceRequest, GetTransferDeviceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferDeviceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListTransferDevicesResponse> listTransferDevices(
+            final ListTransferDevicesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferDevicesRequest, ListTransferDevicesResponse>
+                    handler) {
+        LOG.trace("Called async listTransferDevices");
+        final ListTransferDevicesRequest interceptedRequest =
+                ListTransferDevicesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferDevicesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferDevicesResponse>
+                transformer = ListTransferDevicesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListTransferDevicesRequest, ListTransferDevicesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListTransferDevicesRequest, ListTransferDevicesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListTransferDevicesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateTransferDeviceResponse> updateTransferDevice(
+            final UpdateTransferDeviceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferDeviceRequest, UpdateTransferDeviceResponse>
+                    handler) {
+        LOG.trace("Called async updateTransferDevice");
+        final UpdateTransferDeviceRequest interceptedRequest =
+                UpdateTransferDeviceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferDeviceResponse>
+                transformer = UpdateTransferDeviceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateTransferDeviceRequest, UpdateTransferDeviceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateTransferDeviceRequest, UpdateTransferDeviceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferDeviceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateTransferDeviceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateTransferDeviceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferDeviceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
@@ -1,0 +1,528 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferDeviceClient implements TransferDevice {
+    /**
+     * Service instance for TransferDevice.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERDEVICE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final TransferDeviceWaiters waiters;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public TransferDeviceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("TransferDevice-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new TransferDeviceWaiters(executorService, this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, TransferDeviceClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferDeviceClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferDeviceClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public CreateTransferDeviceResponse createTransferDevice(CreateTransferDeviceRequest request) {
+        LOG.trace("Called createTransferDevice");
+        final CreateTransferDeviceRequest interceptedRequest =
+                CreateTransferDeviceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferDeviceResponse>
+                transformer = CreateTransferDeviceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateTransferDeviceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteTransferDeviceResponse deleteTransferDevice(DeleteTransferDeviceRequest request) {
+        LOG.trace("Called deleteTransferDevice");
+        final DeleteTransferDeviceRequest interceptedRequest =
+                DeleteTransferDeviceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferDeviceResponse>
+                transformer = DeleteTransferDeviceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferDeviceResponse getTransferDevice(GetTransferDeviceRequest request) {
+        LOG.trace("Called getTransferDevice");
+        final GetTransferDeviceRequest interceptedRequest =
+                GetTransferDeviceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferDeviceResponse>
+                transformer = GetTransferDeviceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListTransferDevicesResponse listTransferDevices(ListTransferDevicesRequest request) {
+        LOG.trace("Called listTransferDevices");
+        final ListTransferDevicesRequest interceptedRequest =
+                ListTransferDevicesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferDevicesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferDevicesResponse>
+                transformer = ListTransferDevicesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateTransferDeviceResponse updateTransferDevice(UpdateTransferDeviceRequest request) {
+        LOG.trace("Called updateTransferDevice");
+        final UpdateTransferDeviceRequest interceptedRequest =
+                UpdateTransferDeviceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferDeviceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferDeviceResponse>
+                transformer = UpdateTransferDeviceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateTransferDeviceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public TransferDeviceWaiters getWaiters() {
+        return waiters;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of TransferDevice.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.RequiredArgsConstructor
+public class TransferDeviceWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final TransferDevice client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferDeviceRequest, GetTransferDeviceResponse>
+            forTransferDevice(
+                    GetTransferDeviceRequest request,
+                    com.oracle.bmc.dts.model.TransferDevice.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forTransferDevice(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferDeviceRequest, GetTransferDeviceResponse>
+            forTransferDevice(
+                    GetTransferDeviceRequest request,
+                    com.oracle.bmc.dts.model.TransferDevice.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forTransferDevice(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferDeviceRequest, GetTransferDeviceResponse>
+            forTransferDevice(
+                    GetTransferDeviceRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dts.model.TransferDevice.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forTransferDevice(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for TransferDevice.
+    private com.oracle.bmc.waiter.Waiter<GetTransferDeviceRequest, GetTransferDeviceResponse>
+            forTransferDevice(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetTransferDeviceRequest request,
+                    final com.oracle.bmc.dts.model.TransferDevice.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.dts.model.TransferDevice.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetTransferDeviceRequest, GetTransferDeviceResponse>() {
+                            @Override
+                            public GetTransferDeviceResponse apply(
+                                    GetTransferDeviceRequest request) {
+                                return client.getTransferDevice(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetTransferDeviceResponse>() {
+                            @Override
+                            public boolean apply(GetTransferDeviceResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getTransferDevice().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dts.model.TransferDevice.LifecycleState.Deleted)),
+                request);
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferJob extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a TransferJob into a different compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeTransferJobCompartmentResponse changeTransferJobCompartment(
+            ChangeTransferJobCompartmentRequest request);
+
+    /**
+     * Create a new Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferJobResponse createTransferJob(CreateTransferJobRequest request);
+
+    /**
+     * deletes a transfer job
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteTransferJobResponse deleteTransferJob(DeleteTransferJobRequest request);
+
+    /**
+     * Describes a transfer job in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferJobResponse getTransferJob(GetTransferJobRequest request);
+
+    /**
+     * Lists Transfer Jobs in a given compartment
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListTransferJobsResponse listTransferJobs(ListTransferJobsRequest request);
+
+    /**
+     * Updates a Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateTransferJobResponse updateTransferJob(UpdateTransferJobRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    TransferJobWaiters getWaiters();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferJobAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a TransferJob into a different compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeTransferJobCompartmentResponse> changeTransferJobCompartment(
+            ChangeTransferJobCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeTransferJobCompartmentRequest,
+                            ChangeTransferJobCompartmentResponse>
+                    handler);
+
+    /**
+     * Create a new Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferJobResponse> createTransferJob(
+            CreateTransferJobRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferJobRequest, CreateTransferJobResponse>
+                    handler);
+
+    /**
+     * deletes a transfer job
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteTransferJobResponse> deleteTransferJob(
+            DeleteTransferJobRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferJobRequest, DeleteTransferJobResponse>
+                    handler);
+
+    /**
+     * Describes a transfer job in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferJobResponse> getTransferJob(
+            GetTransferJobRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetTransferJobRequest, GetTransferJobResponse>
+                    handler);
+
+    /**
+     * Lists Transfer Jobs in a given compartment
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListTransferJobsResponse> listTransferJobs(
+            ListTransferJobsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListTransferJobsRequest, ListTransferJobsResponse>
+                    handler);
+
+    /**
+     * Updates a Transfer Job that corresponds with customer's logical dataset e.g. a DB or a filesystem.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateTransferJobResponse> updateTransferJob(
+            UpdateTransferJobRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferJobRequest, UpdateTransferJobResponse>
+                    handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
@@ -1,0 +1,798 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for TransferJob service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferJobAsyncClient implements TransferJobAsync {
+    /**
+     * Service instance for TransferJob.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERJOB")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferJobAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, TransferJobAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferJobAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferJobAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeTransferJobCompartmentResponse>
+            changeTransferJobCompartment(
+                    final ChangeTransferJobCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeTransferJobCompartmentRequest,
+                                    ChangeTransferJobCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeTransferJobCompartment");
+        final ChangeTransferJobCompartmentRequest interceptedRequest =
+                ChangeTransferJobCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeTransferJobCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>
+                transformer = ChangeTransferJobCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeTransferJobCompartmentRequest, ChangeTransferJobCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeTransferJobCompartmentRequest,
+                            ChangeTransferJobCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeTransferJobCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeTransferJobCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeTransferJobCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferJobResponse> createTransferJob(
+            final CreateTransferJobRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferJobRequest, CreateTransferJobResponse>
+                    handler) {
+        LOG.trace("Called async createTransferJob");
+        final CreateTransferJobRequest interceptedRequest =
+                CreateTransferJobConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferJobConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferJobResponse>
+                transformer = CreateTransferJobConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreateTransferJobRequest, CreateTransferJobResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferJobRequest, CreateTransferJobResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferJobDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateTransferJobDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferJobResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferJobDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteTransferJobResponse> deleteTransferJob(
+            final DeleteTransferJobRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferJobRequest, DeleteTransferJobResponse>
+                    handler) {
+        LOG.trace("Called async deleteTransferJob");
+        final DeleteTransferJobRequest interceptedRequest =
+                DeleteTransferJobConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferJobConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferJobResponse>
+                transformer = DeleteTransferJobConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteTransferJobRequest, DeleteTransferJobResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteTransferJobRequest, DeleteTransferJobResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteTransferJobResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferJobResponse> getTransferJob(
+            final GetTransferJobRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferJobRequest, GetTransferJobResponse>
+                    handler) {
+        LOG.trace("Called async getTransferJob");
+        final GetTransferJobRequest interceptedRequest =
+                GetTransferJobConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferJobConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferJobResponse>
+                transformer = GetTransferJobConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetTransferJobRequest, GetTransferJobResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferJobRequest, GetTransferJobResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferJobResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListTransferJobsResponse> listTransferJobs(
+            final ListTransferJobsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferJobsRequest, ListTransferJobsResponse>
+                    handler) {
+        LOG.trace("Called async listTransferJobs");
+        final ListTransferJobsRequest interceptedRequest =
+                ListTransferJobsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferJobsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferJobsResponse>
+                transformer = ListTransferJobsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListTransferJobsRequest, ListTransferJobsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListTransferJobsRequest, ListTransferJobsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListTransferJobsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateTransferJobResponse> updateTransferJob(
+            final UpdateTransferJobRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferJobRequest, UpdateTransferJobResponse>
+                    handler) {
+        LOG.trace("Called async updateTransferJob");
+        final UpdateTransferJobRequest interceptedRequest =
+                UpdateTransferJobConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferJobConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferJobResponse>
+                transformer = UpdateTransferJobConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateTransferJobRequest, UpdateTransferJobResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateTransferJobRequest, UpdateTransferJobResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferJobDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateTransferJobDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateTransferJobResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferJobDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
@@ -1,0 +1,563 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferJobClient implements TransferJob {
+    /**
+     * Service instance for TransferJob.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERJOB")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final TransferJobWaiters waiters;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public TransferJobClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("TransferJob-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new TransferJobWaiters(executorService, this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, TransferJobClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferJobClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferJobClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public ChangeTransferJobCompartmentResponse changeTransferJobCompartment(
+            ChangeTransferJobCompartmentRequest request) {
+        LOG.trace("Called changeTransferJobCompartment");
+        final ChangeTransferJobCompartmentRequest interceptedRequest =
+                ChangeTransferJobCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeTransferJobCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>
+                transformer = ChangeTransferJobCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeTransferJobCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateTransferJobResponse createTransferJob(CreateTransferJobRequest request) {
+        LOG.trace("Called createTransferJob");
+        final CreateTransferJobRequest interceptedRequest =
+                CreateTransferJobConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferJobConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferJobResponse>
+                transformer = CreateTransferJobConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateTransferJobDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteTransferJobResponse deleteTransferJob(DeleteTransferJobRequest request) {
+        LOG.trace("Called deleteTransferJob");
+        final DeleteTransferJobRequest interceptedRequest =
+                DeleteTransferJobConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferJobConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferJobResponse>
+                transformer = DeleteTransferJobConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferJobResponse getTransferJob(GetTransferJobRequest request) {
+        LOG.trace("Called getTransferJob");
+        final GetTransferJobRequest interceptedRequest =
+                GetTransferJobConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferJobConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferJobResponse>
+                transformer = GetTransferJobConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListTransferJobsResponse listTransferJobs(ListTransferJobsRequest request) {
+        LOG.trace("Called listTransferJobs");
+        final ListTransferJobsRequest interceptedRequest =
+                ListTransferJobsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferJobsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferJobsResponse>
+                transformer = ListTransferJobsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateTransferJobResponse updateTransferJob(UpdateTransferJobRequest request) {
+        LOG.trace("Called updateTransferJob");
+        final UpdateTransferJobRequest interceptedRequest =
+                UpdateTransferJobConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferJobConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferJobResponse>
+                transformer = UpdateTransferJobConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateTransferJobDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public TransferJobWaiters getWaiters() {
+        return waiters;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of TransferJob.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.RequiredArgsConstructor
+public class TransferJobWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final TransferJob client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferJobRequest, GetTransferJobResponse>
+            forTransferJob(
+                    GetTransferJobRequest request,
+                    com.oracle.bmc.dts.model.TransferJob.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forTransferJob(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferJobRequest, GetTransferJobResponse>
+            forTransferJob(
+                    GetTransferJobRequest request,
+                    com.oracle.bmc.dts.model.TransferJob.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forTransferJob(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferJobRequest, GetTransferJobResponse>
+            forTransferJob(
+                    GetTransferJobRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dts.model.TransferJob.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forTransferJob(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for TransferJob.
+    private com.oracle.bmc.waiter.Waiter<GetTransferJobRequest, GetTransferJobResponse>
+            forTransferJob(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetTransferJobRequest request,
+                    final com.oracle.bmc.dts.model.TransferJob.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.dts.model.TransferJob.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetTransferJobRequest, GetTransferJobResponse>() {
+                            @Override
+                            public GetTransferJobResponse apply(GetTransferJobRequest request) {
+                                return client.getTransferJob(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetTransferJobResponse>() {
+                            @Override
+                            public boolean apply(GetTransferJobResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getTransferJob().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dts.model.TransferJob.LifecycleState.Deleted)),
+                request);
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferPackage extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Attaches Devices to a Transfer Package
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AttachDevicesToTransferPackageResponse attachDevicesToTransferPackage(
+            AttachDevicesToTransferPackageRequest request);
+
+    /**
+     * Create a new Transfer Package
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateTransferPackageResponse createTransferPackage(CreateTransferPackageRequest request);
+
+    /**
+     * deletes a transfer Package
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteTransferPackageResponse deleteTransferPackage(DeleteTransferPackageRequest request);
+
+    /**
+     * Detaches Devices from a Transfer Package
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DetachDevicesFromTransferPackageResponse detachDevicesFromTransferPackage(
+            DetachDevicesFromTransferPackageRequest request);
+
+    /**
+     * Describes a transfer package in detail
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetTransferPackageResponse getTransferPackage(GetTransferPackageRequest request);
+
+    /**
+     * Lists Transfer Packages associated with a transferJob
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListTransferPackagesResponse listTransferPackages(ListTransferPackagesRequest request);
+
+    /**
+     * Updates a Transfer Package
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateTransferPackageResponse updateTransferPackage(UpdateTransferPackageRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    TransferPackageWaiters getWaiters();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+public interface TransferPackageAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Attaches Devices to a Transfer Package
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AttachDevicesToTransferPackageResponse>
+            attachDevicesToTransferPackage(
+                    AttachDevicesToTransferPackageRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    AttachDevicesToTransferPackageRequest,
+                                    AttachDevicesToTransferPackageResponse>
+                            handler);
+
+    /**
+     * Create a new Transfer Package
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateTransferPackageResponse> createTransferPackage(
+            CreateTransferPackageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferPackageRequest, CreateTransferPackageResponse>
+                    handler);
+
+    /**
+     * deletes a transfer Package
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteTransferPackageResponse> deleteTransferPackage(
+            DeleteTransferPackageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferPackageRequest, DeleteTransferPackageResponse>
+                    handler);
+
+    /**
+     * Detaches Devices from a Transfer Package
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DetachDevicesFromTransferPackageResponse>
+            detachDevicesFromTransferPackage(
+                    DetachDevicesFromTransferPackageRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DetachDevicesFromTransferPackageRequest,
+                                    DetachDevicesFromTransferPackageResponse>
+                            handler);
+
+    /**
+     * Describes a transfer package in detail
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetTransferPackageResponse> getTransferPackage(
+            GetTransferPackageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferPackageRequest, GetTransferPackageResponse>
+                    handler);
+
+    /**
+     * Lists Transfer Packages associated with a transferJob
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListTransferPackagesResponse> listTransferPackages(
+            ListTransferPackagesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferPackagesRequest, ListTransferPackagesResponse>
+                    handler);
+
+    /**
+     * Updates a Transfer Package
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateTransferPackageResponse> updateTransferPackage(
+            UpdateTransferPackageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferPackageRequest, UpdateTransferPackageResponse>
+                    handler);
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
@@ -1,0 +1,903 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Async client implementation for TransferPackage service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferPackageAsyncClient implements TransferPackageAsync {
+    /**
+     * Service instance for TransferPackage.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERPACKAGE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferPackageAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, TransferPackageAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferPackageAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferPackageAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<AttachDevicesToTransferPackageResponse>
+            attachDevicesToTransferPackage(
+                    final AttachDevicesToTransferPackageRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    AttachDevicesToTransferPackageRequest,
+                                    AttachDevicesToTransferPackageResponse>
+                            handler) {
+        LOG.trace("Called async attachDevicesToTransferPackage");
+        final AttachDevicesToTransferPackageRequest interceptedRequest =
+                AttachDevicesToTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AttachDevicesToTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AttachDevicesToTransferPackageResponse>
+                transformer = AttachDevicesToTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AttachDevicesToTransferPackageRequest,
+                        AttachDevicesToTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            AttachDevicesToTransferPackageRequest,
+                            AttachDevicesToTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getAttachDevicesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getAttachDevicesDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, AttachDevicesToTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getAttachDevicesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateTransferPackageResponse> createTransferPackage(
+            final CreateTransferPackageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateTransferPackageRequest, CreateTransferPackageResponse>
+                    handler) {
+        LOG.trace("Called async createTransferPackage");
+        final CreateTransferPackageRequest interceptedRequest =
+                CreateTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferPackageResponse>
+                transformer = CreateTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateTransferPackageRequest, CreateTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateTransferPackageRequest, CreateTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferPackageDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateTransferPackageDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateTransferPackageDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteTransferPackageResponse> deleteTransferPackage(
+            final DeleteTransferPackageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteTransferPackageRequest, DeleteTransferPackageResponse>
+                    handler) {
+        LOG.trace("Called async deleteTransferPackage");
+        final DeleteTransferPackageRequest interceptedRequest =
+                DeleteTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferPackageResponse>
+                transformer = DeleteTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteTransferPackageRequest, DeleteTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteTransferPackageRequest, DeleteTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DetachDevicesFromTransferPackageResponse>
+            detachDevicesFromTransferPackage(
+                    final DetachDevicesFromTransferPackageRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DetachDevicesFromTransferPackageRequest,
+                                    DetachDevicesFromTransferPackageResponse>
+                            handler) {
+        LOG.trace("Called async detachDevicesFromTransferPackage");
+        final DetachDevicesFromTransferPackageRequest interceptedRequest =
+                DetachDevicesFromTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DetachDevicesFromTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DetachDevicesFromTransferPackageResponse>
+                transformer = DetachDevicesFromTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DetachDevicesFromTransferPackageRequest,
+                        DetachDevicesFromTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DetachDevicesFromTransferPackageRequest,
+                            DetachDevicesFromTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getDetachDevicesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getDetachDevicesDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DetachDevicesFromTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getDetachDevicesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetTransferPackageResponse> getTransferPackage(
+            final GetTransferPackageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetTransferPackageRequest, GetTransferPackageResponse>
+                    handler) {
+        LOG.trace("Called async getTransferPackage");
+        final GetTransferPackageRequest interceptedRequest =
+                GetTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferPackageResponse>
+                transformer = GetTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetTransferPackageRequest, GetTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetTransferPackageRequest, GetTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListTransferPackagesResponse> listTransferPackages(
+            final ListTransferPackagesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListTransferPackagesRequest, ListTransferPackagesResponse>
+                    handler) {
+        LOG.trace("Called async listTransferPackages");
+        final ListTransferPackagesRequest interceptedRequest =
+                ListTransferPackagesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferPackagesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferPackagesResponse>
+                transformer = ListTransferPackagesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListTransferPackagesRequest, ListTransferPackagesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListTransferPackagesRequest, ListTransferPackagesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListTransferPackagesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateTransferPackageResponse> updateTransferPackage(
+            final UpdateTransferPackageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateTransferPackageRequest, UpdateTransferPackageResponse>
+                    handler) {
+        LOG.trace("Called async updateTransferPackage");
+        final UpdateTransferPackageRequest interceptedRequest =
+                UpdateTransferPackageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferPackageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferPackageResponse>
+                transformer = UpdateTransferPackageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateTransferPackageRequest, UpdateTransferPackageResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateTransferPackageRequest, UpdateTransferPackageResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferPackageDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateTransferPackageDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateTransferPackageResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateTransferPackageDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
@@ -1,0 +1,599 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import java.util.Locale;
+import com.oracle.bmc.dts.internal.http.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class TransferPackageClient implements TransferPackage {
+    /**
+     * Service instance for TransferPackage.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("TRANSFERPACKAGE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final TransferPackageWaiters waiters;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public TransferPackageClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("TransferPackage-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new TransferPackageWaiters(executorService, this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, TransferPackageClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public TransferPackageClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new TransferPackageClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public AttachDevicesToTransferPackageResponse attachDevicesToTransferPackage(
+            AttachDevicesToTransferPackageRequest request) {
+        LOG.trace("Called attachDevicesToTransferPackage");
+        final AttachDevicesToTransferPackageRequest interceptedRequest =
+                AttachDevicesToTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AttachDevicesToTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AttachDevicesToTransferPackageResponse>
+                transformer = AttachDevicesToTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAttachDevicesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateTransferPackageResponse createTransferPackage(
+            CreateTransferPackageRequest request) {
+        LOG.trace("Called createTransferPackage");
+        final CreateTransferPackageRequest interceptedRequest =
+                CreateTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferPackageResponse>
+                transformer = CreateTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateTransferPackageDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteTransferPackageResponse deleteTransferPackage(
+            DeleteTransferPackageRequest request) {
+        LOG.trace("Called deleteTransferPackage");
+        final DeleteTransferPackageRequest interceptedRequest =
+                DeleteTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferPackageResponse>
+                transformer = DeleteTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DetachDevicesFromTransferPackageResponse detachDevicesFromTransferPackage(
+            DetachDevicesFromTransferPackageRequest request) {
+        LOG.trace("Called detachDevicesFromTransferPackage");
+        final DetachDevicesFromTransferPackageRequest interceptedRequest =
+                DetachDevicesFromTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DetachDevicesFromTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DetachDevicesFromTransferPackageResponse>
+                transformer = DetachDevicesFromTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getDetachDevicesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetTransferPackageResponse getTransferPackage(GetTransferPackageRequest request) {
+        LOG.trace("Called getTransferPackage");
+        final GetTransferPackageRequest interceptedRequest =
+                GetTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferPackageResponse>
+                transformer = GetTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListTransferPackagesResponse listTransferPackages(ListTransferPackagesRequest request) {
+        LOG.trace("Called listTransferPackages");
+        final ListTransferPackagesRequest interceptedRequest =
+                ListTransferPackagesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferPackagesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferPackagesResponse>
+                transformer = ListTransferPackagesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateTransferPackageResponse updateTransferPackage(
+            UpdateTransferPackageRequest request) {
+        LOG.trace("Called updateTransferPackage");
+        final UpdateTransferPackageRequest interceptedRequest =
+                UpdateTransferPackageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateTransferPackageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferPackageResponse>
+                transformer = UpdateTransferPackageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateTransferPackageDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public TransferPackageWaiters getWaiters() {
+        return waiters;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of TransferPackage.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.RequiredArgsConstructor
+public class TransferPackageWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final TransferPackage client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferPackageRequest, GetTransferPackageResponse>
+            forTransferPackage(
+                    GetTransferPackageRequest request,
+                    com.oracle.bmc.dts.model.TransferPackage.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forTransferPackage(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferPackageRequest, GetTransferPackageResponse>
+            forTransferPackage(
+                    GetTransferPackageRequest request,
+                    com.oracle.bmc.dts.model.TransferPackage.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forTransferPackage(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetTransferPackageRequest, GetTransferPackageResponse>
+            forTransferPackage(
+                    GetTransferPackageRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dts.model.TransferPackage.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forTransferPackage(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for TransferPackage.
+    private com.oracle.bmc.waiter.Waiter<GetTransferPackageRequest, GetTransferPackageResponse>
+            forTransferPackage(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetTransferPackageRequest request,
+                    final com.oracle.bmc.dts.model.TransferPackage.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.dts.model.TransferPackage.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetTransferPackageRequest, GetTransferPackageResponse>() {
+                            @Override
+                            public GetTransferPackageResponse apply(
+                                    GetTransferPackageRequest request) {
+                                return client.getTransferPackage(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetTransferPackageResponse>() {
+                            @Override
+                            public boolean apply(GetTransferPackageResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getTransferPackage().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dts.model.TransferPackage.LifecycleState.Deleted)),
+                request);
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class AttachDevicesToTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static AttachDevicesToTransferPackageRequest interceptRequest(
+            AttachDevicesToTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            AttachDevicesToTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferPackageLabel(), "transferPackageLabel must not be blank");
+        Validate.notNull(request.getAttachDevicesDetails(), "attachDevicesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferPackageLabel()))
+                        .path("actions")
+                        .path("attachDevices");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, AttachDevicesToTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AttachDevicesToTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                AttachDevicesToTransferPackageResponse>() {
+                            @Override
+                            public AttachDevicesToTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for AttachDevicesToTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                AttachDevicesToTransferPackageResponse.Builder builder =
+                                        AttachDevicesToTransferPackageResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                AttachDevicesToTransferPackageResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ChangeTransferJobCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeTransferJobCompartmentRequest interceptRequest(
+            ChangeTransferJobCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeTransferJobCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getTransferJobId(), "transferJobId must not be blank");
+        Validate.notNull(
+                request.getChangeTransferJobCompartmentDetails(),
+                "changeTransferJobCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferJobId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ChangeTransferJobCompartmentResponse>() {
+                            @Override
+                            public ChangeTransferJobCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeTransferJobCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeTransferJobCompartmentResponse.Builder builder =
+                                        ChangeTransferJobCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                ChangeTransferJobCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferApplianceAdminCredentialsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferApplianceAdminCredentialsRequest interceptRequest(
+            CreateTransferApplianceAdminCredentialsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateTransferApplianceAdminCredentialsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+        Validate.notNull(request.getAdminPublicKey(), "adminPublicKey is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()))
+                        .path("admin_credentials");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferApplianceAdminCredentialsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceAdminCredentialsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                CreateTransferApplianceAdminCredentialsResponse>() {
+                            @Override
+                            public CreateTransferApplianceAdminCredentialsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferApplianceAdminCredentialsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferApplianceCertificate>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferApplianceCertificate.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                TransferApplianceCertificate>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferApplianceAdminCredentialsResponse.Builder builder =
+                                        CreateTransferApplianceAdminCredentialsResponse.builder();
+
+                                builder.transferApplianceCertificate(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferApplianceAdminCredentialsResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferApplianceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferApplianceRequest interceptRequest(
+            CreateTransferApplianceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateTransferApplianceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferApplianceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateTransferApplianceResponse>() {
+                            @Override
+                            public CreateTransferApplianceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferApplianceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferAppliance>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferAppliance.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferAppliance>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferApplianceResponse.Builder builder =
+                                        CreateTransferApplianceResponse.builder();
+
+                                builder.transferAppliance(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferApplianceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferApplianceEntitlementConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferApplianceEntitlementRequest interceptRequest(
+            CreateTransferApplianceEntitlementRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateTransferApplianceEntitlementRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateTransferApplianceEntitlementDetails(),
+                "createTransferApplianceEntitlementDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20171001").path("transferApplianceEntitlement");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferApplianceEntitlementResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferApplianceEntitlementResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                CreateTransferApplianceEntitlementResponse>() {
+                            @Override
+                            public CreateTransferApplianceEntitlementResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferApplianceEntitlementResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferApplianceEntitlement>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferApplianceEntitlement.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                TransferApplianceEntitlement>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferApplianceEntitlementResponse.Builder builder =
+                                        CreateTransferApplianceEntitlementResponse.builder();
+
+                                builder.transferApplianceEntitlement(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferApplianceEntitlementResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferDeviceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferDeviceRequest interceptRequest(
+            CreateTransferDeviceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, CreateTransferDeviceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notNull(
+                request.getCreateTransferDeviceDetails(),
+                "createTransferDeviceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferDevices");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferDeviceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferDeviceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateTransferDeviceResponse>() {
+                            @Override
+                            public CreateTransferDeviceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferDeviceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        NewTransferDevice>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        NewTransferDevice.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<NewTransferDevice>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferDeviceResponse.Builder builder =
+                                        CreateTransferDeviceResponse.builder();
+
+                                builder.newTransferDevice(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferDeviceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferJobConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferJobRequest interceptRequest(CreateTransferJobRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, CreateTransferJobRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateTransferJobDetails(), "createTransferJobDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20171001").path("transferJobs");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferJobResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateTransferJobResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateTransferJobResponse>() {
+                            @Override
+                            public CreateTransferJobResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferJobResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferJob>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferJob.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferJob> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferJobResponse.Builder builder =
+                                        CreateTransferJobResponse.builder();
+
+                                builder.transferJob(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferJobResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class CreateTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateTransferPackageRequest interceptRequest(
+            CreateTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, CreateTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateTransferPackageResponse>() {
+                            @Override
+                            public CreateTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferPackage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferPackage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferPackage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateTransferPackageResponse.Builder builder =
+                                        CreateTransferPackageResponse.builder();
+
+                                builder.transferPackage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                CreateTransferPackageResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class DeleteTransferApplianceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteTransferApplianceRequest interceptRequest(
+            DeleteTransferApplianceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DeleteTransferApplianceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteTransferApplianceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferApplianceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteTransferApplianceResponse>() {
+                            @Override
+                            public DeleteTransferApplianceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteTransferApplianceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteTransferApplianceResponse.Builder builder =
+                                        DeleteTransferApplianceResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteTransferApplianceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class DeleteTransferDeviceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteTransferDeviceRequest interceptRequest(
+            DeleteTransferDeviceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteTransferDeviceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferDeviceLabel(), "transferDeviceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferDevices")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferDeviceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteTransferDeviceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferDeviceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteTransferDeviceResponse>() {
+                            @Override
+                            public DeleteTransferDeviceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteTransferDeviceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteTransferDeviceResponse.Builder builder =
+                                        DeleteTransferDeviceResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteTransferDeviceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class DeleteTransferJobConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteTransferJobRequest interceptRequest(DeleteTransferJobRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteTransferJobRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteTransferJobResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteTransferJobResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteTransferJobResponse>() {
+                            @Override
+                            public DeleteTransferJobResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteTransferJobResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteTransferJobResponse.Builder builder =
+                                        DeleteTransferJobResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteTransferJobResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class DeleteTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteTransferPackageRequest interceptRequest(
+            DeleteTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferPackageLabel(), "transferPackageLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferPackageLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteTransferPackageResponse>() {
+                            @Override
+                            public DeleteTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteTransferPackageResponse.Builder builder =
+                                        DeleteTransferPackageResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteTransferPackageResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class DetachDevicesFromTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DetachDevicesFromTransferPackageRequest interceptRequest(
+            DetachDevicesFromTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DetachDevicesFromTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferPackageLabel(), "transferPackageLabel must not be blank");
+        Validate.notNull(request.getDetachDevicesDetails(), "detachDevicesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferPackageLabel()))
+                        .path("actions")
+                        .path("detachDevices");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DetachDevicesFromTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DetachDevicesFromTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                DetachDevicesFromTransferPackageResponse>() {
+                            @Override
+                            public DetachDevicesFromTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DetachDevicesFromTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DetachDevicesFromTransferPackageResponse.Builder builder =
+                                        DetachDevicesFromTransferPackageResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                DetachDevicesFromTransferPackageResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferApplianceCertificateAuthorityCertificateConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferApplianceCertificateAuthorityCertificateRequest interceptRequest(
+            GetTransferApplianceCertificateAuthorityCertificateRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetTransferApplianceCertificateAuthorityCertificateRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()))
+                        .path("certificate_authority_certificate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    GetTransferApplianceCertificateAuthorityCertificateResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetTransferApplianceCertificateAuthorityCertificateResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GetTransferApplianceCertificateAuthorityCertificateResponse>() {
+                            @Override
+                            public GetTransferApplianceCertificateAuthorityCertificateResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferApplianceCertificateAuthorityCertificateResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferApplianceCertificate>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferApplianceCertificate.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                TransferApplianceCertificate>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferApplianceCertificateAuthorityCertificateResponse.Builder
+                                        builder =
+                                                GetTransferApplianceCertificateAuthorityCertificateResponse
+                                                        .builder();
+
+                                builder.transferApplianceCertificate(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferApplianceCertificateAuthorityCertificateResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferApplianceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferApplianceRequest interceptRequest(
+            GetTransferApplianceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetTransferApplianceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetTransferApplianceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetTransferApplianceResponse>() {
+                            @Override
+                            public GetTransferApplianceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferApplianceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferAppliance>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferAppliance.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferAppliance>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferApplianceResponse.Builder builder =
+                                        GetTransferApplianceResponse.builder();
+
+                                builder.transferAppliance(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferApplianceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferApplianceEncryptionPassphraseConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferApplianceEncryptionPassphraseRequest interceptRequest(
+            GetTransferApplianceEncryptionPassphraseRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetTransferApplianceEncryptionPassphraseRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()))
+                        .path("encryptionPassphrase");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetTransferApplianceEncryptionPassphraseResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEncryptionPassphraseResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GetTransferApplianceEncryptionPassphraseResponse>() {
+                            @Override
+                            public GetTransferApplianceEncryptionPassphraseResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferApplianceEncryptionPassphraseResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferApplianceEncryptionPassphrase>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferApplianceEncryptionPassphrase
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                TransferApplianceEncryptionPassphrase>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferApplianceEncryptionPassphraseResponse.Builder builder =
+                                        GetTransferApplianceEncryptionPassphraseResponse.builder();
+
+                                builder.transferApplianceEncryptionPassphrase(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferApplianceEncryptionPassphraseResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferApplianceEntitlementConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferApplianceEntitlementRequest interceptRequest(
+            GetTransferApplianceEntitlementRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetTransferApplianceEntitlementRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getTenantId(), "tenantId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferApplianceEntitlement")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTenantId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GetTransferApplianceEntitlementResponse>() {
+                            @Override
+                            public GetTransferApplianceEntitlementResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferApplianceEntitlementResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferApplianceEntitlement>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferApplianceEntitlement.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                TransferApplianceEntitlement>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferApplianceEntitlementResponse.Builder builder =
+                                        GetTransferApplianceEntitlementResponse.builder();
+
+                                builder.transferApplianceEntitlement(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetTransferApplianceEntitlementResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferDeviceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferDeviceRequest interceptRequest(GetTransferDeviceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetTransferDeviceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferDeviceLabel(), "transferDeviceLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferDevices")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferDeviceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetTransferDeviceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferDeviceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetTransferDeviceResponse>() {
+                            @Override
+                            public GetTransferDeviceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferDeviceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferDevice>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferDevice.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferDevice> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferDeviceResponse.Builder builder =
+                                        GetTransferDeviceResponse.builder();
+
+                                builder.transferDevice(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferDeviceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferJobConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferJobRequest interceptRequest(GetTransferJobRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetTransferJobRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferJobResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferJobResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetTransferJobResponse>() {
+                            @Override
+                            public GetTransferJobResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for GetTransferJobResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferJob>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferJob.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferJob> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferJobResponse.Builder builder =
+                                        GetTransferJobResponse.builder();
+
+                                builder.transferJob(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferJobResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class GetTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetTransferPackageRequest interceptRequest(GetTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferPackageLabel(), "transferPackageLabel must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferPackageLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetTransferPackageResponse>() {
+                            @Override
+                            public GetTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferPackage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferPackage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferPackage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetTransferPackageResponse.Builder builder =
+                                        GetTransferPackageResponse.builder();
+
+                                builder.transferPackage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                GetTransferPackageResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ListShippingVendorsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListShippingVendorsRequest interceptRequest(ListShippingVendorsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListShippingVendorsRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20171001").path("shippingVendors");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListShippingVendorsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListShippingVendorsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListShippingVendorsResponse>() {
+                            @Override
+                            public ListShippingVendorsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListShippingVendorsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ShippingVendors>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ShippingVendors.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ShippingVendors> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListShippingVendorsResponse.Builder builder =
+                                        ListShippingVendorsResponse.builder();
+
+                                builder.shippingVendors(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListShippingVendorsResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ListTransferAppliancesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListTransferAppliancesRequest interceptRequest(
+            ListTransferAppliancesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListTransferAppliancesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances");
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListTransferAppliancesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferAppliancesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListTransferAppliancesResponse>() {
+                            @Override
+                            public ListTransferAppliancesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListTransferAppliancesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        MultipleTransferAppliances>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        MultipleTransferAppliances.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<MultipleTransferAppliances>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListTransferAppliancesResponse.Builder builder =
+                                        ListTransferAppliancesResponse.builder();
+
+                                builder.multipleTransferAppliances(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListTransferAppliancesResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ListTransferDevicesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListTransferDevicesRequest interceptRequest(ListTransferDevicesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListTransferDevicesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferDevices");
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListTransferDevicesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferDevicesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListTransferDevicesResponse>() {
+                            @Override
+                            public ListTransferDevicesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListTransferDevicesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        MultipleTransferDevices>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        MultipleTransferDevices.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<MultipleTransferDevices>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListTransferDevicesResponse.Builder builder =
+                                        ListTransferDevicesResponse.builder();
+
+                                builder.multipleTransferDevices(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListTransferDevicesResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ListTransferJobsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListTransferJobsRequest interceptRequest(ListTransferJobsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListTransferJobsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20171001").path("transferJobs");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListTransferJobsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListTransferJobsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListTransferJobsResponse>() {
+                            @Override
+                            public ListTransferJobsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListTransferJobsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<TransferJobSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        TransferJobSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<TransferJobSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListTransferJobsResponse.Builder builder =
+                                        ListTransferJobsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListTransferJobsResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class ListTransferPackagesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListTransferPackagesRequest interceptRequest(
+            ListTransferPackagesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListTransferPackagesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages");
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListTransferPackagesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferPackagesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListTransferPackagesResponse>() {
+                            @Override
+                            public ListTransferPackagesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListTransferPackagesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        MultipleTransferPackages>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        MultipleTransferPackages.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<MultipleTransferPackages>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListTransferPackagesResponse.Builder builder =
+                                        ListTransferPackagesResponse.builder();
+
+                                builder.multipleTransferPackages(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListTransferPackagesResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class UpdateTransferApplianceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateTransferApplianceRequest interceptRequest(
+            UpdateTransferApplianceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateTransferApplianceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferApplianceLabel(), "transferApplianceLabel must not be blank");
+        Validate.notNull(
+                request.getUpdateTransferApplianceDetails(),
+                "updateTransferApplianceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferAppliances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferApplianceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateTransferApplianceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferApplianceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateTransferApplianceResponse>() {
+                            @Override
+                            public UpdateTransferApplianceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateTransferApplianceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferAppliance>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferAppliance.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferAppliance>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateTransferApplianceResponse.Builder builder =
+                                        UpdateTransferApplianceResponse.builder();
+
+                                builder.transferAppliance(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                UpdateTransferApplianceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class UpdateTransferDeviceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateTransferDeviceRequest interceptRequest(
+            UpdateTransferDeviceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateTransferDeviceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferDeviceLabel(), "transferDeviceLabel must not be blank");
+        Validate.notNull(
+                request.getUpdateTransferDeviceDetails(),
+                "updateTransferDeviceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferDevices")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferDeviceLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateTransferDeviceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferDeviceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateTransferDeviceResponse>() {
+                            @Override
+                            public UpdateTransferDeviceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateTransferDeviceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferDevice>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferDevice.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferDevice> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateTransferDeviceResponse.Builder builder =
+                                        UpdateTransferDeviceResponse.builder();
+
+                                builder.transferDevice(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                UpdateTransferDeviceResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class UpdateTransferJobConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateTransferJobRequest interceptRequest(UpdateTransferJobRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateTransferJobRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notNull(
+                request.getUpdateTransferJobDetails(), "updateTransferJobDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateTransferJobResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateTransferJobResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateTransferJobResponse>() {
+                            @Override
+                            public UpdateTransferJobResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateTransferJobResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferJob>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferJob.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferJob> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateTransferJobResponse.Builder builder =
+                                        UpdateTransferJobResponse.builder();
+
+                                builder.transferJob(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                UpdateTransferJobResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.extern.slf4j.Slf4j
+public class UpdateTransferPackageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateTransferPackageRequest interceptRequest(
+            UpdateTransferPackageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateTransferPackageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getId(), "id must not be blank");
+        Validate.notBlank(
+                request.getTransferPackageLabel(), "transferPackageLabel must not be blank");
+        Validate.notNull(
+                request.getUpdateTransferPackageDetails(),
+                "updateTransferPackageDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20171001")
+                        .path("transferJobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getId()))
+                        .path("transferPackages")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTransferPackageLabel()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateTransferPackageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateTransferPackageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateTransferPackageResponse>() {
+                            @Override
+                            public UpdateTransferPackageResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateTransferPackageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        TransferPackage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        TransferPackage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<TransferPackage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateTransferPackageResponse.Builder builder =
+                                        UpdateTransferPackageResponse.builder();
+
+                                builder.transferPackage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                UpdateTransferPackageResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AttachDevicesDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AttachDevicesDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceLabels")
+        private java.util.List<String> deviceLabels;
+
+        public Builder deviceLabels(java.util.List<String> deviceLabels) {
+            this.deviceLabels = deviceLabels;
+            this.__explicitlySet__.add("deviceLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AttachDevicesDetails build() {
+            AttachDevicesDetails __instance__ = new AttachDevicesDetails(deviceLabels);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AttachDevicesDetails o) {
+            Builder copiedBuilder = deviceLabels(o.getDeviceLabels());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of TransferDeviceLabel's
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceLabels")
+    java.util.List<String> deviceLabels;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeTransferJobCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeTransferJobCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeTransferJobCompartmentDetails build() {
+            ChangeTransferJobCompartmentDetails __instance__ =
+                    new ChangeTransferJobCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeTransferJobCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID] (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment into which the resources should be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTransferApplianceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTransferApplianceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+        private ShippingAddress customerShippingAddress;
+
+        public Builder customerShippingAddress(ShippingAddress customerShippingAddress) {
+            this.customerShippingAddress = customerShippingAddress;
+            this.__explicitlySet__.add("customerShippingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTransferApplianceDetails build() {
+            CreateTransferApplianceDetails __instance__ =
+                    new CreateTransferApplianceDetails(customerShippingAddress);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTransferApplianceDetails o) {
+            Builder copiedBuilder = customerShippingAddress(o.getCustomerShippingAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+    ShippingAddress customerShippingAddress;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTransferApplianceEntitlementDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTransferApplianceEntitlementDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+        private String requestorName;
+
+        public Builder requestorName(String requestorName) {
+            this.requestorName = requestorName;
+            this.__explicitlySet__.add("requestorName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+        private String requestorEmail;
+
+        public Builder requestorEmail(String requestorEmail) {
+            this.requestorEmail = requestorEmail;
+            this.__explicitlySet__.add("requestorEmail");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTransferApplianceEntitlementDetails build() {
+            CreateTransferApplianceEntitlementDetails __instance__ =
+                    new CreateTransferApplianceEntitlementDetails(
+                            compartmentId, requestorName, requestorEmail);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTransferApplianceEntitlementDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .requestorName(o.getRequestorName())
+                            .requestorEmail(o.getRequestorEmail());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+    String requestorName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+    String requestorEmail;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTransferDeviceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTransferDeviceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+        private String iscsiIQN;
+
+        public Builder iscsiIQN(String iscsiIQN) {
+            this.iscsiIQN = iscsiIQN;
+            this.__explicitlySet__.add("iscsiIQN");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTransferDeviceDetails build() {
+            CreateTransferDeviceDetails __instance__ =
+                    new CreateTransferDeviceDetails(serialNumber, iscsiIQN);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTransferDeviceDetails o) {
+            Builder copiedBuilder = serialNumber(o.getSerialNumber()).iscsiIQN(o.getIscsiIQN());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+    String iscsiIQN;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTransferJobDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTransferJobDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+        private String uploadBucketName;
+
+        public Builder uploadBucketName(String uploadBucketName) {
+            this.uploadBucketName = uploadBucketName;
+            this.__explicitlySet__.add("uploadBucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+        private DeviceType deviceType;
+
+        public Builder deviceType(DeviceType deviceType) {
+            this.deviceType = deviceType;
+            this.__explicitlySet__.add("deviceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTransferJobDetails build() {
+            CreateTransferJobDetails __instance__ =
+                    new CreateTransferJobDetails(
+                            compartmentId,
+                            uploadBucketName,
+                            displayName,
+                            deviceType,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTransferJobDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .uploadBucketName(o.getUploadBucketName())
+                            .displayName(o.getDisplayName())
+                            .deviceType(o.getDeviceType())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+    String uploadBucketName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+    /**
+     **/
+    public enum DeviceType {
+        Disk("DISK"),
+        Appliance("APPLIANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DeviceType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DeviceType v : DeviceType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DeviceType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DeviceType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid DeviceType: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+    DeviceType deviceType;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTransferPackageDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTransferPackageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+        private String originalPackageDeliveryTrackingNumber;
+
+        public Builder originalPackageDeliveryTrackingNumber(
+                String originalPackageDeliveryTrackingNumber) {
+            this.originalPackageDeliveryTrackingNumber = originalPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("originalPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+        private String returnPackageDeliveryTrackingNumber;
+
+        public Builder returnPackageDeliveryTrackingNumber(
+                String returnPackageDeliveryTrackingNumber) {
+            this.returnPackageDeliveryTrackingNumber = returnPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("returnPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+        private String packageDeliveryVendor;
+
+        public Builder packageDeliveryVendor(String packageDeliveryVendor) {
+            this.packageDeliveryVendor = packageDeliveryVendor;
+            this.__explicitlySet__.add("packageDeliveryVendor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTransferPackageDetails build() {
+            CreateTransferPackageDetails __instance__ =
+                    new CreateTransferPackageDetails(
+                            originalPackageDeliveryTrackingNumber,
+                            returnPackageDeliveryTrackingNumber,
+                            packageDeliveryVendor);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTransferPackageDetails o) {
+            Builder copiedBuilder =
+                    originalPackageDeliveryTrackingNumber(
+                                    o.getOriginalPackageDeliveryTrackingNumber())
+                            .returnPackageDeliveryTrackingNumber(
+                                    o.getReturnPackageDeliveryTrackingNumber())
+                            .packageDeliveryVendor(o.getPackageDeliveryVendor());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+    String originalPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+    String returnPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+    String packageDeliveryVendor;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DetachDevicesDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class DetachDevicesDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceLabels")
+        private java.util.List<String> deviceLabels;
+
+        public Builder deviceLabels(java.util.List<String> deviceLabels) {
+            this.deviceLabels = deviceLabels;
+            this.__explicitlySet__.add("deviceLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DetachDevicesDetails build() {
+            DetachDevicesDetails __instance__ = new DetachDevicesDetails(deviceLabels);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DetachDevicesDetails o) {
+            Builder copiedBuilder = deviceLabels(o.getDeviceLabels());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of TransferDeviceLabel's
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceLabels")
+    java.util.List<String> deviceLabels;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MultipleTransferAppliances.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class MultipleTransferAppliances {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("transferApplianceObjects")
+        private java.util.List<TransferApplianceSummary> transferApplianceObjects;
+
+        public Builder transferApplianceObjects(
+                java.util.List<TransferApplianceSummary> transferApplianceObjects) {
+            this.transferApplianceObjects = transferApplianceObjects;
+            this.__explicitlySet__.add("transferApplianceObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MultipleTransferAppliances build() {
+            MultipleTransferAppliances __instance__ =
+                    new MultipleTransferAppliances(transferApplianceObjects);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MultipleTransferAppliances o) {
+            Builder copiedBuilder = transferApplianceObjects(o.getTransferApplianceObjects());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of TransferAppliance summary's
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("transferApplianceObjects")
+    java.util.List<TransferApplianceSummary> transferApplianceObjects;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MultipleTransferDevices.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class MultipleTransferDevices {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("transferDeviceObjects")
+        private java.util.List<TransferDeviceSummary> transferDeviceObjects;
+
+        public Builder transferDeviceObjects(
+                java.util.List<TransferDeviceSummary> transferDeviceObjects) {
+            this.transferDeviceObjects = transferDeviceObjects;
+            this.__explicitlySet__.add("transferDeviceObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MultipleTransferDevices build() {
+            MultipleTransferDevices __instance__ =
+                    new MultipleTransferDevices(transferDeviceObjects);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MultipleTransferDevices o) {
+            Builder copiedBuilder = transferDeviceObjects(o.getTransferDeviceObjects());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of TransferDeviceObject's
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("transferDeviceObjects")
+    java.util.List<TransferDeviceSummary> transferDeviceObjects;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MultipleTransferPackages.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class MultipleTransferPackages {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("transferPackageObjects")
+        private java.util.List<TransferPackageSummary> transferPackageObjects;
+
+        public Builder transferPackageObjects(
+                java.util.List<TransferPackageSummary> transferPackageObjects) {
+            this.transferPackageObjects = transferPackageObjects;
+            this.__explicitlySet__.add("transferPackageObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MultipleTransferPackages build() {
+            MultipleTransferPackages __instance__ =
+                    new MultipleTransferPackages(transferPackageObjects);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MultipleTransferPackages o) {
+            Builder copiedBuilder = transferPackageObjects(o.getTransferPackageObjects());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of TransferPackage summary's
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("transferPackageObjects")
+    java.util.List<TransferPackageSummary> transferPackageObjects;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NewTransferDevice.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class NewTransferDevice {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+        private String iscsiIQN;
+
+        public Builder iscsiIQN(String iscsiIQN) {
+            this.iscsiIQN = iscsiIQN;
+            this.__explicitlySet__.add("iscsiIQN");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("encryptionPassphrase")
+        private String encryptionPassphrase;
+
+        public Builder encryptionPassphrase(String encryptionPassphrase) {
+            this.encryptionPassphrase = encryptionPassphrase;
+            this.__explicitlySet__.add("encryptionPassphrase");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+        private String transferJobId;
+
+        public Builder transferJobId(String transferJobId) {
+            this.transferJobId = transferJobId;
+            this.__explicitlySet__.add("transferJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NewTransferDevice build() {
+            NewTransferDevice __instance__ =
+                    new NewTransferDevice(
+                            label,
+                            serialNumber,
+                            iscsiIQN,
+                            lifecycleState,
+                            encryptionPassphrase,
+                            transferJobId,
+                            creationTime);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NewTransferDevice o) {
+            Builder copiedBuilder =
+                    label(o.getLabel())
+                            .serialNumber(o.getSerialNumber())
+                            .iscsiIQN(o.getIscsiIQN())
+                            .lifecycleState(o.getLifecycleState())
+                            .encryptionPassphrase(o.getEncryptionPassphrase())
+                            .transferJobId(o.getTransferJobId())
+                            .creationTime(o.getCreationTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+    String iscsiIQN;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("encryptionPassphrase")
+    String encryptionPassphrase;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+    String transferJobId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingAddress.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ShippingAddress {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("addressee")
+        private String addressee;
+
+        public Builder addressee(String addressee) {
+            this.addressee = addressee;
+            this.__explicitlySet__.add("addressee");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("careOf")
+        private String careOf;
+
+        public Builder careOf(String careOf) {
+            this.careOf = careOf;
+            this.__explicitlySet__.add("careOf");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("address1")
+        private String address1;
+
+        public Builder address1(String address1) {
+            this.address1 = address1;
+            this.__explicitlySet__.add("address1");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("address2")
+        private String address2;
+
+        public Builder address2(String address2) {
+            this.address2 = address2;
+            this.__explicitlySet__.add("address2");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("address3")
+        private String address3;
+
+        public Builder address3(String address3) {
+            this.address3 = address3;
+            this.__explicitlySet__.add("address3");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("address4")
+        private String address4;
+
+        public Builder address4(String address4) {
+            this.address4 = address4;
+            this.__explicitlySet__.add("address4");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cityOrLocality")
+        private String cityOrLocality;
+
+        public Builder cityOrLocality(String cityOrLocality) {
+            this.cityOrLocality = cityOrLocality;
+            this.__explicitlySet__.add("cityOrLocality");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stateOrRegion")
+        private String stateOrRegion;
+
+        public Builder stateOrRegion(String stateOrRegion) {
+            this.stateOrRegion = stateOrRegion;
+            this.__explicitlySet__.add("stateOrRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zipcode")
+        private String zipcode;
+
+        public Builder zipcode(String zipcode) {
+            this.zipcode = zipcode;
+            this.__explicitlySet__.add("zipcode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("country")
+        private String country;
+
+        public Builder country(String country) {
+            this.country = country;
+            this.__explicitlySet__.add("country");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("phoneNumber")
+        private String phoneNumber;
+
+        public Builder phoneNumber(String phoneNumber) {
+            this.phoneNumber = phoneNumber;
+            this.__explicitlySet__.add("phoneNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("email")
+        private String email;
+
+        public Builder email(String email) {
+            this.email = email;
+            this.__explicitlySet__.add("email");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ShippingAddress build() {
+            ShippingAddress __instance__ =
+                    new ShippingAddress(
+                            addressee,
+                            careOf,
+                            address1,
+                            address2,
+                            address3,
+                            address4,
+                            cityOrLocality,
+                            stateOrRegion,
+                            zipcode,
+                            country,
+                            phoneNumber,
+                            email);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ShippingAddress o) {
+            Builder copiedBuilder =
+                    addressee(o.getAddressee())
+                            .careOf(o.getCareOf())
+                            .address1(o.getAddress1())
+                            .address2(o.getAddress2())
+                            .address3(o.getAddress3())
+                            .address4(o.getAddress4())
+                            .cityOrLocality(o.getCityOrLocality())
+                            .stateOrRegion(o.getStateOrRegion())
+                            .zipcode(o.getZipcode())
+                            .country(o.getCountry())
+                            .phoneNumber(o.getPhoneNumber())
+                            .email(o.getEmail());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("addressee")
+    String addressee;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("careOf")
+    String careOf;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("address1")
+    String address1;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("address2")
+    String address2;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("address3")
+    String address3;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("address4")
+    String address4;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("cityOrLocality")
+    String cityOrLocality;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stateOrRegion")
+    String stateOrRegion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("zipcode")
+    String zipcode;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("country")
+    String country;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("phoneNumber")
+    String phoneNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("email")
+    String email;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingVendors.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ShippingVendors {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vendors")
+        private java.util.List<String> vendors;
+
+        public Builder vendors(java.util.List<String> vendors) {
+            this.vendors = vendors;
+            this.__explicitlySet__.add("vendors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ShippingVendors build() {
+            ShippingVendors __instance__ = new ShippingVendors(vendors);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ShippingVendors o) {
+            Builder copiedBuilder = vendors(o.getVendors());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of available shipping vendors for package delivery
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vendors")
+    java.util.List<String> vendors;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferAppliance.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferAppliance {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+        private String transferJobId;
+
+        public Builder transferJobId(String transferJobId) {
+            this.transferJobId = transferJobId;
+            this.__explicitlySet__.add("transferJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReceivedTime")
+        private java.util.Date customerReceivedTime;
+
+        public Builder customerReceivedTime(java.util.Date customerReceivedTime) {
+            this.customerReceivedTime = customerReceivedTime;
+            this.__explicitlySet__.add("customerReceivedTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerReturnedTime")
+        private java.util.Date customerReturnedTime;
+
+        public Builder customerReturnedTime(java.util.Date customerReturnedTime) {
+            this.customerReturnedTime = customerReturnedTime;
+            this.__explicitlySet__.add("customerReturnedTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nextBillingTime")
+        private java.util.Date nextBillingTime;
+
+        public Builder nextBillingTime(java.util.Date nextBillingTime) {
+            this.nextBillingTime = nextBillingTime;
+            this.__explicitlySet__.add("nextBillingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deliverySecurityTieId")
+        private String deliverySecurityTieId;
+
+        public Builder deliverySecurityTieId(String deliverySecurityTieId) {
+            this.deliverySecurityTieId = deliverySecurityTieId;
+            this.__explicitlySet__.add("deliverySecurityTieId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("returnSecurityTieId")
+        private String returnSecurityTieId;
+
+        public Builder returnSecurityTieId(String returnSecurityTieId) {
+            this.returnSecurityTieId = returnSecurityTieId;
+            this.__explicitlySet__.add("returnSecurityTieId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applianceDeliveryTrackingNumber")
+        private String applianceDeliveryTrackingNumber;
+
+        public Builder applianceDeliveryTrackingNumber(String applianceDeliveryTrackingNumber) {
+            this.applianceDeliveryTrackingNumber = applianceDeliveryTrackingNumber;
+            this.__explicitlySet__.add("applianceDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applianceReturnDeliveryTrackingNumber")
+        private String applianceReturnDeliveryTrackingNumber;
+
+        public Builder applianceReturnDeliveryTrackingNumber(
+                String applianceReturnDeliveryTrackingNumber) {
+            this.applianceReturnDeliveryTrackingNumber = applianceReturnDeliveryTrackingNumber;
+            this.__explicitlySet__.add("applianceReturnDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applianceDeliveryVendor")
+        private String applianceDeliveryVendor;
+
+        public Builder applianceDeliveryVendor(String applianceDeliveryVendor) {
+            this.applianceDeliveryVendor = applianceDeliveryVendor;
+            this.__explicitlySet__.add("applianceDeliveryVendor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+        private ShippingAddress customerShippingAddress;
+
+        public Builder customerShippingAddress(ShippingAddress customerShippingAddress) {
+            this.customerShippingAddress = customerShippingAddress;
+            this.__explicitlySet__.add("customerShippingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+        private String uploadStatusLogUri;
+
+        public Builder uploadStatusLogUri(String uploadStatusLogUri) {
+            this.uploadStatusLogUri = uploadStatusLogUri;
+            this.__explicitlySet__.add("uploadStatusLogUri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferAppliance build() {
+            TransferAppliance __instance__ =
+                    new TransferAppliance(
+                            label,
+                            lifecycleState,
+                            transferJobId,
+                            serialNumber,
+                            creationTime,
+                            customerReceivedTime,
+                            customerReturnedTime,
+                            nextBillingTime,
+                            deliverySecurityTieId,
+                            returnSecurityTieId,
+                            applianceDeliveryTrackingNumber,
+                            applianceReturnDeliveryTrackingNumber,
+                            applianceDeliveryVendor,
+                            customerShippingAddress,
+                            uploadStatusLogUri);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferAppliance o) {
+            Builder copiedBuilder =
+                    label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .transferJobId(o.getTransferJobId())
+                            .serialNumber(o.getSerialNumber())
+                            .creationTime(o.getCreationTime())
+                            .customerReceivedTime(o.getCustomerReceivedTime())
+                            .customerReturnedTime(o.getCustomerReturnedTime())
+                            .nextBillingTime(o.getNextBillingTime())
+                            .deliverySecurityTieId(o.getDeliverySecurityTieId())
+                            .returnSecurityTieId(o.getReturnSecurityTieId())
+                            .applianceDeliveryTrackingNumber(o.getApplianceDeliveryTrackingNumber())
+                            .applianceReturnDeliveryTrackingNumber(
+                                    o.getApplianceReturnDeliveryTrackingNumber())
+                            .applianceDeliveryVendor(o.getApplianceDeliveryVendor())
+                            .customerShippingAddress(o.getCustomerShippingAddress())
+                            .uploadStatusLogUri(o.getUploadStatusLogUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique alpha-numeric identifier for a transfer appliance auto generated during create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Requested("REQUESTED"),
+        OraclePreparing("ORACLE_PREPARING"),
+        Shipping("SHIPPING"),
+        Delivered("DELIVERED"),
+        Preparing("PREPARING"),
+        ReturnShipped("RETURN_SHIPPED"),
+        ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
+        OracleReceived("ORACLE_RECEIVED"),
+        OracleReceivedCancelled("ORACLE_RECEIVED_CANCELLED"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        CustomerNeverReceived("CUSTOMER_NEVER_RECEIVED"),
+        OracleNeverReceived("ORACLE_NEVER_RECEIVED"),
+        CustomerLost("CUSTOMER_LOST"),
+        Cancelled("CANCELLED"),
+        Deleted("DELETED"),
+        Rejected("REJECTED"),
+        Error("ERROR"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+    String transferJobId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReceivedTime")
+    java.util.Date customerReceivedTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customerReturnedTime")
+    java.util.Date customerReturnedTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("nextBillingTime")
+    java.util.Date nextBillingTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deliverySecurityTieId")
+    String deliverySecurityTieId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("returnSecurityTieId")
+    String returnSecurityTieId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("applianceDeliveryTrackingNumber")
+    String applianceDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("applianceReturnDeliveryTrackingNumber")
+    String applianceReturnDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("applianceDeliveryVendor")
+    String applianceDeliveryVendor;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+    ShippingAddress customerShippingAddress;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+    String uploadStatusLogUri;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferApplianceCertificate.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferApplianceCertificate {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("certificate")
+        private String certificate;
+
+        public Builder certificate(String certificate) {
+            this.certificate = certificate;
+            this.__explicitlySet__.add("certificate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferApplianceCertificate build() {
+            TransferApplianceCertificate __instance__ =
+                    new TransferApplianceCertificate(certificate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferApplianceCertificate o) {
+            Builder copiedBuilder = certificate(o.getCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("certificate")
+    String certificate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferApplianceEncryptionPassphrase.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferApplianceEncryptionPassphrase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("encryptionPassphrase")
+        private String encryptionPassphrase;
+
+        public Builder encryptionPassphrase(String encryptionPassphrase) {
+            this.encryptionPassphrase = encryptionPassphrase;
+            this.__explicitlySet__.add("encryptionPassphrase");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferApplianceEncryptionPassphrase build() {
+            TransferApplianceEncryptionPassphrase __instance__ =
+                    new TransferApplianceEncryptionPassphrase(encryptionPassphrase);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferApplianceEncryptionPassphrase o) {
+            Builder copiedBuilder = encryptionPassphrase(o.getEncryptionPassphrase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("encryptionPassphrase")
+    String encryptionPassphrase;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferApplianceEntitlement.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferApplianceEntitlement {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
+        private String tenantId;
+
+        public Builder tenantId(String tenantId) {
+            this.tenantId = tenantId;
+            this.__explicitlySet__.add("tenantId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+        private String requestorName;
+
+        public Builder requestorName(String requestorName) {
+            this.requestorName = requestorName;
+            this.__explicitlySet__.add("requestorName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+        private String requestorEmail;
+
+        public Builder requestorEmail(String requestorEmail) {
+            this.requestorEmail = requestorEmail;
+            this.__explicitlySet__.add("requestorEmail");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("updateTime")
+        private java.util.Date updateTime;
+
+        public Builder updateTime(java.util.Date updateTime) {
+            this.updateTime = updateTime;
+            this.__explicitlySet__.add("updateTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferApplianceEntitlement build() {
+            TransferApplianceEntitlement __instance__ =
+                    new TransferApplianceEntitlement(
+                            tenantId,
+                            requestorName,
+                            requestorEmail,
+                            status,
+                            creationTime,
+                            updateTime);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferApplianceEntitlement o) {
+            Builder copiedBuilder =
+                    tenantId(o.getTenantId())
+                            .requestorName(o.getRequestorName())
+                            .requestorEmail(o.getRequestorEmail())
+                            .status(o.getStatus())
+                            .creationTime(o.getCreationTime())
+                            .updateTime(o.getUpdateTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
+    String tenantId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+    String requestorName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+    String requestorEmail;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Status {
+        Requested("REQUESTED"),
+        PendingSigning("PENDING_SIGNING"),
+        PendingApproval("PENDING_APPROVAL"),
+        TermsExpired("TERMS_EXPIRED"),
+        Approved("APPROVED"),
+        Rejected("REJECTED"),
+        Cancelled("CANCELLED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("updateTime")
+    java.util.Date updateTime;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferAppliancePublicKey.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferAppliancePublicKey {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("publicKey")
+        private String publicKey;
+
+        public Builder publicKey(String publicKey) {
+            this.publicKey = publicKey;
+            this.__explicitlySet__.add("publicKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferAppliancePublicKey build() {
+            TransferAppliancePublicKey __instance__ = new TransferAppliancePublicKey(publicKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferAppliancePublicKey o) {
+            Builder copiedBuilder = publicKey(o.getPublicKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("publicKey")
+    String publicKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferApplianceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferApplianceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferApplianceSummary build() {
+            TransferApplianceSummary __instance__ =
+                    new TransferApplianceSummary(label, lifecycleState, serialNumber, creationTime);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferApplianceSummary o) {
+            Builder copiedBuilder =
+                    label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .serialNumber(o.getSerialNumber())
+                            .creationTime(o.getCreationTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Requested("REQUESTED"),
+        OraclePreparing("ORACLE_PREPARING"),
+        Shipping("SHIPPING"),
+        Delivered("DELIVERED"),
+        Preparing("PREPARING"),
+        ReturnShipped("RETURN_SHIPPED"),
+        ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
+        OracleReceived("ORACLE_RECEIVED"),
+        OracleReceivedCancelled("ORACLE_RECEIVED_CANCELLED"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        CustomerNeverReceived("CUSTOMER_NEVER_RECEIVED"),
+        OracleNeverReceived("ORACLE_NEVER_RECEIVED"),
+        CustomerLost("CUSTOMER_LOST"),
+        Cancelled("CANCELLED"),
+        Deleted("DELETED"),
+        Rejected("REJECTED"),
+        Error("ERROR"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferDevice.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferDevice {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+        private String iscsiIQN;
+
+        public Builder iscsiIQN(String iscsiIQN) {
+            this.iscsiIQN = iscsiIQN;
+            this.__explicitlySet__.add("iscsiIQN");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+        private String transferJobId;
+
+        public Builder transferJobId(String transferJobId) {
+            this.transferJobId = transferJobId;
+            this.__explicitlySet__.add("transferJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabel")
+        private String attachedTransferPackageLabel;
+
+        public Builder attachedTransferPackageLabel(String attachedTransferPackageLabel) {
+            this.attachedTransferPackageLabel = attachedTransferPackageLabel;
+            this.__explicitlySet__.add("attachedTransferPackageLabel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+        private String uploadStatusLogUri;
+
+        public Builder uploadStatusLogUri(String uploadStatusLogUri) {
+            this.uploadStatusLogUri = uploadStatusLogUri;
+            this.__explicitlySet__.add("uploadStatusLogUri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferDevice build() {
+            TransferDevice __instance__ =
+                    new TransferDevice(
+                            serialNumber,
+                            iscsiIQN,
+                            label,
+                            lifecycleState,
+                            transferJobId,
+                            attachedTransferPackageLabel,
+                            creationTime,
+                            uploadStatusLogUri);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferDevice o) {
+            Builder copiedBuilder =
+                    serialNumber(o.getSerialNumber())
+                            .iscsiIQN(o.getIscsiIQN())
+                            .label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .transferJobId(o.getTransferJobId())
+                            .attachedTransferPackageLabel(o.getAttachedTransferPackageLabel())
+                            .creationTime(o.getCreationTime())
+                            .uploadStatusLogUri(o.getUploadStatusLogUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+    String iscsiIQN;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Ready("READY"),
+        Packaged("PACKAGED"),
+        Active("ACTIVE"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        Missing("MISSING"),
+        Error("ERROR"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+    String transferJobId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabel")
+    String attachedTransferPackageLabel;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+    String uploadStatusLogUri;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferDeviceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferDeviceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+        private String serialNumber;
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            this.__explicitlySet__.add("serialNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+        private String iscsiIQN;
+
+        public Builder iscsiIQN(String iscsiIQN) {
+            this.iscsiIQN = iscsiIQN;
+            this.__explicitlySet__.add("iscsiIQN");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabel")
+        private String attachedTransferPackageLabel;
+
+        public Builder attachedTransferPackageLabel(String attachedTransferPackageLabel) {
+            this.attachedTransferPackageLabel = attachedTransferPackageLabel;
+            this.__explicitlySet__.add("attachedTransferPackageLabel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+        private String uploadStatusLogUri;
+
+        public Builder uploadStatusLogUri(String uploadStatusLogUri) {
+            this.uploadStatusLogUri = uploadStatusLogUri;
+            this.__explicitlySet__.add("uploadStatusLogUri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferDeviceSummary build() {
+            TransferDeviceSummary __instance__ =
+                    new TransferDeviceSummary(
+                            serialNumber,
+                            iscsiIQN,
+                            label,
+                            lifecycleState,
+                            attachedTransferPackageLabel,
+                            creationTime,
+                            uploadStatusLogUri);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferDeviceSummary o) {
+            Builder copiedBuilder =
+                    serialNumber(o.getSerialNumber())
+                            .iscsiIQN(o.getIscsiIQN())
+                            .label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .attachedTransferPackageLabel(o.getAttachedTransferPackageLabel())
+                            .creationTime(o.getCreationTime())
+                            .uploadStatusLogUri(o.getUploadStatusLogUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
+    String serialNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("iscsiIQN")
+    String iscsiIQN;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Ready("READY"),
+        Packaged("PACKAGED"),
+        Active("ACTIVE"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        Missing("MISSING"),
+        Error("ERROR"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabel")
+    String attachedTransferPackageLabel;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadStatusLogUri")
+    String uploadStatusLogUri;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferJob.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferJob {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+        private String uploadBucketName;
+
+        public Builder uploadBucketName(String uploadBucketName) {
+            this.uploadBucketName = uploadBucketName;
+            this.__explicitlySet__.add("uploadBucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+        private DeviceType deviceType;
+
+        public Builder deviceType(DeviceType deviceType) {
+            this.deviceType = deviceType;
+            this.__explicitlySet__.add("deviceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferApplianceLabels")
+        private java.util.List<String> attachedTransferApplianceLabels;
+
+        public Builder attachedTransferApplianceLabels(
+                java.util.List<String> attachedTransferApplianceLabels) {
+            this.attachedTransferApplianceLabels = attachedTransferApplianceLabels;
+            this.__explicitlySet__.add("attachedTransferApplianceLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabels")
+        private java.util.List<String> attachedTransferPackageLabels;
+
+        public Builder attachedTransferPackageLabels(
+                java.util.List<String> attachedTransferPackageLabels) {
+            this.attachedTransferPackageLabels = attachedTransferPackageLabels;
+            this.__explicitlySet__.add("attachedTransferPackageLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferDeviceLabels")
+        private java.util.List<String> attachedTransferDeviceLabels;
+
+        public Builder attachedTransferDeviceLabels(
+                java.util.List<String> attachedTransferDeviceLabels) {
+            this.attachedTransferDeviceLabels = attachedTransferDeviceLabels;
+            this.__explicitlySet__.add("attachedTransferDeviceLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferJob build() {
+            TransferJob __instance__ =
+                    new TransferJob(
+                            id,
+                            compartmentId,
+                            uploadBucketName,
+                            displayName,
+                            label,
+                            creationTime,
+                            deviceType,
+                            lifecycleState,
+                            attachedTransferApplianceLabels,
+                            attachedTransferPackageLabels,
+                            attachedTransferDeviceLabels,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferJob o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .uploadBucketName(o.getUploadBucketName())
+                            .displayName(o.getDisplayName())
+                            .label(o.getLabel())
+                            .creationTime(o.getCreationTime())
+                            .deviceType(o.getDeviceType())
+                            .lifecycleState(o.getLifecycleState())
+                            .attachedTransferApplianceLabels(o.getAttachedTransferApplianceLabels())
+                            .attachedTransferPackageLabels(o.getAttachedTransferPackageLabels())
+                            .attachedTransferDeviceLabels(o.getAttachedTransferDeviceLabels())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+    String uploadBucketName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DeviceType {
+        Disk("DISK"),
+        Appliance("APPLIANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DeviceType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DeviceType v : DeviceType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DeviceType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DeviceType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DeviceType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+    DeviceType deviceType;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Initiated("INITIATED"),
+        Preparing("PREPARING"),
+        Active("ACTIVE"),
+        Deleted("DELETED"),
+        Closed("CLOSED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Transfer Appliance labels associated with this transfer Job
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferApplianceLabels")
+    java.util.List<String> attachedTransferApplianceLabels;
+
+    /**
+     * Transfer Package labels associated with this transfer Job
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferPackageLabels")
+    java.util.List<String> attachedTransferPackageLabels;
+
+    /**
+     * Transfer Device labels associated with this transfer Job
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferDeviceLabels")
+    java.util.List<String> attachedTransferDeviceLabels;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferJobSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferJobSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+        private String uploadBucketName;
+
+        public Builder uploadBucketName(String uploadBucketName) {
+            this.uploadBucketName = uploadBucketName;
+            this.__explicitlySet__.add("uploadBucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+        private DeviceType deviceType;
+
+        public Builder deviceType(DeviceType deviceType) {
+            this.deviceType = deviceType;
+            this.__explicitlySet__.add("deviceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferJobSummary build() {
+            TransferJobSummary __instance__ =
+                    new TransferJobSummary(
+                            id,
+                            uploadBucketName,
+                            displayName,
+                            label,
+                            deviceType,
+                            creationTime,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferJobSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .uploadBucketName(o.getUploadBucketName())
+                            .displayName(o.getDisplayName())
+                            .label(o.getLabel())
+                            .deviceType(o.getDeviceType())
+                            .creationTime(o.getCreationTime())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uploadBucketName")
+    String uploadBucketName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DeviceType {
+        Disk("DISK"),
+        Appliance("APPLIANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DeviceType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DeviceType v : DeviceType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DeviceType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DeviceType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DeviceType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+    DeviceType deviceType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Initiated("INITIATED"),
+        Preparing("PREPARING"),
+        Active("ACTIVE"),
+        Deleted("DELETED"),
+        Closed("CLOSED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferPackage.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferPackage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+        private String transferJobId;
+
+        public Builder transferJobId(String transferJobId) {
+            this.transferJobId = transferJobId;
+            this.__explicitlySet__.add("transferJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+        private String originalPackageDeliveryTrackingNumber;
+
+        public Builder originalPackageDeliveryTrackingNumber(
+                String originalPackageDeliveryTrackingNumber) {
+            this.originalPackageDeliveryTrackingNumber = originalPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("originalPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+        private String returnPackageDeliveryTrackingNumber;
+
+        public Builder returnPackageDeliveryTrackingNumber(
+                String returnPackageDeliveryTrackingNumber) {
+            this.returnPackageDeliveryTrackingNumber = returnPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("returnPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+        private String packageDeliveryVendor;
+
+        public Builder packageDeliveryVendor(String packageDeliveryVendor) {
+            this.packageDeliveryVendor = packageDeliveryVendor;
+            this.__explicitlySet__.add("packageDeliveryVendor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transferSiteShippingAddress")
+        private String transferSiteShippingAddress;
+
+        public Builder transferSiteShippingAddress(String transferSiteShippingAddress) {
+            this.transferSiteShippingAddress = transferSiteShippingAddress;
+            this.__explicitlySet__.add("transferSiteShippingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferDeviceLabels")
+        private java.util.List<String> attachedTransferDeviceLabels;
+
+        public Builder attachedTransferDeviceLabels(
+                java.util.List<String> attachedTransferDeviceLabels) {
+            this.attachedTransferDeviceLabels = attachedTransferDeviceLabels;
+            this.__explicitlySet__.add("attachedTransferDeviceLabels");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferPackage build() {
+            TransferPackage __instance__ =
+                    new TransferPackage(
+                            label,
+                            lifecycleState,
+                            transferJobId,
+                            creationTime,
+                            originalPackageDeliveryTrackingNumber,
+                            returnPackageDeliveryTrackingNumber,
+                            packageDeliveryVendor,
+                            transferSiteShippingAddress,
+                            attachedTransferDeviceLabels);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferPackage o) {
+            Builder copiedBuilder =
+                    label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .transferJobId(o.getTransferJobId())
+                            .creationTime(o.getCreationTime())
+                            .originalPackageDeliveryTrackingNumber(
+                                    o.getOriginalPackageDeliveryTrackingNumber())
+                            .returnPackageDeliveryTrackingNumber(
+                                    o.getReturnPackageDeliveryTrackingNumber())
+                            .packageDeliveryVendor(o.getPackageDeliveryVendor())
+                            .transferSiteShippingAddress(o.getTransferSiteShippingAddress())
+                            .attachedTransferDeviceLabels(o.getAttachedTransferDeviceLabels());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Shipping("SHIPPING"),
+        Received("RECEIVED"),
+        Processing("PROCESSING"),
+        Processed("PROCESSED"),
+        Returned("RETURNED"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+        CancelledReturned("CANCELLED_RETURNED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("transferJobId")
+    String transferJobId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+    String originalPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+    String returnPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+    String packageDeliveryVendor;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("transferSiteShippingAddress")
+    String transferSiteShippingAddress;
+
+    /**
+     * Transfer Devices attached to this Transfer Package
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedTransferDeviceLabels")
+    java.util.List<String> attachedTransferDeviceLabels;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferPackageSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferPackageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("label")
+        private String label;
+
+        public Builder label(String label) {
+            this.label = label;
+            this.__explicitlySet__.add("label");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+        private java.util.Date creationTime;
+
+        public Builder creationTime(java.util.Date creationTime) {
+            this.creationTime = creationTime;
+            this.__explicitlySet__.add("creationTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferPackageSummary build() {
+            TransferPackageSummary __instance__ =
+                    new TransferPackageSummary(label, lifecycleState, creationTime);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferPackageSummary o) {
+            Builder copiedBuilder =
+                    label(o.getLabel())
+                            .lifecycleState(o.getLifecycleState())
+                            .creationTime(o.getCreationTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("label")
+    String label;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Shipping("SHIPPING"),
+        Received("RECEIVED"),
+        Processing("PROCESSING"),
+        Processed("PROCESSED"),
+        Returned("RETURNED"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+        CancelledReturned("CANCELLED_RETURNED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
+    java.util.Date creationTime;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTransferApplianceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateTransferApplianceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+        private ShippingAddress customerShippingAddress;
+
+        public Builder customerShippingAddress(ShippingAddress customerShippingAddress) {
+            this.customerShippingAddress = customerShippingAddress;
+            this.__explicitlySet__.add("customerShippingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTransferApplianceDetails build() {
+            UpdateTransferApplianceDetails __instance__ =
+                    new UpdateTransferApplianceDetails(lifecycleState, customerShippingAddress);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTransferApplianceDetails o) {
+            Builder copiedBuilder =
+                    lifecycleState(o.getLifecycleState())
+                            .customerShippingAddress(o.getCustomerShippingAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     **/
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Deleted("DELETED"),
+        CustomerNeverReceived("CUSTOMER_NEVER_RECEIVED"),
+        Cancelled("CANCELLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customerShippingAddress")
+    ShippingAddress customerShippingAddress;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTransferDeviceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateTransferDeviceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTransferDeviceDetails build() {
+            UpdateTransferDeviceDetails __instance__ =
+                    new UpdateTransferDeviceDetails(lifecycleState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTransferDeviceDetails o) {
+            Builder copiedBuilder = lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     **/
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Ready("READY"),
+        Cancelled("CANCELLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTransferJobDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateTransferJobDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+        private DeviceType deviceType;
+
+        public Builder deviceType(DeviceType deviceType) {
+            this.deviceType = deviceType;
+            this.__explicitlySet__.add("deviceType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTransferJobDetails build() {
+            UpdateTransferJobDetails __instance__ =
+                    new UpdateTransferJobDetails(
+                            lifecycleState, displayName, deviceType, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTransferJobDetails o) {
+            Builder copiedBuilder =
+                    lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .deviceType(o.getDeviceType())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     **/
+    public enum LifecycleState {
+        Closed("CLOSED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+    /**
+     **/
+    public enum DeviceType {
+        Disk("DISK"),
+        Appliance("APPLIANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DeviceType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DeviceType v : DeviceType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DeviceType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DeviceType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid DeviceType: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("deviceType")
+    DeviceType deviceType;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTransferPackageDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateTransferPackageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+        private String originalPackageDeliveryTrackingNumber;
+
+        public Builder originalPackageDeliveryTrackingNumber(
+                String originalPackageDeliveryTrackingNumber) {
+            this.originalPackageDeliveryTrackingNumber = originalPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("originalPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+        private String returnPackageDeliveryTrackingNumber;
+
+        public Builder returnPackageDeliveryTrackingNumber(
+                String returnPackageDeliveryTrackingNumber) {
+            this.returnPackageDeliveryTrackingNumber = returnPackageDeliveryTrackingNumber;
+            this.__explicitlySet__.add("returnPackageDeliveryTrackingNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+        private String packageDeliveryVendor;
+
+        public Builder packageDeliveryVendor(String packageDeliveryVendor) {
+            this.packageDeliveryVendor = packageDeliveryVendor;
+            this.__explicitlySet__.add("packageDeliveryVendor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTransferPackageDetails build() {
+            UpdateTransferPackageDetails __instance__ =
+                    new UpdateTransferPackageDetails(
+                            originalPackageDeliveryTrackingNumber,
+                            returnPackageDeliveryTrackingNumber,
+                            packageDeliveryVendor,
+                            lifecycleState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTransferPackageDetails o) {
+            Builder copiedBuilder =
+                    originalPackageDeliveryTrackingNumber(
+                                    o.getOriginalPackageDeliveryTrackingNumber())
+                            .returnPackageDeliveryTrackingNumber(
+                                    o.getReturnPackageDeliveryTrackingNumber())
+                            .packageDeliveryVendor(o.getPackageDeliveryVendor())
+                            .lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("originalPackageDeliveryTrackingNumber")
+    String originalPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("returnPackageDeliveryTrackingNumber")
+    String returnPackageDeliveryTrackingNumber;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("packageDeliveryVendor")
+    String packageDeliveryVendor;
+    /**
+     **/
+    public enum LifecycleState {
+        Shipping("SHIPPING"),
+        Cancelled("CANCELLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AttachDevicesToTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Package
+     */
+    private String transferPackageLabel;
+
+    /**
+     * Labels of Transfer Devices to attach
+     */
+    private AttachDevicesDetails attachDevicesDetails;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AttachDevicesToTransferPackageRequest o) {
+            id(o.getId());
+            transferPackageLabel(o.getTransferPackageLabel());
+            attachDevicesDetails(o.getAttachDevicesDetails());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AttachDevicesToTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AttachDevicesToTransferPackageRequest
+         */
+        public AttachDevicesToTransferPackageRequest build() {
+            AttachDevicesToTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeTransferJobCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String transferJobId;
+
+    /**
+     * CompartmentId of the destination compartment
+     */
+    private ChangeTransferJobCompartmentDetails changeTransferJobCompartmentDetails;
+
+    /**
+     * The entity tag to match. Optional, if set, the update will be successful only if the
+     * object's tag matches the tag specified in the request.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeTransferJobCompartmentRequest o) {
+            transferJobId(o.getTransferJobId());
+            changeTransferJobCompartmentDetails(o.getChangeTransferJobCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeTransferJobCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeTransferJobCompartmentRequest
+         */
+        public ChangeTransferJobCompartmentRequest build() {
+            ChangeTransferJobCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferApplianceAdminCredentialsRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    /**
+     *
+     */
+    private TransferAppliancePublicKey adminPublicKey;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceAdminCredentialsRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            adminPublicKey(o.getAdminPublicKey());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferApplianceAdminCredentialsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferApplianceAdminCredentialsRequest
+         */
+        public CreateTransferApplianceAdminCredentialsRequest build() {
+            CreateTransferApplianceAdminCredentialsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferApplianceEntitlementRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Creates a Transfer Appliance Entitlement
+     */
+    private CreateTransferApplianceEntitlementDetails createTransferApplianceEntitlementDetails;
+
+    /**
+     * opc retry token
+     */
+    private String opcRetryToken;
+
+    /**
+     * opc request id
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceEntitlementRequest o) {
+            createTransferApplianceEntitlementDetails(
+                    o.getCreateTransferApplianceEntitlementDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferApplianceEntitlementRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferApplianceEntitlementRequest
+         */
+        public CreateTransferApplianceEntitlementRequest build() {
+            CreateTransferApplianceEntitlementRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Creates a New Transfer Appliance
+     */
+    private CreateTransferApplianceDetails createTransferApplianceDetails;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceRequest o) {
+            id(o.getId());
+            opcRetryToken(o.getOpcRetryToken());
+            createTransferApplianceDetails(o.getCreateTransferApplianceDetails());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferApplianceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferApplianceRequest
+         */
+        public CreateTransferApplianceRequest build() {
+            CreateTransferApplianceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Creates a New Transfer Device
+     */
+    private CreateTransferDeviceDetails createTransferDeviceDetails;
+
+    /**
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferDeviceRequest o) {
+            id(o.getId());
+            createTransferDeviceDetails(o.getCreateTransferDeviceDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferDeviceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferDeviceRequest
+         */
+        public CreateTransferDeviceRequest build() {
+            CreateTransferDeviceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Creates a New Transfer Job
+     */
+    private CreateTransferJobDetails createTransferJobDetails;
+
+    /**
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferJobRequest o) {
+            createTransferJobDetails(o.getCreateTransferJobDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferJobRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferJobRequest
+         */
+        public CreateTransferJobRequest build() {
+            CreateTransferJobRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Creates a New Transfer Package
+     */
+    private CreateTransferPackageDetails createTransferPackageDetails;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferPackageRequest o) {
+            id(o.getId());
+            opcRetryToken(o.getOpcRetryToken());
+            createTransferPackageDetails(o.getCreateTransferPackageDetails());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateTransferPackageRequest
+         */
+        public CreateTransferPackageRequest build() {
+            CreateTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferApplianceRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteTransferApplianceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteTransferApplianceRequest
+         */
+        public DeleteTransferApplianceRequest build() {
+            DeleteTransferApplianceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Device
+     */
+    private String transferDeviceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferDeviceRequest o) {
+            id(o.getId());
+            transferDeviceLabel(o.getTransferDeviceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteTransferDeviceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteTransferDeviceRequest
+         */
+        public DeleteTransferDeviceRequest build() {
+            DeleteTransferDeviceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferJobRequest o) {
+            id(o.getId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteTransferJobRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteTransferJobRequest
+         */
+        public DeleteTransferJobRequest build() {
+            DeleteTransferJobRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Package
+     */
+    private String transferPackageLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferPackageRequest o) {
+            id(o.getId());
+            transferPackageLabel(o.getTransferPackageLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteTransferPackageRequest
+         */
+        public DeleteTransferPackageRequest build() {
+            DeleteTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DetachDevicesFromTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Package
+     */
+    private String transferPackageLabel;
+
+    /**
+     * Labels of Transfer Devices to detach
+     */
+    private DetachDevicesDetails detachDevicesDetails;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DetachDevicesFromTransferPackageRequest o) {
+            id(o.getId());
+            transferPackageLabel(o.getTransferPackageLabel());
+            detachDevicesDetails(o.getDetachDevicesDetails());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DetachDevicesFromTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DetachDevicesFromTransferPackageRequest
+         */
+        public DetachDevicesFromTransferPackageRequest build() {
+            DetachDevicesFromTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferApplianceCertificateAuthorityCertificateRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceCertificateAuthorityCertificateRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferApplianceCertificateAuthorityCertificateRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferApplianceCertificateAuthorityCertificateRequest
+         */
+        public GetTransferApplianceCertificateAuthorityCertificateRequest build() {
+            GetTransferApplianceCertificateAuthorityCertificateRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferApplianceEncryptionPassphraseRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceEncryptionPassphraseRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferApplianceEncryptionPassphraseRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferApplianceEncryptionPassphraseRequest
+         */
+        public GetTransferApplianceEncryptionPassphraseRequest build() {
+            GetTransferApplianceEncryptionPassphraseRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferApplianceEntitlementRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Tenant Id
+     */
+    private String tenantId;
+
+    /**
+     * opc request id
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceEntitlementRequest o) {
+            tenantId(o.getTenantId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferApplianceEntitlementRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferApplianceEntitlementRequest
+         */
+        public GetTransferApplianceEntitlementRequest build() {
+            GetTransferApplianceEntitlementRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferApplianceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferApplianceRequest
+         */
+        public GetTransferApplianceRequest build() {
+            GetTransferApplianceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Device
+     */
+    private String transferDeviceLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferDeviceRequest o) {
+            id(o.getId());
+            transferDeviceLabel(o.getTransferDeviceLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferDeviceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferDeviceRequest
+         */
+        public GetTransferDeviceRequest build() {
+            GetTransferDeviceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * OCID of the Transfer Job
+     */
+    private String id;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferJobRequest o) {
+            id(o.getId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferJobRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferJobRequest
+         */
+        public GetTransferJobRequest build() {
+            GetTransferJobRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Package
+     */
+    private String transferPackageLabel;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferPackageRequest o) {
+            id(o.getId());
+            transferPackageLabel(o.getTransferPackageLabel());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetTransferPackageRequest
+         */
+        public GetTransferPackageRequest build() {
+            GetTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListShippingVendorsRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListShippingVendorsRequest o) {
+
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListShippingVendorsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListShippingVendorsRequest
+         */
+        public ListShippingVendorsRequest build() {
+            ListShippingVendorsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListTransferAppliancesRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * filtering by lifecycleState
+     */
+    private LifecycleState lifecycleState;
+
+    /**
+     * filtering by lifecycleState
+     **/
+    public enum LifecycleState {
+        Requested("REQUESTED"),
+        OraclePreparing("ORACLE_PREPARING"),
+        Shipping("SHIPPING"),
+        Delivered("DELIVERED"),
+        Preparing("PREPARING"),
+        ReturnShipped("RETURN_SHIPPED"),
+        ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
+        OracleReceived("ORACLE_RECEIVED"),
+        OracleReceivedCancelled("ORACLE_RECEIVED_CANCELLED"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        CustomerNeverReceived("CUSTOMER_NEVER_RECEIVED"),
+        OracleNeverReceived("ORACLE_NEVER_RECEIVED"),
+        CustomerLost("CUSTOMER_LOST"),
+        Cancelled("CANCELLED"),
+        Deleted("DELETED"),
+        Rejected("REJECTED"),
+        Error("ERROR"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferAppliancesRequest o) {
+            id(o.getId());
+            lifecycleState(o.getLifecycleState());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListTransferAppliancesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListTransferAppliancesRequest
+         */
+        public ListTransferAppliancesRequest build() {
+            ListTransferAppliancesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListTransferDevicesRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * filtering by lifecycleState
+     */
+    private LifecycleState lifecycleState;
+
+    /**
+     * filtering by lifecycleState
+     **/
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Ready("READY"),
+        Packaged("PACKAGED"),
+        Active("ACTIVE"),
+        Processing("PROCESSING"),
+        Complete("COMPLETE"),
+        Missing("MISSING"),
+        Error("ERROR"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    /**
+     * filtering by displayName
+     */
+    private String displayName;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferDevicesRequest o) {
+            id(o.getId());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListTransferDevicesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListTransferDevicesRequest
+         */
+        public ListTransferDevicesRequest build() {
+            ListTransferDevicesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListTransferJobsRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * compartment id
+     */
+    private String compartmentId;
+
+    /**
+     * filtering by lifecycleState
+     */
+    private LifecycleState lifecycleState;
+
+    /**
+     * filtering by lifecycleState
+     **/
+    public enum LifecycleState {
+        Initiated("INITIATED"),
+        Preparing("PREPARING"),
+        Active("ACTIVE"),
+        Deleted("DELETED"),
+        Closed("CLOSED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    /**
+     * filtering by displayName
+     */
+    private String displayName;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferJobsRequest o) {
+            compartmentId(o.getCompartmentId());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListTransferJobsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListTransferJobsRequest
+         */
+        public ListTransferJobsRequest build() {
+            ListTransferJobsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListTransferPackagesRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * filtering by lifecycleState
+     */
+    private LifecycleState lifecycleState;
+
+    /**
+     * filtering by lifecycleState
+     **/
+    public enum LifecycleState {
+        Preparing("PREPARING"),
+        Shipping("SHIPPING"),
+        Received("RECEIVED"),
+        Processing("PROCESSING"),
+        Processed("PROCESSED"),
+        Returned("RETURNED"),
+        Deleted("DELETED"),
+        Cancelled("CANCELLED"),
+        CancelledReturned("CANCELLED_RETURNED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LifecycleState: " + key);
+        }
+    };
+
+    /**
+     * filtering by displayName
+     */
+    private String displayName;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferPackagesRequest o) {
+            id(o.getId());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListTransferPackagesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListTransferPackagesRequest
+         */
+        public ListTransferPackagesRequest build() {
+            ListTransferPackagesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Appliance
+     */
+    private String transferApplianceLabel;
+
+    /**
+     * fields to update
+     */
+    private UpdateTransferApplianceDetails updateTransferApplianceDetails;
+
+    /**
+     * The entity tag to match. Optional, if set, the update will be successful only if the
+     * object's tag matches the tag specified in the request.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferApplianceRequest o) {
+            id(o.getId());
+            transferApplianceLabel(o.getTransferApplianceLabel());
+            updateTransferApplianceDetails(o.getUpdateTransferApplianceDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateTransferApplianceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateTransferApplianceRequest
+         */
+        public UpdateTransferApplianceRequest build() {
+            UpdateTransferApplianceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Device
+     */
+    private String transferDeviceLabel;
+
+    /**
+     * fields to update
+     */
+    private UpdateTransferDeviceDetails updateTransferDeviceDetails;
+
+    /**
+     * The entity tag to match. Optional, if set, the update will be successful only if the
+     * object's tag matches the tag specified in the request.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferDeviceRequest o) {
+            id(o.getId());
+            transferDeviceLabel(o.getTransferDeviceLabel());
+            updateTransferDeviceDetails(o.getUpdateTransferDeviceDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateTransferDeviceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateTransferDeviceRequest
+         */
+        public UpdateTransferDeviceRequest build() {
+            UpdateTransferDeviceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * fields to update
+     */
+    private UpdateTransferJobDetails updateTransferJobDetails;
+
+    /**
+     * The entity tag to match. Optional, if set, the update will be successful only if the
+     * object's tag matches the tag specified in the request.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferJobRequest o) {
+            id(o.getId());
+            updateTransferJobDetails(o.getUpdateTransferJobDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateTransferJobRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateTransferJobRequest
+         */
+        public UpdateTransferJobRequest build() {
+            UpdateTransferJobRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * ID of the Transfer Job
+     */
+    private String id;
+
+    /**
+     * Label of the Transfer Package
+     */
+    private String transferPackageLabel;
+
+    /**
+     * fields to update
+     */
+    private UpdateTransferPackageDetails updateTransferPackageDetails;
+
+    /**
+     * The entity tag to match. Optional, if set, the update will be successful only if the
+     * object's tag matches the tag specified in the request.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferPackageRequest o) {
+            id(o.getId());
+            transferPackageLabel(o.getTransferPackageLabel());
+            updateTransferPackageDetails(o.getUpdateTransferPackageDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateTransferPackageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateTransferPackageRequest
+         */
+        public UpdateTransferPackageRequest build() {
+            UpdateTransferPackageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AttachDevicesToTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AttachDevicesToTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeTransferJobCompartmentResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See 'if-match'.
+     */
+    private String etag;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeTransferJobCompartmentResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferApplianceAdminCredentialsResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferApplianceCertificate instance.
+     */
+    private TransferApplianceCertificate transferApplianceCertificate;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceAdminCredentialsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferApplianceCertificate(o.getTransferApplianceCertificate());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferApplianceEntitlementResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferApplianceEntitlement instance.
+     */
+    private TransferApplianceEntitlement transferApplianceEntitlement;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceEntitlementResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferApplianceEntitlement(o.getTransferApplianceEntitlement());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferApplianceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferAppliance instance.
+     */
+    private TransferAppliance transferAppliance;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferApplianceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferAppliance(o.getTransferAppliance());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferDeviceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned NewTransferDevice instance.
+     */
+    private NewTransferDevice newTransferDevice;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferDeviceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            newTransferDevice(o.getNewTransferDevice());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferJobResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferJob instance.
+     */
+    private TransferJob transferJob;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferJobResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferJob(o.getTransferJob());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferPackage instance.
+     */
+    private TransferPackage transferPackage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferPackage(o.getTransferPackage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteTransferApplianceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferApplianceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteTransferDeviceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferDeviceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteTransferJobResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferJobResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DetachDevicesFromTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DetachDevicesFromTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferApplianceCertificateAuthorityCertificateResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferApplianceCertificate instance.
+     */
+    private TransferApplianceCertificate transferApplianceCertificate;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceCertificateAuthorityCertificateResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferApplianceCertificate(o.getTransferApplianceCertificate());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferApplianceEncryptionPassphraseResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferApplianceEncryptionPassphrase instance.
+     */
+    private TransferApplianceEncryptionPassphrase transferApplianceEncryptionPassphrase;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceEncryptionPassphraseResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferApplianceEncryptionPassphrase(o.getTransferApplianceEncryptionPassphrase());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferApplianceEntitlementResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned TransferApplianceEntitlement instance.
+     */
+    private TransferApplianceEntitlement transferApplianceEntitlement;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceEntitlementResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            transferApplianceEntitlement(o.getTransferApplianceEntitlement());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferApplianceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferAppliance instance.
+     */
+    private TransferAppliance transferAppliance;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferApplianceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferAppliance(o.getTransferAppliance());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferDeviceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferDevice instance.
+     */
+    private TransferDevice transferDevice;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferDeviceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferDevice(o.getTransferDevice());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferJobResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferJob instance.
+     */
+    private TransferJob transferJob;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferJobResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferJob(o.getTransferJob());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferPackage instance.
+     */
+    private TransferPackage transferPackage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferPackage(o.getTransferPackage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListShippingVendorsResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ShippingVendors instance.
+     */
+    private ShippingVendors shippingVendors;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListShippingVendorsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            shippingVendors(o.getShippingVendors());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListTransferAppliancesResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned MultipleTransferAppliances instance.
+     */
+    private MultipleTransferAppliances multipleTransferAppliances;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferAppliancesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            multipleTransferAppliances(o.getMultipleTransferAppliances());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListTransferDevicesResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned MultipleTransferDevices instance.
+     */
+    private MultipleTransferDevices multipleTransferDevices;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferDevicesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            multipleTransferDevices(o.getMultipleTransferDevices());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListTransferJobsResponse {
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of TransferJobSummary instances.
+     */
+    private java.util.List<TransferJobSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferJobsResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListTransferPackagesResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned MultipleTransferPackages instance.
+     */
+    private MultipleTransferPackages multipleTransferPackages;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferPackagesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            multipleTransferPackages(o.getMultipleTransferPackages());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateTransferApplianceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferAppliance instance.
+     */
+    private TransferAppliance transferAppliance;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferApplianceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferAppliance(o.getTransferAppliance());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateTransferDeviceResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferDevice instance.
+     */
+    private TransferDevice transferDevice;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferDeviceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferDevice(o.getTransferDevice());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateTransferJobResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferJob instance.
+     */
+    private TransferJob transferJob;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferJobResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferJob(o.getTransferJob());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateTransferPackageResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned TransferPackage instance.
+     */
+    private TransferPackage transferPackage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateTransferPackageResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            transferPackage(o.getTransferPackage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -96,12 +96,6 @@
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-resourcemanager</artifactId>
     </dependency>
-    <!-- For HttpProxyExample -->
-    <dependency>
-      <groupId>org.littleshoot</groupId>
-      <artifactId>littleproxy</artifactId>
-      <version>1.1.2</version>
-    </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-waas</artifactId>
@@ -142,6 +136,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-events</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-dts</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/src/main/java/HttpProxyExample.java
+++ b/bmc-examples/src/main/java/HttpProxyExample.java
@@ -12,33 +12,18 @@ import com.oracle.bmc.http.ClientConfigurator;
 import com.oracle.bmc.identity.IdentityClient;
 import com.oracle.bmc.identity.requests.ListRegionsRequest;
 import com.oracle.bmc.identity.responses.ListRegionsResponse;
-import org.littleshoot.proxy.HttpProxyServer;
-import org.littleshoot.proxy.ProxyAuthenticator;
-import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.util.Collections;
 
 /**
  * A sample to demonstrate how to configure a client to connect through an authenticated HTTP or HTTPS proxy.
- *
- * Note:  This sample utilizes the <a href="https://github.com/adamfisk/LittleProxy">LittleProxy</a> library to
- * host a proxy server on localhost. This dependency can be added to an existing maven configuration with the following
- * dependency:
- * <pre>
- * <dependency>
- *     <groupId>org.littleshoot</groupId>
- *     <artifactId>littleproxy</artifactId>
- *     <version>1.1.2</version>
- * </dependency>
- * </pre>
  */
 public class HttpProxyExample {
     private static final String CONFIG_FILE_PATH = "~/.oci/config";
     private static final String CONFIG_PROFILE = "DEFAULT";
 
     // Proxy Server configuration
-    private static final int PROXY_PORT = 8889;
-    private static final String PROXY_URI = "http://localhost:" + PROXY_PORT;
+    private static final String PROXY_URI = "http://localhost:8889";
     private static final String PROXY_USERNAME = "username";
     private static final String PROXY_PASSWORD = "password";
 
@@ -49,9 +34,6 @@ public class HttpProxyExample {
         final AuthenticationDetailsProvider authenticationDetailsProvider =
                 new ConfigFileAuthenticationDetailsProvider(CONFIG_FILE_PATH, CONFIG_PROFILE);
 
-        // Start a HTTP proxy server for clients to connect to locally
-        final HttpProxyServer proxyServer =
-                newProxyServer(PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD);
         try {
             // Specify an ApacheProxyConfig when building a new client with the ApacheConfigurator
             final ApacheProxyConfig proxyConfig =
@@ -74,41 +56,7 @@ public class HttpProxyExample {
             ListRegionsResponse response = identityClient.listRegions(LIST_REGIONS_REQUEST);
             System.out.println("    List of regions: " + response.getItems());
         } finally {
-            proxyServer.stop();
             System.out.println("Stopped proxy server");
         }
-    }
-
-    /**
-     * Starts and returns a new HTTP proxy server that is used as an example proxy server for clients to connect to.
-     * It is hosted on 'localhost' for the given {@code port}, {@code username}, and {@code password}.
-     *
-     * @param port the port for the proxy to listen on
-     * @param username the username to validate the client connection with
-     * @param password the password to validate the client connection with
-     * @return a HTTP proxy server instance
-     */
-    private static HttpProxyServer newProxyServer(
-            final int port, final String username, final String password) {
-        final ProxyAuthenticator authenticator =
-                new ProxyAuthenticator() {
-                    @Override
-                    public boolean authenticate(final String username, final String password) {
-                        return username.equals(username) && password.equals(password);
-                    }
-
-                    @Override
-                    public String getRealm() {
-                        return null;
-                    }
-                };
-        final HttpProxyServer proxyServer =
-                DefaultHttpProxyServer.bootstrap()
-                        .withPort(port)
-                        .withProxyAuthenticator(authenticator)
-                        .start();
-
-        System.out.println(String.format("Started authenticated proxy server on port [%s]", port));
-        return proxyServer;
     }
 }

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.5.17</version>
+        <version>1.6.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -126,6 +126,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-events</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-dts</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/Waas.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/Waas.java
@@ -210,7 +210,7 @@ public interface Waas extends AutoCloseable {
     GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
 
     /**
-     * Gets the currently configured access rules for the Web Application Firewall configration of a specified WAAS policy.
+     * Gets the currently configured access rules for the Web Application Firewall configuration of a specified WAAS policy.
      * The order of the access rules is important. The rules will be checked in the order they are specified and the first matching rule will be used.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasAsync.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasAsync.java
@@ -353,7 +353,7 @@ public interface WaasAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the currently configured access rules for the Web Application Firewall configration of a specified WAAS policy.
+     * Gets the currently configured access rules for the Web Application Firewall configuration of a specified WAAS policy.
      * The order of the access rules is important. The rules will be checked in the order they are specified and the first matching rule will be used.
      *
      * @param request The request object containing the details to send

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasAsyncClient.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasAsyncClient.java
@@ -31,6 +31,7 @@ public class WaasAsyncClient implements WaasAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("WAAS")
                     .serviceEndpointPrefix("waas")
+                    .serviceEndpointTemplate("https://waas.{region}.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasClient.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/WaasClient.java
@@ -18,6 +18,7 @@ public class WaasClient implements Waas {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("WAAS")
                     .serviceEndpointPrefix("waas")
+                    .serviceEndpointTemplate("https://waas.{region}.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/AcceptRecommendationsConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/AcceptRecommendationsConverter.java
@@ -91,15 +91,6 @@ public class AcceptRecommendationsConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/DeleteWaasPolicyConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/DeleteWaasPolicyConverter.java
@@ -90,15 +90,6 @@ public class DeleteWaasPolicyConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateAccessRulesConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateAccessRulesConverter.java
@@ -93,15 +93,6 @@ public class UpdateAccessRulesConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateCaptchasConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateCaptchasConverter.java
@@ -91,15 +91,6 @@ public class UpdateCaptchasConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateDeviceFingerprintChallengeConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateDeviceFingerprintChallengeConverter.java
@@ -99,15 +99,6 @@ public class UpdateDeviceFingerprintChallengeConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateGoodBotsConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateGoodBotsConverter.java
@@ -91,15 +91,6 @@ public class UpdateGoodBotsConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateHumanInteractionChallengeConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateHumanInteractionChallengeConverter.java
@@ -99,15 +99,6 @@ public class UpdateHumanInteractionChallengeConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateJsChallengeConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateJsChallengeConverter.java
@@ -94,15 +94,6 @@ public class UpdateJsChallengeConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdatePolicyConfigConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdatePolicyConfigConverter.java
@@ -93,15 +93,6 @@ public class UpdatePolicyConfigConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateProtectionRulesConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateProtectionRulesConverter.java
@@ -91,15 +91,6 @@ public class UpdateProtectionRulesConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateProtectionSettingsConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateProtectionSettingsConverter.java
@@ -98,15 +98,6 @@ public class UpdateProtectionSettingsConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateThreatFeedsConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateThreatFeedsConverter.java
@@ -89,15 +89,6 @@ public class UpdateThreatFeedsConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWaasPolicyConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWaasPolicyConverter.java
@@ -92,15 +92,6 @@ public class UpdateWaasPolicyConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWafAddressRateLimitingConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWafAddressRateLimitingConverter.java
@@ -98,15 +98,6 @@ public class UpdateWafAddressRateLimitingConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWafConfigConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWafConfigConverter.java
@@ -91,15 +91,6 @@ public class UpdateWafConfigConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWhitelistsConverter.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/internal/http/UpdateWhitelistsConverter.java
@@ -93,15 +93,6 @@ public class UpdateWhitelistsConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/AccessRule.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/AccessRule.java
@@ -149,6 +149,12 @@ public class AccessRule {
     java.util.List<AccessRuleCriteria> criteria;
     /**
      * The action to take when the access criteria are met for a rule. If unspecified, defaults to `ALLOW`.
+     * <p>
+     * - **ALLOW:** Takes no action, just logs the request.
+     * <p>
+     * - **DETECT:** Takes no action, but creates an alert for the request.
+     * <p>
+     * - **BLOCK:** Blocks the request by returning specified response code or showing error page.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Action {
@@ -196,6 +202,12 @@ public class AccessRule {
     };
     /**
      * The action to take when the access criteria are met for a rule. If unspecified, defaults to `ALLOW`.
+     * <p>
+     * - **ALLOW:** Takes no action, just logs the request.
+     * <p>
+     * - **DETECT:** Takes no action, but creates an alert for the request.
+     * <p>
+     * - **BLOCK:** Blocks the request by returning specified response code or showing error page.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("action")
     Action action;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/AccessRuleCriteria.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/AccessRuleCriteria.java
@@ -88,6 +88,8 @@ public class AccessRuleCriteria {
      * - **HTTP_HEADER_CONTAINS:** The HTTP_HEADER_CONTAINS criteria is defined using a compound value separated by a colon: a header field name and a header field value. `host:test.example.com` is an example of a criteria value where `host` is the header field name and `test.example.com` is the header field value. A request matches when the header field name is a case insensitive match and the header field value is a case insensitive, substring match.
      * *Example:* With a criteria value of `host:test.example.com`, where `host` is the name of the field and `test.example.com` is the value of the host field, a request with the header values, `Host: www.test.example.com` will match, where as a request with header values of `host: www.example.com` or `host: test.sub.example.com` will not match.
      * <p>
+     *
+     * <p>
      * - **COUNTRY_IS:** Matches if the request originates from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see [ISO's website](https://www.iso.org/obp/ui/#search/code/).
      * <p>
      * - **COUNTRY_IS_NOT:** Matches if the request does not originate from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see [ISO's website](https://www.iso.org/obp/ui/#search/code/).
@@ -170,6 +172,8 @@ public class AccessRuleCriteria {
      * <p>
      * - **HTTP_HEADER_CONTAINS:** The HTTP_HEADER_CONTAINS criteria is defined using a compound value separated by a colon: a header field name and a header field value. `host:test.example.com` is an example of a criteria value where `host` is the header field name and `test.example.com` is the header field value. A request matches when the header field name is a case insensitive match and the header field value is a case insensitive, substring match.
      * *Example:* With a criteria value of `host:test.example.com`, where `host` is the name of the field and `test.example.com` is the value of the host field, a request with the header values, `Host: www.test.example.com` will match, where as a request with header values of `host: www.example.com` or `host: test.sub.example.com` will not match.
+     * <p>
+     *
      * <p>
      * - **COUNTRY_IS:** Matches if the request originates from a country in the `value` field. Country codes are in ISO 3166-1 alpha-2 format. For a list of codes, see [ISO's website](https://www.iso.org/obp/ui/#search/code/).
      * <p>

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate.java
@@ -60,18 +60,18 @@ public class Certificate {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("subjectName")
-        private Certificate_subjectName subjectName;
+        private CertificateSubjectName subjectName;
 
-        public Builder subjectName(Certificate_subjectName subjectName) {
+        public Builder subjectName(CertificateSubjectName subjectName) {
             this.subjectName = subjectName;
             this.__explicitlySet__.add("subjectName");
             return this;
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("issuerName")
-        private Certificate_subjectName issuerName;
+        private CertificateIssuerName issuerName;
 
-        public Builder issuerName(Certificate_subjectName issuerName) {
+        public Builder issuerName(CertificateIssuerName issuerName) {
             this.issuerName = issuerName;
             this.__explicitlySet__.add("issuerName");
             return this;
@@ -259,20 +259,32 @@ public class Certificate {
     String issuedBy;
 
     @com.fasterxml.jackson.annotation.JsonProperty("subjectName")
-    Certificate_subjectName subjectName;
+    CertificateSubjectName subjectName;
 
     @com.fasterxml.jackson.annotation.JsonProperty("issuerName")
-    Certificate_subjectName issuerName;
+    CertificateIssuerName issuerName;
 
+    /**
+     * A unique, positive integer assigned by the Certificate Authority (CA). The issuer name and serial number identify a unique certificate.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
     String serialNumber;
 
+    /**
+     * The version of the encoded certificate.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("version")
     Integer version;
 
+    /**
+     * The identifier for the cryptographic algorithm used by the Certificate Authority (CA) to sign this certificate.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("signatureAlgorithm")
     String signatureAlgorithm;
 
+    /**
+     * The date and time the certificate will become valid, expressed in RFC 3339 timestamp format.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeNotValidBefore")
     java.util.Date timeNotValidBefore;
 
@@ -285,17 +297,28 @@ public class Certificate {
     @com.fasterxml.jackson.annotation.JsonProperty("publicKeyInfo")
     Certificate_publicKeyInfo publicKeyInfo;
 
+    /**
+     * Additional attributes associated with users or public keys for managing relationships between Certificate Authorities.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("extensions")
     java.util.List<Certificate_extensions> extensions;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateIssuerName.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateIssuerName.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.waas.model;
 
 /**
- *
+ * The issuer of the certificate.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -17,10 +17,10 @@ package com.oracle.bmc.waas.model;
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
-    builder = Certificate_subjectName.Builder.class
+    builder = CertificateIssuerName.Builder.class
 )
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class Certificate_subjectName {
+public class CertificateIssuerName {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
@@ -90,9 +90,9 @@ public class Certificate_subjectName {
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
-        public Certificate_subjectName build() {
-            Certificate_subjectName __instance__ =
-                    new Certificate_subjectName(
+        public CertificateIssuerName build() {
+            CertificateIssuerName __instance__ =
+                    new CertificateIssuerName(
                             country,
                             stateProvince,
                             locality,
@@ -105,7 +105,7 @@ public class Certificate_subjectName {
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(Certificate_subjectName o) {
+        public Builder copy(CertificateIssuerName o) {
             Builder copiedBuilder =
                     country(o.getCountry())
                             .stateProvince(o.getStateProvince())
@@ -127,24 +127,45 @@ public class Certificate_subjectName {
         return new Builder();
     }
 
+    /**
+     * ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see [ISO's website](https://www.iso.org/obp/ui/#search/code/).
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("country")
     String country;
 
+    /**
+     * The province where the organization is located.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("stateProvince")
     String stateProvince;
 
+    /**
+     * The city in which the organization is located.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("locality")
     String locality;
 
+    /**
+     * The organization name.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("organization")
     String organization;
 
+    /**
+     * The field to differentiate between divisions within an organization.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("organizationalUnit")
     String organizationalUnit;
 
+    /**
+     * The Certificate Authority (CA) name.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("commonName")
     String commonName;
 
+    /**
+     * The email address of the server's administrator.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("emailAddress")
     String emailAddress;
 

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateSubjectName.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateSubjectName.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.waas.model;
+
+/**
+ * The entity to be secured by the certificate.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181116")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CertificateSubjectName.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CertificateSubjectName {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("country")
+        private String country;
+
+        public Builder country(String country) {
+            this.country = country;
+            this.__explicitlySet__.add("country");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stateProvince")
+        private String stateProvince;
+
+        public Builder stateProvince(String stateProvince) {
+            this.stateProvince = stateProvince;
+            this.__explicitlySet__.add("stateProvince");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("locality")
+        private String locality;
+
+        public Builder locality(String locality) {
+            this.locality = locality;
+            this.__explicitlySet__.add("locality");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("organization")
+        private String organization;
+
+        public Builder organization(String organization) {
+            this.organization = organization;
+            this.__explicitlySet__.add("organization");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("organizationalUnit")
+        private String organizationalUnit;
+
+        public Builder organizationalUnit(String organizationalUnit) {
+            this.organizationalUnit = organizationalUnit;
+            this.__explicitlySet__.add("organizationalUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("commonName")
+        private String commonName;
+
+        public Builder commonName(String commonName) {
+            this.commonName = commonName;
+            this.__explicitlySet__.add("commonName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("emailAddress")
+        private String emailAddress;
+
+        public Builder emailAddress(String emailAddress) {
+            this.emailAddress = emailAddress;
+            this.__explicitlySet__.add("emailAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CertificateSubjectName build() {
+            CertificateSubjectName __instance__ =
+                    new CertificateSubjectName(
+                            country,
+                            stateProvince,
+                            locality,
+                            organization,
+                            organizationalUnit,
+                            commonName,
+                            emailAddress);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CertificateSubjectName o) {
+            Builder copiedBuilder =
+                    country(o.getCountry())
+                            .stateProvince(o.getStateProvince())
+                            .locality(o.getLocality())
+                            .organization(o.getOrganization())
+                            .organizationalUnit(o.getOrganizationalUnit())
+                            .commonName(o.getCommonName())
+                            .emailAddress(o.getEmailAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * ISO 3166-1 alpha-2 code of the country where the organization is located. For a list of codes, see [ISO's website](https://www.iso.org/obp/ui/#search/code/).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("country")
+    String country;
+
+    /**
+     * The province where the organization is located.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("stateProvince")
+    String stateProvince;
+
+    /**
+     * The city in which the organization is located.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("locality")
+    String locality;
+
+    /**
+     * The organization name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("organization")
+    String organization;
+
+    /**
+     * The field to differentiate between divisions within an organization.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("organizationalUnit")
+    String organizationalUnit;
+
+    /**
+     * The fully qualified domain name used for DNS lookups of the server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("commonName")
+    String commonName;
+
+    /**
+     * The email address of the server's administrator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("emailAddress")
+    String emailAddress;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateSummary.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CertificateSummary.java
@@ -165,13 +165,21 @@ public class CertificateSummary {
     java.util.Date timeNotValidAfter;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate_extensions.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate_extensions.java
@@ -78,12 +78,21 @@ public class Certificate_extensions {
         return new Builder();
     }
 
+    /**
+     * The certificate extension name.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
+    /**
+     * The critical flag of the extension. Critical extensions must be processed, non-critical extensions can be ignored.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCritical")
     Boolean isCritical;
 
+    /**
+     * The certificate extension value.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("value")
     String value;
 

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate_publicKeyInfo.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/Certificate_publicKeyInfo.java
@@ -4,7 +4,7 @@
 package com.oracle.bmc.waas.model;
 
 /**
- *
+ * Information about the public key and the algorithm used by the public key.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -78,12 +78,21 @@ public class Certificate_publicKeyInfo {
         return new Builder();
     }
 
+    /**
+     * The algorithm identifier and parameters for the public key.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("algorithm")
     String algorithm;
 
+    /**
+     * The private key exponent.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("exponent")
     Integer exponent;
 
+    /**
+     * The number of bits in a key used by a cryptographic algorithm.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("keySize")
     Integer keySize;
 

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateCertificateDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateCertificateDetails.java
@@ -144,6 +144,17 @@ public class CreateCertificateDetails {
 
     /**
      * The data of the SSL certificate.
+     * <p>
+     *
+     * **Note:** Many SSL certificate providers require an intermediate certificate chain to ensure a trusted status.
+     * If your SSL certificate requires an intermediate certificate chain, please append the intermediate certificate
+     * key in the `certificateData` field after the leaf certificate issued by the SSL certificate provider. If you
+     * are unsure if your certificate requires an intermediate certificate chain, see your certificate
+     * provider's documentation.
+     * <p>
+     *
+     * The example below shows an intermediate certificate appended to a leaf certificate.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("certificateData")
     String certificateData;
@@ -155,19 +166,27 @@ public class CreateCertificateDetails {
     String privateKeyData;
 
     /**
-     * Set to true if the SSL certificate is self-signed.
+     * Set to `true` if the SSL certificate is self-signed.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isTrustVerificationDisabled")
     Boolean isTrustVerificationDisabled;
 
     /**
-     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example:
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateWaasPolicyDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/CreateWaasPolicyDetails.java
@@ -159,7 +159,7 @@ public class CreateWaasPolicyDetails {
     String compartmentId;
 
     /**
-     * A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+     * A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -189,13 +189,21 @@ public class CreateWaasPolicyDetails {
     WafConfigDetails wafConfig;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/ProtectionRuleExclusion.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/ProtectionRuleExclusion.java
@@ -10,11 +10,11 @@ package com.oracle.bmc.waas.model;
  *     \"exclusions\": [
  *         {
  *             \"target\":\"REQUEST_COOKIES\",
- *             \"exclusions\":[\"yourcompany.com\", \"Wed, 21 Oct 2015 07:28:00 GMT\", \"12345\", \"219ffwef9w0f\"]
+ *             \"exclusions\":[\"example.com\", \"Wed, 21 Oct 2015 07:28:00 GMT\", \"12345\", \"219ffwef9w0f\"]
  *         },
  *                             {
  *             \"target\":\"REQUEST_COOKIES_NAMES\",
- *             \"exclusions\":[\"domain\", \"expires\", \"id\", \"sessionid\"]
+ *             \"exclusions\":[\"OAMAuthnCookie\", \"JSESSIONID\", \"HCM-PSJSESSIONID\"]
  *         }
  *     ],
  *     \"key\": \"1000000\",

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateCertificateDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateCertificateDetails.java
@@ -90,13 +90,21 @@ public class UpdateCertificateDetails {
     String displayName;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateWaasPolicyDetails.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/UpdateWaasPolicyDetails.java
@@ -131,7 +131,7 @@ public class UpdateWaasPolicyDetails {
     }
 
     /**
-     * A user-friendly name for the WAAS policy. The name is can be changed and does not need to be unique.
+     * A user-friendly name for the WAAS policy. The name can be changed and does not need to be unique.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -155,13 +155,21 @@ public class UpdateWaasPolicyDetails {
     WafConfig wafConfig;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WaasPolicy.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WaasPolicy.java
@@ -255,13 +255,21 @@ public class WaasPolicy {
     WafConfig wafConfig;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WaasPolicySummary.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WaasPolicySummary.java
@@ -178,13 +178,21 @@ public class WaasPolicySummary {
     java.util.Date timeCreated;
 
     /**
-     * A simple key-value pair without any defined schema.
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WafLog.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WafLog.java
@@ -240,9 +240,9 @@ public class WafLog {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
-        private String timestamp;
+        private java.util.Date timestamp;
 
-        public Builder timestamp(String timestamp) {
+        public Builder timestamp(java.util.Date timestamp) {
             this.timestamp = timestamp;
             this.__explicitlySet__.add("timestamp");
             return this;
@@ -527,7 +527,7 @@ public class WafLog {
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
-    String timestamp;
+    java.util.Date timestamp;
 
     /**
      * The type of log of the request. For more about log types, see [WAF Logs](https://docs.cloud.oracle.com/iaas/Content/WAF/Tasks/waflogs.htm).

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WorkRequestOperationTypes.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/model/WorkRequestOperationTypes.java
@@ -12,7 +12,6 @@ public enum WorkRequestOperationTypes {
     CreateWaasPolicy("CREATE_WAAS_POLICY"),
     UpdateWaasPolicy("UPDATE_WAAS_POLICY"),
     DeleteWaasPolicy("DELETE_WAAS_POLICY"),
-    PurgeWaasPolicy("PURGE_WAAS_POLICY"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/requests/ListCertificatesRequest.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/requests/ListCertificatesRequest.java
@@ -128,7 +128,7 @@ public class ListCertificatesRequest extends com.oracle.bmc.requests.BmcRequest 
     /**
      * Filter certificates using a list of lifecycle states.
      */
-    private java.util.List<String> lifecycleState;
+    private java.util.List<com.oracle.bmc.waas.model.LifecycleStates> lifecycleState;
 
     /**
      * A filter that matches certificates created on or after the specified date-time.

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/requests/ListWaasPoliciesRequest.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/requests/ListWaasPoliciesRequest.java
@@ -126,7 +126,7 @@ public class ListWaasPoliciesRequest extends com.oracle.bmc.requests.BmcRequest 
     /**
      * Filter policies using a list of lifecycle states.
      */
-    private java.util.List<String> lifecycleState;
+    private java.util.List<com.oracle.bmc.waas.model.LifecycleStates> lifecycleState;
 
     /**
      * A filter that matches policies created on or after the specified date and time.

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/AcceptRecommendationsResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/AcceptRecommendationsResponse.java
@@ -16,11 +16,6 @@ public class AcceptRecommendationsResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class AcceptRecommendationsResponse {
          */
         public Builder copy(AcceptRecommendationsResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/DeleteWaasPolicyResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/DeleteWaasPolicyResponse.java
@@ -16,11 +16,6 @@ public class DeleteWaasPolicyResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class DeleteWaasPolicyResponse {
          */
         public Builder copy(DeleteWaasPolicyResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateAccessRulesResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateAccessRulesResponse.java
@@ -16,11 +16,6 @@ public class UpdateAccessRulesResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateAccessRulesResponse {
          */
         public Builder copy(UpdateAccessRulesResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateCaptchasResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateCaptchasResponse.java
@@ -16,11 +16,6 @@ public class UpdateCaptchasResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateCaptchasResponse {
          */
         public Builder copy(UpdateCaptchasResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateDeviceFingerprintChallengeResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateDeviceFingerprintChallengeResponse.java
@@ -16,11 +16,6 @@ public class UpdateDeviceFingerprintChallengeResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateDeviceFingerprintChallengeResponse {
          */
         public Builder copy(UpdateDeviceFingerprintChallengeResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateGoodBotsResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateGoodBotsResponse.java
@@ -16,11 +16,6 @@ public class UpdateGoodBotsResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateGoodBotsResponse {
          */
         public Builder copy(UpdateGoodBotsResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateHumanInteractionChallengeResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateHumanInteractionChallengeResponse.java
@@ -16,11 +16,6 @@ public class UpdateHumanInteractionChallengeResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateHumanInteractionChallengeResponse {
          */
         public Builder copy(UpdateHumanInteractionChallengeResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateJsChallengeResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateJsChallengeResponse.java
@@ -16,11 +16,6 @@ public class UpdateJsChallengeResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateJsChallengeResponse {
          */
         public Builder copy(UpdateJsChallengeResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdatePolicyConfigResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdatePolicyConfigResponse.java
@@ -16,11 +16,6 @@ public class UpdatePolicyConfigResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdatePolicyConfigResponse {
          */
         public Builder copy(UpdatePolicyConfigResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateProtectionRulesResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateProtectionRulesResponse.java
@@ -16,11 +16,6 @@ public class UpdateProtectionRulesResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateProtectionRulesResponse {
          */
         public Builder copy(UpdateProtectionRulesResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateProtectionSettingsResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateProtectionSettingsResponse.java
@@ -16,11 +16,6 @@ public class UpdateProtectionSettingsResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateProtectionSettingsResponse {
          */
         public Builder copy(UpdateProtectionSettingsResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateThreatFeedsResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateThreatFeedsResponse.java
@@ -16,11 +16,6 @@ public class UpdateThreatFeedsResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateThreatFeedsResponse {
          */
         public Builder copy(UpdateThreatFeedsResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWaasPolicyResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWaasPolicyResponse.java
@@ -16,11 +16,6 @@ public class UpdateWaasPolicyResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateWaasPolicyResponse {
          */
         public Builder copy(UpdateWaasPolicyResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWafAddressRateLimitingResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWafAddressRateLimitingResponse.java
@@ -16,11 +16,6 @@ public class UpdateWafAddressRateLimitingResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateWafAddressRateLimitingResponse {
          */
         public Builder copy(UpdateWafAddressRateLimitingResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWafConfigResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWafConfigResponse.java
@@ -16,11 +16,6 @@ public class UpdateWafConfigResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateWafConfigResponse {
          */
         public Builder copy(UpdateWafConfigResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWhitelistsResponse.java
+++ b/bmc-waas/src/main/java/com/oracle/bmc/waas/responses/UpdateWhitelistsResponse.java
@@ -16,11 +16,6 @@ public class UpdateWhitelistsResponse {
     private String opcRequestId;
 
     /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
-    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String opcWorkRequestId;
@@ -32,7 +27,6 @@ public class UpdateWhitelistsResponse {
          */
         public Builder copy(UpdateWhitelistsResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.5.17</version>
+    <version>1.6.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.5.17</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.5.17</version>
+  <version>1.6.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -654,6 +654,7 @@
     <module>bmc-limits</module>
     <module>bmc-functions</module>
     <module>bmc-events</module>
+    <module>bmc-dts</module>
     <module>bmc-full</module>
     <module>bmc-shaded</module>
   </modules>


### PR DESCRIPTION
### Added

- Support for the Data Transfer service

- Support for the Zurich (ZRH) region



### Breaking changes

- Breaking changes were made in the Web Application Acceleration and Security (WAAS) service:

    - `Certificate_subjectName` class was renamed to `CertificateIssuerName`

    - `Certificate_subjectName` class was renamed to `CertificateSubjectName`

    - `WafLog#timestamp` type was changed from `String` to `java.util.Date`

    - `WorkRequestOperationTypes#PurgeWaasPolicy` enum was removed

    - `ListCertificatesRequest#lifecycleState` and `ListWaasPoliciesRequest#lifecycleState` type was changed from `String` to `com.oracle.bmc.waas.model.LifecycleStates`

    - The `etag` parameter was removed from the following classes:

        - `AcceptRecommendationsResponse`

        - `DeleteWaasPolicyResponse`

        - `UpdateAccessRulesResponse`

        - `UpdateCaptchasResponse`

        - `UpdateDeviceFingerprintChallengeResponse`

        - `UpdateGoodBotsResponse`

        - `UpdateHumanInteractionChallengeResponse`

        - `UpdateJsChallengeResponse`

        - `UpdatePolicyConfigResponse`

        - `UpdateProtectionRulesResponse`

        - `UpdateProtectionSettingsResponse`

        - `UpdateThreatFeedsResponse`

        - `UpdateWaasPolicyResponse`

        - `UpdateWafAddressRateLimitingResponse`

        - `UpdateWafConfigResponse`

        - `UpdateWhitelistsResponse`


