### PR TITLE
Releasing version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,30 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.8.0 - 2019-09-17
+### Added
+- Support for importing state files in the Resource Manager service
+- Support for Exadata Cloud at Customer in the Database service
+- Support for free tier resources and system tags in the Load Balancing service
+- Support for free tier resources and system tags in the Compute service
+- Support for free tier resources and system tags in the Block Storage service
+- Support for free tier and system tags on autonomous databases in the Database service
+
+### Breaking
+- The class `com.oracle.bmc.database.model.CreateDbHomeWithDbSystemIdBase` was renamed to `com.oracle.bmc.database.model.CreateDbHomeBase` that impacts the following references:
+    - `CreateDbHomeRequest#createDbHomeWithDbSystemIdDetails` parameter type
+    - `CreateDbHomeWithDbSystemIdDetails` class extension
+    - `CreateDbHomeWithDbSystemIdFromBackupDetails` class extension
+
 ## 1.7.0 - 2019-09-10
 ### Added
-- Support for specifying the autoBackupWindow field for scheduling backups in the Database service
+- Support for specifying the `autoBackupWindow` field for scheduling backups in the Database service
 - Support for network security groups on autonomous Exadata infrastructure in the Database service
 - Support for Kubernetes secrets encryption in customer clusters, regional subnets, and cluster authentication for instance principals in the Container Engine for Kubernetes service
 - Support for the Oracle Content and Experience service
 
 ### Breaking
-- The etag field has been removed from the com.oracle.bmc.ons.responses.ChangeTopicCompartmentResponse and com.oracle.bmc.ons.responses.ChangeSubscriptionCompartmentResponse classes of the Notifications service
+- The etag field has been removed from the `com.oracle.bmc.ons.responses.ChangeTopicCompartmentResponse` and `com.oracle.bmc.ons.responses.ChangeSubscriptionCompartmentResponse` classes of the Notifications service
 
 ## 1.6.3 - 2019-09-03
 ### Added

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,181 +19,181 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -30,28 +30,26 @@ public final class Region implements Serializable, Comparable<Region> {
     private static final Map<String, Region> KNOWN_REGIONS = new LinkedHashMap<>();
 
     // OC1
-    public static final Region AP_MUMBAI_1 = register("ap-mumbai-1", Realm.OC1);
-    public static final Region AP_SEOUL_1 = register("ap-seoul-1", Realm.OC1);
-    public static final Region AP_SYDNEY_1 = register("ap-sydney-1", Realm.OC1);
-    public static final Region AP_TOKYO_1 = register("ap-tokyo-1", Realm.OC1);
-    public static final Region CA_TORONTO_1 = register("ca-toronto-1", Realm.OC1);
-    // regionCode for FRA shouldn't be needed, but left for backwards compat
+    public static final Region AP_MUMBAI_1 = register("ap-mumbai-1", Realm.OC1, "bom");
+    public static final Region AP_SEOUL_1 = register("ap-seoul-1", Realm.OC1, "icn");
+    public static final Region AP_SYDNEY_1 = register("ap-sydney-1", Realm.OC1, "syd");
+    public static final Region AP_TOKYO_1 = register("ap-tokyo-1", Realm.OC1, "nrt");
+    public static final Region CA_TORONTO_1 = register("ca-toronto-1", Realm.OC1, "yyz");
     public static final Region EU_FRANKFURT_1 = register("eu-frankfurt-1", Realm.OC1, "fra");
-    public static final Region EU_ZURICH_1 = register("eu-zurich-1", Realm.OC1);
-    public static final Region SA_SAOPAULO_1 = register("sa-saopaulo-1", Realm.OC1);
-    // regionCode for LHR shouldn't be needed, but left for backwards compat
+    public static final Region EU_ZURICH_1 = register("eu-zurich-1", Realm.OC1, "zrh");
+    public static final Region SA_SAOPAULO_1 = register("sa-saopaulo-1", Realm.OC1, "gru");
     public static final Region UK_LONDON_1 = register("uk-london-1", Realm.OC1, "lhr");
     public static final Region US_ASHBURN_1 = register("us-ashburn-1", Realm.OC1, "iad");
     public static final Region US_PHOENIX_1 = register("us-phoenix-1", Realm.OC1, "phx");
 
     // OC2
-    public static final Region US_LANGLEY_1 = register("us-langley-1", Realm.OC2);
-    public static final Region US_LUKE_1 = register("us-luke-1", Realm.OC2);
+    public static final Region US_LANGLEY_1 = register("us-langley-1", Realm.OC2, "lfi");
+    public static final Region US_LUKE_1 = register("us-luke-1", Realm.OC2, "luf");
 
     // OC3
-    public static final Region US_GOV_ASHBURN_1 = register("us-gov-ashburn-1", Realm.OC3);
-    public static final Region US_GOV_CHICAGO_1 = register("us-gov-chicago-1", Realm.OC3);
-    public static final Region US_GOV_PHOENIX_1 = register("us-gov-phoenix-1", Realm.OC3);
+    public static final Region US_GOV_ASHBURN_1 = register("us-gov-ashburn-1", Realm.OC3, "ric");
+    public static final Region US_GOV_CHICAGO_1 = register("us-gov-chicago-1", Realm.OC3, "pia");
+    public static final Region US_GOV_PHOENIX_1 = register("us-gov-phoenix-1", Realm.OC3, "tus");
 
     private static final Map<String, Map<Region, String>> SERVICE_TO_REGION_ENDPOINTS =
             new HashMap<>();

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -38,6 +38,15 @@ public interface Database extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Activates the specified Exadata infrastructure.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ActivateExadataInfrastructureResponse activateExadataInfrastructure(
+            ActivateExadataInfrastructureRequest request);
+
+    /**
      * Move the Autonomous Container Database and its dependent resources to the specified compartment.
      * For more information about moving Autonomous Container Databases, see
      * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -76,6 +85,18 @@ public interface Database extends AutoCloseable {
                     ChangeAutonomousExadataInfrastructureCompartmentRequest request);
 
     /**
+     * Move the backup destination and its dependent resources to the specified compartment.
+     * For more information about moving backup destinations, see
+     * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeBackupDestinationCompartmentResponse changeBackupDestinationCompartment(
+            ChangeBackupDestinationCompartmentRequest request);
+
+    /**
      * Move the DB system and its dependent resources to the specified compartment.
      * For more information about moving DB systems, see
      * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -86,6 +107,28 @@ public interface Database extends AutoCloseable {
      */
     ChangeDbSystemCompartmentResponse changeDbSystemCompartment(
             ChangeDbSystemCompartmentRequest request);
+
+    /**
+     * To move an Exadata infrastructure and its dependent resources to another compartment, use the
+     * {@link #changeExadataInfrastructureCompartment(ChangeExadataInfrastructureCompartmentRequest) changeExadataInfrastructureCompartment} operation.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeExadataInfrastructureCompartmentResponse changeExadataInfrastructureCompartment(
+            ChangeExadataInfrastructureCompartmentRequest request);
+
+    /**
+     * To move a VM cluster and its dependent resources to another compartment, use the
+     * {@link #changeVmClusterCompartment(ChangeVmClusterCompartmentRequest) changeVmClusterCompartment} operation.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeVmClusterCompartmentResponse changeVmClusterCompartment(
+            ChangeVmClusterCompartmentRequest request);
 
     /**
      * Changes the status of the standalone backup resource to `ACTIVE` after the backup is created from the on-premises database and placed in Oracle Cloud Infrastructure Object Storage.
@@ -159,6 +202,15 @@ public interface Database extends AutoCloseable {
     CreateBackupResponse createBackup(CreateBackupRequest request);
 
     /**
+     * Creates a backup destination.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateBackupDestinationResponse createBackupDestination(CreateBackupDestinationRequest request);
+
+    /**
      * Creates a new Data Guard association.  A Data Guard association represents the replication relationship between the
      * specified database and a peer database. For more information, see [Using Oracle Data Guard](https://docs.cloud.oracle.com/Content/Database/Tasks/usingdataguard.htm).
      * <p>
@@ -185,6 +237,15 @@ public interface Database extends AutoCloseable {
     CreateDbHomeResponse createDbHome(CreateDbHomeRequest request);
 
     /**
+     * Create Exadata infrastructure.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateExadataInfrastructureResponse createExadataInfrastructure(
+            CreateExadataInfrastructureRequest request);
+
+    /**
      * Creates a new backup resource and returns the information the caller needs to back up an on-premises Oracle Database to Oracle Cloud Infrastructure.
      * <p>
      **Note:** This API is used by an Oracle Cloud Infrastructure Python script that is packaged with the Oracle Cloud Infrastructure CLI. Oracle recommends that you use the script instead using the API directly. See [Migrating an On-Premises Database to Oracle Cloud Infrastructure by Creating a Backup in the Cloud](https://docs.cloud.oracle.com/Content/Database/Tasks/mig-onprembackup.htm) for more information.
@@ -194,6 +255,24 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     CreateExternalBackupJobResponse createExternalBackupJob(CreateExternalBackupJobRequest request);
+
+    /**
+     * Creates a VM cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateVmClusterResponse createVmCluster(CreateVmClusterRequest request);
+
+    /**
+     * Creates the VM cluster network.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateVmClusterNetworkResponse createVmClusterNetwork(CreateVmClusterNetworkRequest request);
 
     /**
      * Performs one of the following power actions on the specified DB node:
@@ -245,6 +324,15 @@ public interface Database extends AutoCloseable {
     DeleteBackupResponse deleteBackup(DeleteBackupRequest request);
 
     /**
+     * Deletes a backup destination.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteBackupDestinationResponse deleteBackupDestination(DeleteBackupDestinationRequest request);
+
+    /**
      * Deletes a DB Home. The DB Home and its database data are local to the DB system and will be lost when it is deleted. Oracle recommends that you back up any data in the DB system prior to deleting it.
      *
      * @param request The request object containing the details to send
@@ -252,6 +340,54 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     DeleteDbHomeResponse deleteDbHome(DeleteDbHomeRequest request);
+
+    /**
+     * Deletes the Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteExadataInfrastructureResponse deleteExadataInfrastructure(
+            DeleteExadataInfrastructureRequest request);
+
+    /**
+     * Deletes the specified VM cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteVmClusterResponse deleteVmCluster(DeleteVmClusterRequest request);
+
+    /**
+     * Deletes the specified VM cluster network.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteVmClusterNetworkResponse deleteVmClusterNetwork(DeleteVmClusterNetworkRequest request);
+
+    /**
+     * Downloads the configuration file for the specified Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DownloadExadataInfrastructureConfigFileResponse downloadExadataInfrastructureConfigFile(
+            DownloadExadataInfrastructureConfigFileRequest request);
+
+    /**
+     * Downloads the configuration file for the specified VM Cluster Network.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DownloadVmClusterNetworkConfigFileResponse downloadVmClusterNetworkConfigFile(
+            DownloadVmClusterNetworkConfigFileRequest request);
 
     /**
      * Performs a failover to transition the standby database identified by the `databaseId` parameter into the
@@ -286,6 +422,16 @@ public interface Database extends AutoCloseable {
      */
     GenerateAutonomousDatabaseWalletResponse generateAutonomousDatabaseWallet(
             GenerateAutonomousDatabaseWalletRequest request);
+
+    /**
+     * Generates a recommended VM cluster network configuration.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GenerateRecommendedVmClusterNetworkResponse generateRecommendedVmClusterNetwork(
+            GenerateRecommendedVmClusterNetworkRequest request);
 
     /**
      * Gets information about the specified Autonomous Container Database.
@@ -350,6 +496,15 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetBackupResponse getBackup(GetBackupRequest request);
+
+    /**
+     * Gets information about the specified backup destination.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetBackupDestinationResponse getBackupDestination(GetBackupDestinationRequest request);
 
     /**
      * Gets the specified Data Guard association's configuration information.
@@ -431,6 +586,15 @@ public interface Database extends AutoCloseable {
             GetDbSystemPatchHistoryEntryRequest request);
 
     /**
+     * Gets information about the specified Exadata infrastructure.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetExadataInfrastructureResponse getExadataInfrastructure(
+            GetExadataInfrastructureRequest request);
+
+    /**
      * Gets `IORM` Setting for the requested Exadata DB System.
      * The default IORM Settings is pre-created in all the Exadata DB System.
      *
@@ -458,6 +622,22 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetMaintenanceRunResponse getMaintenanceRun(GetMaintenanceRunRequest request);
+
+    /**
+     * Gets information about the specified VM cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetVmClusterResponse getVmCluster(GetVmClusterRequest request);
+
+    /**
+     * Gets information about the specified VM cluster network.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetVmClusterNetworkResponse getVmClusterNetwork(GetVmClusterNetworkRequest request);
 
     /**
      * Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
@@ -559,6 +739,15 @@ public interface Database extends AutoCloseable {
      */
     ListAutonomousExadataInfrastructuresResponse listAutonomousExadataInfrastructures(
             ListAutonomousExadataInfrastructuresRequest request);
+
+    /**
+     * Gets a list of backup destinations in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListBackupDestinationResponse listBackupDestination(ListBackupDestinationRequest request);
 
     /**
      * Gets a list of backups based on the databaseId or compartmentId specified. Either one of the query parameters must be provided.
@@ -671,6 +860,24 @@ public interface Database extends AutoCloseable {
     ListDbVersionsResponse listDbVersions(ListDbVersionsRequest request);
 
     /**
+     * Gets a list of the Exadata infrastructure in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListExadataInfrastructuresResponse listExadataInfrastructures(
+            ListExadataInfrastructuresRequest request);
+
+    /**
+     * Gets a list of supported GI versions for VM Cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListGiVersionsResponse listGiVersions(ListGiVersionsRequest request);
+
+    /**
      * Gets a list of the Maintenance Runs in the specified compartment.
      *
      * @param request The request object containing the details to send
@@ -678,6 +885,24 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ListMaintenanceRunsResponse listMaintenanceRuns(ListMaintenanceRunsRequest request);
+
+    /**
+     * Gets a list of the VM cluster networks in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListVmClusterNetworksResponse listVmClusterNetworks(ListVmClusterNetworksRequest request);
+
+    /**
+     * Gets a list of the VM clusters in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListVmClustersResponse listVmClusters(ListVmClustersRequest request);
 
     /**
      * Reinstates the database identified by the `databaseId` parameter into the standby role in a Data Guard association.
@@ -844,6 +1069,17 @@ public interface Database extends AutoCloseable {
             UpdateAutonomousExadataInfrastructureRequest request);
 
     /**
+     * If no database is associated with the backup destination:
+     * - For a RECOVERY_APPLIANCE backup destination, updates the connection string and/or the list of VPC users.
+     * - For an NFS backup destination, updates the NFS location.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateBackupDestinationResponse updateBackupDestination(UpdateBackupDestinationRequest request);
+
+    /**
      * Update a Database based on the request parameters you provide.
      *
      * @param request The request object containing the details to send
@@ -869,6 +1105,16 @@ public interface Database extends AutoCloseable {
     UpdateDbSystemResponse updateDbSystem(UpdateDbSystemRequest request);
 
     /**
+     * Updates the Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateExadataInfrastructureResponse updateExadataInfrastructure(
+            UpdateExadataInfrastructureRequest request);
+
+    /**
      * Update `IORM` Settings for the requested Exadata DB System.
      *
      * @param request The request object containing the details to send
@@ -884,6 +1130,34 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     UpdateMaintenanceRunResponse updateMaintenanceRun(UpdateMaintenanceRunRequest request);
+
+    /**
+     * Updates the specified VM cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateVmClusterResponse updateVmCluster(UpdateVmClusterRequest request);
+
+    /**
+     * Updates the specified VM cluster network.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateVmClusterNetworkResponse updateVmClusterNetwork(UpdateVmClusterNetworkRequest request);
+
+    /**
+     * Validates the specified VM cluster network.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ValidateVmClusterNetworkResponse validateVmClusterNetwork(
+            ValidateVmClusterNetworkRequest request);
 
     /**
      * Gets the pre-configured waiters available for resources for this service.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -37,6 +37,24 @@ public interface DatabaseAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Activates the specified Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ActivateExadataInfrastructureResponse>
+            activateExadataInfrastructure(
+                    ActivateExadataInfrastructureRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ActivateExadataInfrastructureRequest,
+                                    ActivateExadataInfrastructureResponse>
+                            handler);
+
+    /**
      * Move the Autonomous Container Database and its dependent resources to the specified compartment.
      * For more information about moving Autonomous Container Databases, see
      * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -100,6 +118,27 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Move the backup destination and its dependent resources to the specified compartment.
+     * For more information about moving backup destinations, see
+     * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeBackupDestinationCompartmentResponse>
+            changeBackupDestinationCompartment(
+                    ChangeBackupDestinationCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeBackupDestinationCompartmentRequest,
+                                    ChangeBackupDestinationCompartmentResponse>
+                            handler);
+
+    /**
      * Move the DB system and its dependent resources to the specified compartment.
      * For more information about moving DB systems, see
      * [Moving Database Resources to a Different Compartment](https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes).
@@ -116,6 +155,44 @@ public interface DatabaseAsync extends AutoCloseable {
             ChangeDbSystemCompartmentRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ChangeDbSystemCompartmentRequest, ChangeDbSystemCompartmentResponse>
+                    handler);
+
+    /**
+     * To move an Exadata infrastructure and its dependent resources to another compartment, use the
+     * {@link #changeExadataInfrastructureCompartment(ChangeExadataInfrastructureCompartmentRequest, Consumer, Consumer) changeExadataInfrastructureCompartment} operation.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeExadataInfrastructureCompartmentResponse>
+            changeExadataInfrastructureCompartment(
+                    ChangeExadataInfrastructureCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeExadataInfrastructureCompartmentRequest,
+                                    ChangeExadataInfrastructureCompartmentResponse>
+                            handler);
+
+    /**
+     * To move a VM cluster and its dependent resources to another compartment, use the
+     * {@link #changeVmClusterCompartment(ChangeVmClusterCompartmentRequest, Consumer, Consumer) changeVmClusterCompartment} operation.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeVmClusterCompartmentResponse> changeVmClusterCompartment(
+            ChangeVmClusterCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeVmClusterCompartmentRequest, ChangeVmClusterCompartmentResponse>
                     handler);
 
     /**
@@ -247,6 +324,23 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Creates a backup destination.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateBackupDestinationResponse> createBackupDestination(
+            CreateBackupDestinationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateBackupDestinationRequest, CreateBackupDestinationResponse>
+                    handler);
+
+    /**
      * Creates a new Data Guard association.  A Data Guard association represents the replication relationship between the
      * specified database and a peer database. For more information, see [Using Oracle Data Guard](https://docs.cloud.oracle.com/Content/Database/Tasks/usingdataguard.htm).
      * <p>
@@ -287,6 +381,22 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Create Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateExadataInfrastructureResponse> createExadataInfrastructure(
+            CreateExadataInfrastructureRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateExadataInfrastructureRequest, CreateExadataInfrastructureResponse>
+                    handler);
+
+    /**
      * Creates a new backup resource and returns the information the caller needs to back up an on-premises Oracle Database to Oracle Cloud Infrastructure.
      * <p>
      **Note:** This API is used by an Oracle Cloud Infrastructure Python script that is packaged with the Oracle Cloud Infrastructure CLI. Oracle recommends that you use the script instead using the API directly. See [Migrating an On-Premises Database to Oracle Cloud Infrastructure by Creating a Backup in the Cloud](https://docs.cloud.oracle.com/Content/Database/Tasks/mig-onprembackup.htm) for more information.
@@ -303,6 +413,39 @@ public interface DatabaseAsync extends AutoCloseable {
             CreateExternalBackupJobRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             CreateExternalBackupJobRequest, CreateExternalBackupJobResponse>
+                    handler);
+
+    /**
+     * Creates a VM cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateVmClusterResponse> createVmCluster(
+            CreateVmClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateVmClusterRequest, CreateVmClusterResponse>
+                    handler);
+
+    /**
+     * Creates the VM cluster network.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateVmClusterNetworkResponse> createVmClusterNetwork(
+            CreateVmClusterNetworkRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateVmClusterNetworkRequest, CreateVmClusterNetworkResponse>
                     handler);
 
     /**
@@ -385,6 +528,23 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes a backup destination.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteBackupDestinationResponse> deleteBackupDestination(
+            DeleteBackupDestinationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteBackupDestinationRequest, DeleteBackupDestinationResponse>
+                    handler);
+
+    /**
      * Deletes a DB Home. The DB Home and its database data are local to the DB system and will be lost when it is deleted. Oracle recommends that you back up any data in the DB system prior to deleting it.
      *
      *
@@ -399,6 +559,94 @@ public interface DatabaseAsync extends AutoCloseable {
             DeleteDbHomeRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeleteDbHomeRequest, DeleteDbHomeResponse>
                     handler);
+
+    /**
+     * Deletes the Exadata infrastructure.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteExadataInfrastructureResponse> deleteExadataInfrastructure(
+            DeleteExadataInfrastructureRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteExadataInfrastructureRequest, DeleteExadataInfrastructureResponse>
+                    handler);
+
+    /**
+     * Deletes the specified VM cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteVmClusterResponse> deleteVmCluster(
+            DeleteVmClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteVmClusterRequest, DeleteVmClusterResponse>
+                    handler);
+
+    /**
+     * Deletes the specified VM cluster network.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteVmClusterNetworkResponse> deleteVmClusterNetwork(
+            DeleteVmClusterNetworkRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVmClusterNetworkRequest, DeleteVmClusterNetworkResponse>
+                    handler);
+
+    /**
+     * Downloads the configuration file for the specified Exadata infrastructure.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DownloadExadataInfrastructureConfigFileResponse>
+            downloadExadataInfrastructureConfigFile(
+                    DownloadExadataInfrastructureConfigFileRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DownloadExadataInfrastructureConfigFileRequest,
+                                    DownloadExadataInfrastructureConfigFileResponse>
+                            handler);
+
+    /**
+     * Downloads the configuration file for the specified VM Cluster Network.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DownloadVmClusterNetworkConfigFileResponse>
+            downloadVmClusterNetworkConfigFile(
+                    DownloadVmClusterNetworkConfigFileRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DownloadVmClusterNetworkConfigFileRequest,
+                                    DownloadVmClusterNetworkConfigFileResponse>
+                            handler);
 
     /**
      * Performs a failover to transition the standby database identified by the `databaseId` parameter into the
@@ -458,6 +706,25 @@ public interface DatabaseAsync extends AutoCloseable {
                     com.oracle.bmc.responses.AsyncHandler<
                                     GenerateAutonomousDatabaseWalletRequest,
                                     GenerateAutonomousDatabaseWalletResponse>
+                            handler);
+
+    /**
+     * Generates a recommended VM cluster network configuration.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GenerateRecommendedVmClusterNetworkResponse>
+            generateRecommendedVmClusterNetwork(
+                    GenerateRecommendedVmClusterNetworkRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateRecommendedVmClusterNetworkRequest,
+                                    GenerateRecommendedVmClusterNetworkResponse>
                             handler);
 
     /**
@@ -578,6 +845,23 @@ public interface DatabaseAsync extends AutoCloseable {
     java.util.concurrent.Future<GetBackupResponse> getBackup(
             GetBackupRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetBackupRequest, GetBackupResponse> handler);
+
+    /**
+     * Gets information about the specified backup destination.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetBackupDestinationResponse> getBackupDestination(
+            GetBackupDestinationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetBackupDestinationRequest, GetBackupDestinationResponse>
+                    handler);
 
     /**
      * Gets the specified Data Guard association's configuration information.
@@ -720,6 +1004,22 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets information about the specified Exadata infrastructure.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetExadataInfrastructureResponse> getExadataInfrastructure(
+            GetExadataInfrastructureRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+                    handler);
+
+    /**
      * Gets `IORM` Setting for the requested Exadata DB System.
      * The default IORM Settings is pre-created in all the Exadata DB System.
      *
@@ -770,6 +1070,37 @@ public interface DatabaseAsync extends AutoCloseable {
             GetMaintenanceRunRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             GetMaintenanceRunRequest, GetMaintenanceRunResponse>
+                    handler);
+
+    /**
+     * Gets information about the specified VM cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVmClusterResponse> getVmCluster(
+            GetVmClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetVmClusterRequest, GetVmClusterResponse>
+                    handler);
+
+    /**
+     * Gets information about the specified VM cluster network.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVmClusterNetworkResponse> getVmClusterNetwork(
+            GetVmClusterNetworkRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
                     handler);
 
     /**
@@ -958,6 +1289,23 @@ public interface DatabaseAsync extends AutoCloseable {
                                     ListAutonomousExadataInfrastructuresRequest,
                                     ListAutonomousExadataInfrastructuresResponse>
                             handler);
+
+    /**
+     * Gets a list of backup destinations in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBackupDestinationResponse> listBackupDestination(
+            ListBackupDestinationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListBackupDestinationRequest, ListBackupDestinationResponse>
+                    handler);
 
     /**
      * Gets a list of backups based on the databaseId or compartmentId specified. Either one of the query parameters must be provided.
@@ -1158,6 +1506,38 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets a list of the Exadata infrastructure in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListExadataInfrastructuresResponse> listExadataInfrastructures(
+            ListExadataInfrastructuresRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListExadataInfrastructuresRequest, ListExadataInfrastructuresResponse>
+                    handler);
+
+    /**
+     * Gets a list of supported GI versions for VM Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListGiVersionsResponse> listGiVersions(
+            ListGiVersionsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListGiVersionsRequest, ListGiVersionsResponse>
+                    handler);
+
+    /**
      * Gets a list of the Maintenance Runs in the specified compartment.
      *
      *
@@ -1172,6 +1552,39 @@ public interface DatabaseAsync extends AutoCloseable {
             ListMaintenanceRunsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListMaintenanceRunsRequest, ListMaintenanceRunsResponse>
+                    handler);
+
+    /**
+     * Gets a list of the VM cluster networks in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVmClusterNetworksResponse> listVmClusterNetworks(
+            ListVmClusterNetworksRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>
+                    handler);
+
+    /**
+     * Gets a list of the VM clusters in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVmClustersResponse> listVmClusters(
+            ListVmClustersRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListVmClustersRequest, ListVmClustersResponse>
                     handler);
 
     /**
@@ -1480,6 +1893,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * If no database is associated with the backup destination:
+     * - For a RECOVERY_APPLIANCE backup destination, updates the connection string and/or the list of VPC users.
+     * - For an NFS backup destination, updates the NFS location.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateBackupDestinationResponse> updateBackupDestination(
+            UpdateBackupDestinationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateBackupDestinationRequest, UpdateBackupDestinationResponse>
+                    handler);
+
+    /**
      * Update a Database based on the request parameters you provide.
      *
      *
@@ -1526,6 +1958,23 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Updates the Exadata infrastructure.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateExadataInfrastructureResponse> updateExadataInfrastructure(
+            UpdateExadataInfrastructureRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateExadataInfrastructureRequest, UpdateExadataInfrastructureResponse>
+                    handler);
+
+    /**
      * Update `IORM` Settings for the requested Exadata DB System.
      *
      *
@@ -1556,5 +2005,55 @@ public interface DatabaseAsync extends AutoCloseable {
             UpdateMaintenanceRunRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateMaintenanceRunRequest, UpdateMaintenanceRunResponse>
+                    handler);
+
+    /**
+     * Updates the specified VM cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateVmClusterResponse> updateVmCluster(
+            UpdateVmClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateVmClusterRequest, UpdateVmClusterResponse>
+                    handler);
+
+    /**
+     * Updates the specified VM cluster network.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateVmClusterNetworkResponse> updateVmClusterNetwork(
+            UpdateVmClusterNetworkRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVmClusterNetworkRequest, UpdateVmClusterNetworkResponse>
+                    handler);
+
+    /**
+     * Validates the specified VM cluster network.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ValidateVmClusterNetworkResponse> validateVmClusterNetwork(
+            ValidateVmClusterNetworkRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ValidateVmClusterNetworkRequest, ValidateVmClusterNetworkResponse>
                     handler);
 }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -303,6 +303,100 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ActivateExadataInfrastructureResponse>
+            activateExadataInfrastructure(
+                    final ActivateExadataInfrastructureRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ActivateExadataInfrastructureRequest,
+                                    ActivateExadataInfrastructureResponse>
+                            handler) {
+        LOG.trace("Called async activateExadataInfrastructure");
+        final ActivateExadataInfrastructureRequest interceptedRequest =
+                ActivateExadataInfrastructureConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ActivateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ActivateExadataInfrastructureResponse>
+                transformer = ActivateExadataInfrastructureConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ActivateExadataInfrastructureRequest, ActivateExadataInfrastructureResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ActivateExadataInfrastructureRequest,
+                            ActivateExadataInfrastructureResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getActivateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getActivateExadataInfrastructureDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ActivateExadataInfrastructureResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getActivateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeAutonomousContainerDatabaseCompartmentResponse>
             changeAutonomousContainerDatabaseCompartment(
                     final ChangeAutonomousContainerDatabaseCompartmentRequest request,
@@ -596,6 +690,101 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeBackupDestinationCompartmentResponse>
+            changeBackupDestinationCompartment(
+                    final ChangeBackupDestinationCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeBackupDestinationCompartmentRequest,
+                                    ChangeBackupDestinationCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeBackupDestinationCompartment");
+        final ChangeBackupDestinationCompartmentRequest interceptedRequest =
+                ChangeBackupDestinationCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBackupDestinationCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeBackupDestinationCompartmentResponse>
+                transformer = ChangeBackupDestinationCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeBackupDestinationCompartmentRequest,
+                        ChangeBackupDestinationCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeBackupDestinationCompartmentRequest,
+                            ChangeBackupDestinationCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeBackupDestinationCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeDbSystemCompartmentResponse> changeDbSystemCompartment(
             final ChangeDbSystemCompartmentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -675,6 +864,197 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getChangeCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeExadataInfrastructureCompartmentResponse>
+            changeExadataInfrastructureCompartment(
+                    final ChangeExadataInfrastructureCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeExadataInfrastructureCompartmentRequest,
+                                    ChangeExadataInfrastructureCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeExadataInfrastructureCompartment");
+        final ChangeExadataInfrastructureCompartmentRequest interceptedRequest =
+                ChangeExadataInfrastructureCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeExadataInfrastructureCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeExadataInfrastructureCompartmentResponse>
+                transformer = ChangeExadataInfrastructureCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeExadataInfrastructureCompartmentRequest,
+                        ChangeExadataInfrastructureCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeExadataInfrastructureCompartmentRequest,
+                            ChangeExadataInfrastructureCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeExadataInfrastructureCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeExadataInfrastructureCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeExadataInfrastructureCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeExadataInfrastructureCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeVmClusterCompartmentResponse>
+            changeVmClusterCompartment(
+                    final ChangeVmClusterCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeVmClusterCompartmentRequest,
+                                    ChangeVmClusterCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeVmClusterCompartment");
+        final ChangeVmClusterCompartmentRequest interceptedRequest =
+                ChangeVmClusterCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeVmClusterCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>
+                transformer = ChangeVmClusterCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeVmClusterCompartmentRequest, ChangeVmClusterCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeVmClusterCompartmentRequest, ChangeVmClusterCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeVmClusterCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeVmClusterCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeVmClusterCompartmentDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -1341,6 +1721,97 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateBackupDestinationResponse> createBackupDestination(
+            final CreateBackupDestinationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateBackupDestinationRequest, CreateBackupDestinationResponse>
+                    handler) {
+        LOG.trace("Called async createBackupDestination");
+        final CreateBackupDestinationRequest interceptedRequest =
+                CreateBackupDestinationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateBackupDestinationResponse>
+                transformer = CreateBackupDestinationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateBackupDestinationRequest, CreateBackupDestinationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateBackupDestinationRequest, CreateBackupDestinationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateBackupDestinationDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateBackupDestinationDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateBackupDestinationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateBackupDestinationDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateDataGuardAssociationResponse>
             createDataGuardAssociation(
                     final CreateDataGuardAssociationRequest request,
@@ -1522,6 +1993,100 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateExadataInfrastructureResponse>
+            createExadataInfrastructure(
+                    final CreateExadataInfrastructureRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    CreateExadataInfrastructureRequest,
+                                    CreateExadataInfrastructureResponse>
+                            handler) {
+        LOG.trace("Called async createExadataInfrastructure");
+        final CreateExadataInfrastructureRequest interceptedRequest =
+                CreateExadataInfrastructureConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>
+                transformer = CreateExadataInfrastructureConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateExadataInfrastructureRequest, CreateExadataInfrastructureResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateExadataInfrastructureRequest,
+                            CreateExadataInfrastructureResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateExadataInfrastructureDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateExternalBackupJobResponse> createExternalBackupJob(
             final CreateExternalBackupJobRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1601,6 +2166,186 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getCreateExternalBackupJobDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateVmClusterResponse> createVmCluster(
+            final CreateVmClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateVmClusterRequest, CreateVmClusterResponse>
+                    handler) {
+        LOG.trace("Called async createVmCluster");
+        final CreateVmClusterRequest interceptedRequest =
+                CreateVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateVmClusterResponse>
+                transformer = CreateVmClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreateVmClusterRequest, CreateVmClusterResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateVmClusterRequest, CreateVmClusterResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateVmClusterDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateVmClusterDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateVmClusterResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateVmClusterDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateVmClusterNetworkResponse> createVmClusterNetwork(
+            final CreateVmClusterNetworkRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateVmClusterNetworkRequest, CreateVmClusterNetworkResponse>
+                    handler) {
+        LOG.trace("Called async createVmClusterNetwork");
+        final CreateVmClusterNetworkRequest interceptedRequest =
+                CreateVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>
+                transformer = CreateVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateVmClusterNetworkRequest, CreateVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateVmClusterNetworkRequest, CreateVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getVmClusterNetworkDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getVmClusterNetworkDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getVmClusterNetworkDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -1914,6 +2659,82 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteBackupDestinationResponse> deleteBackupDestination(
+            final DeleteBackupDestinationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteBackupDestinationRequest, DeleteBackupDestinationResponse>
+                    handler) {
+        LOG.trace("Called async deleteBackupDestination");
+        final DeleteBackupDestinationRequest interceptedRequest =
+                DeleteBackupDestinationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteBackupDestinationResponse>
+                transformer = DeleteBackupDestinationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteBackupDestinationRequest, DeleteBackupDestinationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteBackupDestinationRequest, DeleteBackupDestinationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteBackupDestinationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteDbHomeResponse> deleteDbHome(
             final DeleteDbHomeRequest request,
             final com.oracle.bmc.responses.AsyncHandler<DeleteDbHomeRequest, DeleteDbHomeResponse>
@@ -1978,6 +2799,396 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
                             return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteExadataInfrastructureResponse>
+            deleteExadataInfrastructure(
+                    final DeleteExadataInfrastructureRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteExadataInfrastructureRequest,
+                                    DeleteExadataInfrastructureResponse>
+                            handler) {
+        LOG.trace("Called async deleteExadataInfrastructure");
+        final DeleteExadataInfrastructureRequest interceptedRequest =
+                DeleteExadataInfrastructureConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>
+                transformer = DeleteExadataInfrastructureConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteExadataInfrastructureRequest, DeleteExadataInfrastructureResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteExadataInfrastructureRequest,
+                            DeleteExadataInfrastructureResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteVmClusterResponse> deleteVmCluster(
+            final DeleteVmClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVmClusterRequest, DeleteVmClusterResponse>
+                    handler) {
+        LOG.trace("Called async deleteVmCluster");
+        final DeleteVmClusterRequest interceptedRequest =
+                DeleteVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVmClusterResponse>
+                transformer = DeleteVmClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteVmClusterRequest, DeleteVmClusterResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteVmClusterRequest, DeleteVmClusterResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteVmClusterResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteVmClusterNetworkResponse> deleteVmClusterNetwork(
+            final DeleteVmClusterNetworkRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVmClusterNetworkRequest, DeleteVmClusterNetworkResponse>
+                    handler) {
+        LOG.trace("Called async deleteVmClusterNetwork");
+        final DeleteVmClusterNetworkRequest interceptedRequest =
+                DeleteVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>
+                transformer = DeleteVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteVmClusterNetworkRequest, DeleteVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteVmClusterNetworkRequest, DeleteVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DownloadExadataInfrastructureConfigFileResponse>
+            downloadExadataInfrastructureConfigFile(
+                    final DownloadExadataInfrastructureConfigFileRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DownloadExadataInfrastructureConfigFileRequest,
+                                    DownloadExadataInfrastructureConfigFileResponse>
+                            handler) {
+        LOG.trace("Called async downloadExadataInfrastructureConfigFile");
+        final DownloadExadataInfrastructureConfigFileRequest interceptedRequest =
+                DownloadExadataInfrastructureConfigFileConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DownloadExadataInfrastructureConfigFileConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadExadataInfrastructureConfigFileResponse>
+                transformer = DownloadExadataInfrastructureConfigFileConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DownloadExadataInfrastructureConfigFileRequest,
+                        DownloadExadataInfrastructureConfigFileResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DownloadExadataInfrastructureConfigFileRequest,
+                            DownloadExadataInfrastructureConfigFileResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DownloadExadataInfrastructureConfigFileResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DownloadVmClusterNetworkConfigFileResponse>
+            downloadVmClusterNetworkConfigFile(
+                    final DownloadVmClusterNetworkConfigFileRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DownloadVmClusterNetworkConfigFileRequest,
+                                    DownloadVmClusterNetworkConfigFileResponse>
+                            handler) {
+        LOG.trace("Called async downloadVmClusterNetworkConfigFile");
+        final DownloadVmClusterNetworkConfigFileRequest interceptedRequest =
+                DownloadVmClusterNetworkConfigFileConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DownloadVmClusterNetworkConfigFileConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadVmClusterNetworkConfigFileResponse>
+                transformer = DownloadVmClusterNetworkConfigFileConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DownloadVmClusterNetworkConfigFileRequest,
+                        DownloadVmClusterNetworkConfigFileResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DownloadVmClusterNetworkConfigFileRequest,
+                            DownloadVmClusterNetworkConfigFileResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DownloadVmClusterNetworkConfigFileResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
                         }
                     });
         } else {
@@ -2262,6 +3473,102 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getGenerateAutonomousDatabaseWalletDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GenerateRecommendedVmClusterNetworkResponse>
+            generateRecommendedVmClusterNetwork(
+                    final GenerateRecommendedVmClusterNetworkRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateRecommendedVmClusterNetworkRequest,
+                                    GenerateRecommendedVmClusterNetworkResponse>
+                            handler) {
+        LOG.trace("Called async generateRecommendedVmClusterNetwork");
+        final GenerateRecommendedVmClusterNetworkRequest interceptedRequest =
+                GenerateRecommendedVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateRecommendedVmClusterNetworkConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateRecommendedVmClusterNetworkResponse>
+                transformer = GenerateRecommendedVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GenerateRecommendedVmClusterNetworkRequest,
+                        GenerateRecommendedVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GenerateRecommendedVmClusterNetworkRequest,
+                            GenerateRecommendedVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getGenerateRecommendedNetworkDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getGenerateRecommendedNetworkDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GenerateRecommendedVmClusterNetworkResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getGenerateRecommendedNetworkDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -2801,6 +4108,82 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetBackupResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetBackupDestinationResponse> getBackupDestination(
+            final GetBackupDestinationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetBackupDestinationRequest, GetBackupDestinationResponse>
+                    handler) {
+        LOG.trace("Called async getBackupDestination");
+        final GetBackupDestinationRequest interceptedRequest =
+                GetBackupDestinationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetBackupDestinationResponse>
+                transformer = GetBackupDestinationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetBackupDestinationRequest, GetBackupDestinationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetBackupDestinationRequest, GetBackupDestinationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetBackupDestinationResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -3490,6 +4873,82 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetExadataInfrastructureResponse> getExadataInfrastructure(
+            final GetExadataInfrastructureRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+                    handler) {
+        LOG.trace("Called async getExadataInfrastructure");
+        final GetExadataInfrastructureRequest interceptedRequest =
+                GetExadataInfrastructureConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetExadataInfrastructureResponse>
+                transformer = GetExadataInfrastructureConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetExadataInfrastructureResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetExadataIormConfigResponse> getExadataIormConfig(
             final GetExadataIormConfigRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -3698,6 +5157,155 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetMaintenanceRunResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetVmClusterResponse> getVmCluster(
+            final GetVmClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetVmClusterRequest, GetVmClusterResponse>
+                    handler) {
+        LOG.trace("Called async getVmCluster");
+        final GetVmClusterRequest interceptedRequest =
+                GetVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterResponse>
+                transformer = GetVmClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetVmClusterRequest, GetVmClusterResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetVmClusterRequest, GetVmClusterResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetVmClusterResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetVmClusterNetworkResponse> getVmClusterNetwork(
+            final GetVmClusterNetworkRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+                    handler) {
+        LOG.trace("Called async getVmClusterNetwork");
+        final GetVmClusterNetworkRequest interceptedRequest =
+                GetVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVmClusterNetworkResponse>
+                transformer = GetVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetVmClusterNetworkResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -4522,6 +6130,82 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, ListAutonomousExadataInfrastructuresResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListBackupDestinationResponse> listBackupDestination(
+            final ListBackupDestinationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListBackupDestinationRequest, ListBackupDestinationResponse>
+                    handler) {
+        LOG.trace("Called async listBackupDestination");
+        final ListBackupDestinationRequest interceptedRequest =
+                ListBackupDestinationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBackupDestinationResponse>
+                transformer = ListBackupDestinationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListBackupDestinationRequest, ListBackupDestinationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListBackupDestinationRequest, ListBackupDestinationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListBackupDestinationResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -5438,6 +7122,158 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListExadataInfrastructuresResponse>
+            listExadataInfrastructures(
+                    final ListExadataInfrastructuresRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListExadataInfrastructuresRequest,
+                                    ListExadataInfrastructuresResponse>
+                            handler) {
+        LOG.trace("Called async listExadataInfrastructures");
+        final ListExadataInfrastructuresRequest interceptedRequest =
+                ListExadataInfrastructuresConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListExadataInfrastructuresConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>
+                transformer = ListExadataInfrastructuresConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListExadataInfrastructuresRequest, ListExadataInfrastructuresResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListExadataInfrastructuresRequest, ListExadataInfrastructuresResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListGiVersionsResponse> listGiVersions(
+            final ListGiVersionsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListGiVersionsRequest, ListGiVersionsResponse>
+                    handler) {
+        LOG.trace("Called async listGiVersions");
+        final ListGiVersionsRequest interceptedRequest =
+                ListGiVersionsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListGiVersionsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListGiVersionsResponse>
+                transformer = ListGiVersionsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListGiVersionsRequest, ListGiVersionsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListGiVersionsRequest, ListGiVersionsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListGiVersionsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListMaintenanceRunsResponse> listMaintenanceRuns(
             final ListMaintenanceRunsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -5496,6 +7332,156 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, ListMaintenanceRunsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVmClusterNetworksResponse> listVmClusterNetworks(
+            final ListVmClusterNetworksRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>
+                    handler) {
+        LOG.trace("Called async listVmClusterNetworks");
+        final ListVmClusterNetworksRequest interceptedRequest =
+                ListVmClusterNetworksConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterNetworksConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVmClusterNetworksResponse>
+                transformer = ListVmClusterNetworksConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListVmClusterNetworksResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVmClustersResponse> listVmClusters(
+            final ListVmClustersRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListVmClustersRequest, ListVmClustersResponse>
+                    handler) {
+        LOG.trace("Called async listVmClusters");
+        final ListVmClustersRequest interceptedRequest =
+                ListVmClustersConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClustersConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClustersResponse>
+                transformer = ListVmClustersConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListVmClustersRequest, ListVmClustersResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListVmClustersRequest, ListVmClustersResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListVmClustersResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -6984,6 +8970,97 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<UpdateBackupDestinationResponse> updateBackupDestination(
+            final UpdateBackupDestinationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateBackupDestinationRequest, UpdateBackupDestinationResponse>
+                    handler) {
+        LOG.trace("Called async updateBackupDestination");
+        final UpdateBackupDestinationRequest interceptedRequest =
+                UpdateBackupDestinationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateBackupDestinationResponse>
+                transformer = UpdateBackupDestinationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateBackupDestinationRequest, UpdateBackupDestinationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateBackupDestinationRequest, UpdateBackupDestinationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateBackupDestinationDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateBackupDestinationDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateBackupDestinationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateBackupDestinationDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateDatabaseResponse> updateDatabase(
             final UpdateDatabaseRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -7250,6 +9327,100 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<UpdateExadataInfrastructureResponse>
+            updateExadataInfrastructure(
+                    final UpdateExadataInfrastructureRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateExadataInfrastructureRequest,
+                                    UpdateExadataInfrastructureResponse>
+                            handler) {
+        LOG.trace("Called async updateExadataInfrastructure");
+        final UpdateExadataInfrastructureRequest interceptedRequest =
+                UpdateExadataInfrastructureConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>
+                transformer = UpdateExadataInfrastructureConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateExadataInfrastructureRequest, UpdateExadataInfrastructureResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateExadataInfrastructureRequest,
+                            UpdateExadataInfrastructureResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateExadataInfrastructureDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateExadataInfrastructureDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateExadataIormConfigResponse> updateExadataIormConfig(
             final UpdateExadataIormConfigRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -7423,6 +9594,262 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateVmClusterResponse> updateVmCluster(
+            final UpdateVmClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVmClusterRequest, UpdateVmClusterResponse>
+                    handler) {
+        LOG.trace("Called async updateVmCluster");
+        final UpdateVmClusterRequest interceptedRequest =
+                UpdateVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVmClusterResponse>
+                transformer = UpdateVmClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateVmClusterRequest, UpdateVmClusterResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateVmClusterRequest, UpdateVmClusterResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVmClusterDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateVmClusterDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateVmClusterResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVmClusterDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateVmClusterNetworkResponse> updateVmClusterNetwork(
+            final UpdateVmClusterNetworkRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVmClusterNetworkRequest, UpdateVmClusterNetworkResponse>
+                    handler) {
+        LOG.trace("Called async updateVmClusterNetwork");
+        final UpdateVmClusterNetworkRequest interceptedRequest =
+                UpdateVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>
+                transformer = UpdateVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateVmClusterNetworkRequest, UpdateVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateVmClusterNetworkRequest, UpdateVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVmClusterNetworkDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateVmClusterNetworkDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVmClusterNetworkDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ValidateVmClusterNetworkResponse> validateVmClusterNetwork(
+            final ValidateVmClusterNetworkRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ValidateVmClusterNetworkRequest, ValidateVmClusterNetworkResponse>
+                    handler) {
+        LOG.trace("Called async validateVmClusterNetwork");
+        final ValidateVmClusterNetworkRequest interceptedRequest =
+                ValidateVmClusterNetworkConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ValidateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>
+                transformer = ValidateVmClusterNetworkConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ValidateVmClusterNetworkRequest, ValidateVmClusterNetworkResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ValidateVmClusterNetworkRequest, ValidateVmClusterNetworkResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
                         }
                     });
         } else {

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -380,6 +380,41 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ActivateExadataInfrastructureResponse activateExadataInfrastructure(
+            ActivateExadataInfrastructureRequest request) {
+        LOG.trace("Called activateExadataInfrastructure");
+        final ActivateExadataInfrastructureRequest interceptedRequest =
+                ActivateExadataInfrastructureConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ActivateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ActivateExadataInfrastructureResponse>
+                transformer = ActivateExadataInfrastructureConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getActivateExadataInfrastructureDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeAutonomousContainerDatabaseCompartmentResponse
             changeAutonomousContainerDatabaseCompartment(
                     ChangeAutonomousContainerDatabaseCompartmentRequest request) {
@@ -490,6 +525,40 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ChangeBackupDestinationCompartmentResponse changeBackupDestinationCompartment(
+            ChangeBackupDestinationCompartmentRequest request) {
+        LOG.trace("Called changeBackupDestinationCompartment");
+        final ChangeBackupDestinationCompartmentRequest interceptedRequest =
+                ChangeBackupDestinationCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBackupDestinationCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeBackupDestinationCompartmentResponse>
+                transformer = ChangeBackupDestinationCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeDbSystemCompartmentResponse changeDbSystemCompartment(
             ChangeDbSystemCompartmentRequest request) {
         LOG.trace("Called changeDbSystemCompartment");
@@ -517,6 +586,77 @@ public class DatabaseClient implements Database {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getChangeCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangeExadataInfrastructureCompartmentResponse changeExadataInfrastructureCompartment(
+            ChangeExadataInfrastructureCompartmentRequest request) {
+        LOG.trace("Called changeExadataInfrastructureCompartment");
+        final ChangeExadataInfrastructureCompartmentRequest interceptedRequest =
+                ChangeExadataInfrastructureCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeExadataInfrastructureCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeExadataInfrastructureCompartmentResponse>
+                transformer = ChangeExadataInfrastructureCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeExadataInfrastructureCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangeVmClusterCompartmentResponse changeVmClusterCompartment(
+            ChangeVmClusterCompartmentRequest request) {
+        LOG.trace("Called changeVmClusterCompartment");
+        final ChangeVmClusterCompartmentRequest interceptedRequest =
+                ChangeVmClusterCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeVmClusterCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>
+                transformer = ChangeVmClusterCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeVmClusterCompartmentDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -765,6 +905,39 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public CreateBackupDestinationResponse createBackupDestination(
+            CreateBackupDestinationRequest request) {
+        LOG.trace("Called createBackupDestination");
+        final CreateBackupDestinationRequest interceptedRequest =
+                CreateBackupDestinationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateBackupDestinationResponse>
+                transformer = CreateBackupDestinationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateBackupDestinationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateDataGuardAssociationResponse createDataGuardAssociation(
             CreateDataGuardAssociationRequest request) {
         LOG.trace("Called createDataGuardAssociation");
@@ -833,6 +1006,41 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public CreateExadataInfrastructureResponse createExadataInfrastructure(
+            CreateExadataInfrastructureRequest request) {
+        LOG.trace("Called createExadataInfrastructure");
+        final CreateExadataInfrastructureRequest interceptedRequest =
+                CreateExadataInfrastructureConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>
+                transformer = CreateExadataInfrastructureConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getCreateExadataInfrastructureDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateExternalBackupJobResponse createExternalBackupJob(
             CreateExternalBackupJobRequest request) {
         LOG.trace("Called createExternalBackupJob");
@@ -859,6 +1067,71 @@ public class DatabaseClient implements Database {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getCreateExternalBackupJobDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateVmClusterResponse createVmCluster(CreateVmClusterRequest request) {
+        LOG.trace("Called createVmCluster");
+        final CreateVmClusterRequest interceptedRequest =
+                CreateVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateVmClusterResponse>
+                transformer = CreateVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateVmClusterDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateVmClusterNetworkResponse createVmClusterNetwork(
+            CreateVmClusterNetworkRequest request) {
+        LOG.trace("Called createVmClusterNetwork");
+        final CreateVmClusterNetworkRequest interceptedRequest =
+                CreateVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>
+                transformer = CreateVmClusterNetworkConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getVmClusterNetworkDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -985,6 +1258,36 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public DeleteBackupDestinationResponse deleteBackupDestination(
+            DeleteBackupDestinationRequest request) {
+        LOG.trace("Called deleteBackupDestination");
+        final DeleteBackupDestinationRequest interceptedRequest =
+                DeleteBackupDestinationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBackupDestinationResponse>
+                transformer = DeleteBackupDestinationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteDbHomeResponse deleteDbHome(DeleteDbHomeRequest request) {
         LOG.trace("Called deleteDbHome");
         final DeleteDbHomeRequest interceptedRequest =
@@ -1008,6 +1311,159 @@ public class DatabaseClient implements Database {
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
                                         client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteExadataInfrastructureResponse deleteExadataInfrastructure(
+            DeleteExadataInfrastructureRequest request) {
+        LOG.trace("Called deleteExadataInfrastructure");
+        final DeleteExadataInfrastructureRequest interceptedRequest =
+                DeleteExadataInfrastructureConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>
+                transformer = DeleteExadataInfrastructureConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteVmClusterResponse deleteVmCluster(DeleteVmClusterRequest request) {
+        LOG.trace("Called deleteVmCluster");
+        final DeleteVmClusterRequest interceptedRequest =
+                DeleteVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVmClusterResponse>
+                transformer = DeleteVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteVmClusterNetworkResponse deleteVmClusterNetwork(
+            DeleteVmClusterNetworkRequest request) {
+        LOG.trace("Called deleteVmClusterNetwork");
+        final DeleteVmClusterNetworkRequest interceptedRequest =
+                DeleteVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>
+                transformer = DeleteVmClusterNetworkConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DownloadExadataInfrastructureConfigFileResponse downloadExadataInfrastructureConfigFile(
+            DownloadExadataInfrastructureConfigFileRequest request) {
+        LOG.trace("Called downloadExadataInfrastructureConfigFile");
+        final DownloadExadataInfrastructureConfigFileRequest interceptedRequest =
+                DownloadExadataInfrastructureConfigFileConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DownloadExadataInfrastructureConfigFileConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadExadataInfrastructureConfigFileResponse>
+                transformer = DownloadExadataInfrastructureConfigFileConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DownloadVmClusterNetworkConfigFileResponse downloadVmClusterNetworkConfigFile(
+            DownloadVmClusterNetworkConfigFileRequest request) {
+        LOG.trace("Called downloadVmClusterNetworkConfigFile");
+        final DownloadVmClusterNetworkConfigFileRequest interceptedRequest =
+                DownloadVmClusterNetworkConfigFileConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DownloadVmClusterNetworkConfigFileConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadVmClusterNetworkConfigFileResponse>
+                transformer = DownloadVmClusterNetworkConfigFileConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -1113,6 +1569,42 @@ public class DatabaseClient implements Database {
                                                 ib,
                                                 retriedRequest
                                                         .getGenerateAutonomousDatabaseWalletDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GenerateRecommendedVmClusterNetworkResponse generateRecommendedVmClusterNetwork(
+            GenerateRecommendedVmClusterNetworkRequest request) {
+        LOG.trace("Called generateRecommendedVmClusterNetwork");
+        final GenerateRecommendedVmClusterNetworkRequest interceptedRequest =
+                GenerateRecommendedVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateRecommendedVmClusterNetworkConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateRecommendedVmClusterNetworkResponse>
+                transformer = GenerateRecommendedVmClusterNetworkConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getGenerateRecommendedNetworkDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -1306,6 +1798,34 @@ public class DatabaseClient implements Database {
                 GetBackupConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetBackupResponse> transformer =
                 GetBackupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetBackupDestinationResponse getBackupDestination(GetBackupDestinationRequest request) {
+        LOG.trace("Called getBackupDestination");
+        final GetBackupDestinationRequest interceptedRequest =
+                GetBackupDestinationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBackupDestinationResponse>
+                transformer = GetBackupDestinationConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1581,6 +2101,35 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public GetExadataInfrastructureResponse getExadataInfrastructure(
+            GetExadataInfrastructureRequest request) {
+        LOG.trace("Called getExadataInfrastructure");
+        final GetExadataInfrastructureRequest interceptedRequest =
+                GetExadataInfrastructureConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetExadataInfrastructureResponse>
+                transformer = GetExadataInfrastructureConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetExadataIormConfigResponse getExadataIormConfig(GetExadataIormConfigRequest request) {
         LOG.trace("Called getExadataIormConfig");
         final GetExadataIormConfigRequest interceptedRequest =
@@ -1645,6 +2194,62 @@ public class DatabaseClient implements Database {
                 GetMaintenanceRunConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetMaintenanceRunResponse>
                 transformer = GetMaintenanceRunConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetVmClusterResponse getVmCluster(GetVmClusterRequest request) {
+        LOG.trace("Called getVmCluster");
+        final GetVmClusterRequest interceptedRequest =
+                GetVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterResponse>
+                transformer = GetVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetVmClusterNetworkResponse getVmClusterNetwork(GetVmClusterNetworkRequest request) {
+        LOG.trace("Called getVmClusterNetwork");
+        final GetVmClusterNetworkRequest interceptedRequest =
+                GetVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterNetworkResponse>
+                transformer = GetVmClusterNetworkConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1956,6 +2561,35 @@ public class DatabaseClient implements Database {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, ListAutonomousExadataInfrastructuresResponse>
                 transformer = ListAutonomousExadataInfrastructuresConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListBackupDestinationResponse listBackupDestination(
+            ListBackupDestinationRequest request) {
+        LOG.trace("Called listBackupDestination");
+        final ListBackupDestinationRequest interceptedRequest =
+                ListBackupDestinationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListBackupDestinationResponse>
+                transformer = ListBackupDestinationConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2318,6 +2952,64 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ListExadataInfrastructuresResponse listExadataInfrastructures(
+            ListExadataInfrastructuresRequest request) {
+        LOG.trace("Called listExadataInfrastructures");
+        final ListExadataInfrastructuresRequest interceptedRequest =
+                ListExadataInfrastructuresConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListExadataInfrastructuresConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>
+                transformer = ListExadataInfrastructuresConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListGiVersionsResponse listGiVersions(ListGiVersionsRequest request) {
+        LOG.trace("Called listGiVersions");
+        final ListGiVersionsRequest interceptedRequest =
+                ListGiVersionsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListGiVersionsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListGiVersionsResponse>
+                transformer = ListGiVersionsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListMaintenanceRunsResponse listMaintenanceRuns(ListMaintenanceRunsRequest request) {
         LOG.trace("Called listMaintenanceRuns");
         final ListMaintenanceRunsRequest interceptedRequest =
@@ -2326,6 +3018,63 @@ public class DatabaseClient implements Database {
                 ListMaintenanceRunsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListMaintenanceRunsResponse>
                 transformer = ListMaintenanceRunsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVmClusterNetworksResponse listVmClusterNetworks(
+            ListVmClusterNetworksRequest request) {
+        LOG.trace("Called listVmClusterNetworks");
+        final ListVmClusterNetworksRequest interceptedRequest =
+                ListVmClusterNetworksConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterNetworksConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClusterNetworksResponse>
+                transformer = ListVmClusterNetworksConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVmClustersResponse listVmClusters(ListVmClustersRequest request) {
+        LOG.trace("Called listVmClusters");
+        final ListVmClustersRequest interceptedRequest =
+                ListVmClustersConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClustersConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClustersResponse>
+                transformer = ListVmClustersConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2904,6 +3653,39 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public UpdateBackupDestinationResponse updateBackupDestination(
+            UpdateBackupDestinationRequest request) {
+        LOG.trace("Called updateBackupDestination");
+        final UpdateBackupDestinationRequest interceptedRequest =
+                UpdateBackupDestinationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBackupDestinationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBackupDestinationResponse>
+                transformer = UpdateBackupDestinationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateBackupDestinationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateDatabaseResponse updateDatabase(UpdateDatabaseRequest request) {
         LOG.trace("Called updateDatabase");
         final UpdateDatabaseRequest interceptedRequest =
@@ -3000,6 +3782,41 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public UpdateExadataInfrastructureResponse updateExadataInfrastructure(
+            UpdateExadataInfrastructureRequest request) {
+        LOG.trace("Called updateExadataInfrastructure");
+        final UpdateExadataInfrastructureRequest interceptedRequest =
+                UpdateExadataInfrastructureConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateExadataInfrastructureConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>
+                transformer = UpdateExadataInfrastructureConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateExadataInfrastructureDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateExadataIormConfigResponse updateExadataIormConfig(
             UpdateExadataIormConfigRequest request) {
         LOG.trace("Called updateExadataIormConfig");
@@ -3059,6 +3876,101 @@ public class DatabaseClient implements Database {
                                                 ib,
                                                 retriedRequest.getUpdateMaintenanceRunDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateVmClusterResponse updateVmCluster(UpdateVmClusterRequest request) {
+        LOG.trace("Called updateVmCluster");
+        final UpdateVmClusterRequest interceptedRequest =
+                UpdateVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVmClusterResponse>
+                transformer = UpdateVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateVmClusterDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateVmClusterNetworkResponse updateVmClusterNetwork(
+            UpdateVmClusterNetworkRequest request) {
+        LOG.trace("Called updateVmClusterNetwork");
+        final UpdateVmClusterNetworkRequest interceptedRequest =
+                UpdateVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>
+                transformer = UpdateVmClusterNetworkConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateVmClusterNetworkDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ValidateVmClusterNetworkResponse validateVmClusterNetwork(
+            ValidateVmClusterNetworkRequest request) {
+        LOG.trace("Called validateVmClusterNetwork");
+        final ValidateVmClusterNetworkRequest interceptedRequest =
+                ValidateVmClusterNetworkConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ValidateVmClusterNetworkConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>
+                transformer = ValidateVmClusterNetworkConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
@@ -2414,6 +2414,237 @@ public class DatabasePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listExadataInfrastructures operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListExadataInfrastructuresResponse> listExadataInfrastructuresResponseIterator(
+            final ListExadataInfrastructuresRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListExadataInfrastructuresRequest.Builder, ListExadataInfrastructuresRequest,
+                ListExadataInfrastructuresResponse>(
+                new com.google.common.base.Supplier<ListExadataInfrastructuresRequest.Builder>() {
+                    @Override
+                    public ListExadataInfrastructuresRequest.Builder get() {
+                        return ListExadataInfrastructuresRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListExadataInfrastructuresResponse, String>() {
+                    @Override
+                    public String apply(ListExadataInfrastructuresResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListExadataInfrastructuresRequest.Builder>,
+                        ListExadataInfrastructuresRequest>() {
+                    @Override
+                    public ListExadataInfrastructuresRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListExadataInfrastructuresRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExadataInfrastructuresRequest, ListExadataInfrastructuresResponse>() {
+                    @Override
+                    public ListExadataInfrastructuresResponse apply(
+                            ListExadataInfrastructuresRequest request) {
+                        return client.listExadataInfrastructures(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.ExadataInfrastructureSummary} objects
+     * contained in responses from the listExadataInfrastructures operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.ExadataInfrastructureSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.ExadataInfrastructureSummary>
+            listExadataInfrastructuresRecordIterator(
+                    final ListExadataInfrastructuresRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListExadataInfrastructuresRequest.Builder, ListExadataInfrastructuresRequest,
+                ListExadataInfrastructuresResponse,
+                com.oracle.bmc.database.model.ExadataInfrastructureSummary>(
+                new com.google.common.base.Supplier<ListExadataInfrastructuresRequest.Builder>() {
+                    @Override
+                    public ListExadataInfrastructuresRequest.Builder get() {
+                        return ListExadataInfrastructuresRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListExadataInfrastructuresResponse, String>() {
+                    @Override
+                    public String apply(ListExadataInfrastructuresResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListExadataInfrastructuresRequest.Builder>,
+                        ListExadataInfrastructuresRequest>() {
+                    @Override
+                    public ListExadataInfrastructuresRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListExadataInfrastructuresRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExadataInfrastructuresRequest, ListExadataInfrastructuresResponse>() {
+                    @Override
+                    public ListExadataInfrastructuresResponse apply(
+                            ListExadataInfrastructuresRequest request) {
+                        return client.listExadataInfrastructures(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExadataInfrastructuresResponse,
+                        java.util.List<
+                                com.oracle.bmc.database.model.ExadataInfrastructureSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.database.model.ExadataInfrastructureSummary>
+                            apply(ListExadataInfrastructuresResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listGiVersions operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListGiVersionsResponse> listGiVersionsResponseIterator(
+            final ListGiVersionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListGiVersionsRequest.Builder, ListGiVersionsRequest, ListGiVersionsResponse>(
+                new com.google.common.base.Supplier<ListGiVersionsRequest.Builder>() {
+                    @Override
+                    public ListGiVersionsRequest.Builder get() {
+                        return ListGiVersionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListGiVersionsResponse, String>() {
+                    @Override
+                    public String apply(ListGiVersionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListGiVersionsRequest.Builder>,
+                        ListGiVersionsRequest>() {
+                    @Override
+                    public ListGiVersionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListGiVersionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGiVersionsRequest, ListGiVersionsResponse>() {
+                    @Override
+                    public ListGiVersionsResponse apply(ListGiVersionsRequest request) {
+                        return client.listGiVersions(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.GiVersionSummary} objects
+     * contained in responses from the listGiVersions operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.GiVersionSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.GiVersionSummary> listGiVersionsRecordIterator(
+            final ListGiVersionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListGiVersionsRequest.Builder, ListGiVersionsRequest, ListGiVersionsResponse,
+                com.oracle.bmc.database.model.GiVersionSummary>(
+                new com.google.common.base.Supplier<ListGiVersionsRequest.Builder>() {
+                    @Override
+                    public ListGiVersionsRequest.Builder get() {
+                        return ListGiVersionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListGiVersionsResponse, String>() {
+                    @Override
+                    public String apply(ListGiVersionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListGiVersionsRequest.Builder>,
+                        ListGiVersionsRequest>() {
+                    @Override
+                    public ListGiVersionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListGiVersionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGiVersionsRequest, ListGiVersionsResponse>() {
+                    @Override
+                    public ListGiVersionsResponse apply(ListGiVersionsRequest request) {
+                        return client.listGiVersions(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGiVersionsResponse,
+                        java.util.List<com.oracle.bmc.database.model.GiVersionSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.GiVersionSummary> apply(
+                            ListGiVersionsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listMaintenanceRuns operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -2521,6 +2752,234 @@ public class DatabasePaginators {
                     @Override
                     public java.util.List<com.oracle.bmc.database.model.MaintenanceRunSummary>
                             apply(ListMaintenanceRunsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listVmClusterNetworks operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVmClusterNetworksResponse> listVmClusterNetworksResponseIterator(
+            final ListVmClusterNetworksRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVmClusterNetworksRequest.Builder, ListVmClusterNetworksRequest,
+                ListVmClusterNetworksResponse>(
+                new com.google.common.base.Supplier<ListVmClusterNetworksRequest.Builder>() {
+                    @Override
+                    public ListVmClusterNetworksRequest.Builder get() {
+                        return ListVmClusterNetworksRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClusterNetworksResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterNetworksResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterNetworksRequest.Builder>,
+                        ListVmClusterNetworksRequest>() {
+                    @Override
+                    public ListVmClusterNetworksRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterNetworksRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>() {
+                    @Override
+                    public ListVmClusterNetworksResponse apply(
+                            ListVmClusterNetworksRequest request) {
+                        return client.listVmClusterNetworks(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.VmClusterNetworkSummary} objects
+     * contained in responses from the listVmClusterNetworks operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.VmClusterNetworkSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.VmClusterNetworkSummary>
+            listVmClusterNetworksRecordIterator(final ListVmClusterNetworksRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVmClusterNetworksRequest.Builder, ListVmClusterNetworksRequest,
+                ListVmClusterNetworksResponse,
+                com.oracle.bmc.database.model.VmClusterNetworkSummary>(
+                new com.google.common.base.Supplier<ListVmClusterNetworksRequest.Builder>() {
+                    @Override
+                    public ListVmClusterNetworksRequest.Builder get() {
+                        return ListVmClusterNetworksRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClusterNetworksResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterNetworksResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterNetworksRequest.Builder>,
+                        ListVmClusterNetworksRequest>() {
+                    @Override
+                    public ListVmClusterNetworksRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterNetworksRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterNetworksRequest, ListVmClusterNetworksResponse>() {
+                    @Override
+                    public ListVmClusterNetworksResponse apply(
+                            ListVmClusterNetworksRequest request) {
+                        return client.listVmClusterNetworks(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterNetworksResponse,
+                        java.util.List<com.oracle.bmc.database.model.VmClusterNetworkSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.VmClusterNetworkSummary>
+                            apply(ListVmClusterNetworksResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listVmClusters operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVmClustersResponse> listVmClustersResponseIterator(
+            final ListVmClustersRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVmClustersRequest.Builder, ListVmClustersRequest, ListVmClustersResponse>(
+                new com.google.common.base.Supplier<ListVmClustersRequest.Builder>() {
+                    @Override
+                    public ListVmClustersRequest.Builder get() {
+                        return ListVmClustersRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClustersResponse, String>() {
+                    @Override
+                    public String apply(ListVmClustersResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClustersRequest.Builder>,
+                        ListVmClustersRequest>() {
+                    @Override
+                    public ListVmClustersRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClustersRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClustersRequest, ListVmClustersResponse>() {
+                    @Override
+                    public ListVmClustersResponse apply(ListVmClustersRequest request) {
+                        return client.listVmClusters(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.VmClusterSummary} objects
+     * contained in responses from the listVmClusters operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.VmClusterSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.VmClusterSummary> listVmClustersRecordIterator(
+            final ListVmClustersRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVmClustersRequest.Builder, ListVmClustersRequest, ListVmClustersResponse,
+                com.oracle.bmc.database.model.VmClusterSummary>(
+                new com.google.common.base.Supplier<ListVmClustersRequest.Builder>() {
+                    @Override
+                    public ListVmClustersRequest.Builder get() {
+                        return ListVmClustersRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClustersResponse, String>() {
+                    @Override
+                    public String apply(ListVmClustersResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClustersRequest.Builder>,
+                        ListVmClustersRequest>() {
+                    @Override
+                    public ListVmClustersRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClustersRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClustersRequest, ListVmClustersResponse>() {
+                    @Override
+                    public ListVmClustersResponse apply(ListVmClustersRequest request) {
+                        return client.listVmClusters(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClustersResponse,
+                        java.util.List<com.oracle.bmc.database.model.VmClusterSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.VmClusterSummary> apply(
+                            ListVmClustersResponse response) {
                         return response.getItems();
                     }
                 });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -231,6 +231,68 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    ChangeBackupDestinationCompartmentRequest,
+                    ChangeBackupDestinationCompartmentResponse>
+            forChangeBackupDestinationCompartment(
+                    ChangeBackupDestinationCompartmentRequest request) {
+        return forChangeBackupDestinationCompartment(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ChangeBackupDestinationCompartmentRequest,
+                    ChangeBackupDestinationCompartmentResponse>
+            forChangeBackupDestinationCompartment(
+                    ChangeBackupDestinationCompartmentRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<ChangeBackupDestinationCompartmentResponse>() {
+                    @Override
+                    public ChangeBackupDestinationCompartmentResponse call() throws Exception {
+                        final ChangeBackupDestinationCompartmentResponse response =
+                                client.changeBackupDestinationCompartment(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     ChangeDbSystemCompartmentRequest, ChangeDbSystemCompartmentResponse>
             forChangeDbSystemCompartment(ChangeDbSystemCompartmentRequest request) {
         return forChangeDbSystemCompartment(
@@ -265,6 +327,128 @@ public class DatabaseWaiters {
                     public ChangeDbSystemCompartmentResponse call() throws Exception {
                         final ChangeDbSystemCompartmentResponse response =
                                 client.changeDbSystemCompartment(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ChangeExadataInfrastructureCompartmentRequest,
+                    ChangeExadataInfrastructureCompartmentResponse>
+            forChangeExadataInfrastructureCompartment(
+                    ChangeExadataInfrastructureCompartmentRequest request) {
+        return forChangeExadataInfrastructureCompartment(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ChangeExadataInfrastructureCompartmentRequest,
+                    ChangeExadataInfrastructureCompartmentResponse>
+            forChangeExadataInfrastructureCompartment(
+                    ChangeExadataInfrastructureCompartmentRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        ChangeExadataInfrastructureCompartmentResponse>() {
+                    @Override
+                    public ChangeExadataInfrastructureCompartmentResponse call() throws Exception {
+                        final ChangeExadataInfrastructureCompartmentResponse response =
+                                client.changeExadataInfrastructureCompartment(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ChangeVmClusterCompartmentRequest, ChangeVmClusterCompartmentResponse>
+            forChangeVmClusterCompartment(ChangeVmClusterCompartmentRequest request) {
+        return forChangeVmClusterCompartment(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ChangeVmClusterCompartmentRequest, ChangeVmClusterCompartmentResponse>
+            forChangeVmClusterCompartment(
+                    ChangeVmClusterCompartmentRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<ChangeVmClusterCompartmentResponse>() {
+                    @Override
+                    public ChangeVmClusterCompartmentResponse call() throws Exception {
+                        final ChangeVmClusterCompartmentResponse response =
+                                client.changeVmClusterCompartment(request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =
@@ -1315,6 +1499,112 @@ public class DatabaseWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetBackupDestinationRequest, GetBackupDestinationResponse>
+            forBackupDestination(
+                    GetBackupDestinationRequest request,
+                    com.oracle.bmc.database.model.BackupDestination.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forBackupDestination(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBackupDestinationRequest, GetBackupDestinationResponse>
+            forBackupDestination(
+                    GetBackupDestinationRequest request,
+                    com.oracle.bmc.database.model.BackupDestination.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forBackupDestination(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBackupDestinationRequest, GetBackupDestinationResponse>
+            forBackupDestination(
+                    GetBackupDestinationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.BackupDestination.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forBackupDestination(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for BackupDestination.
+    private com.oracle.bmc.waiter.Waiter<GetBackupDestinationRequest, GetBackupDestinationResponse>
+            forBackupDestination(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetBackupDestinationRequest request,
+                    final com.oracle.bmc.database.model.BackupDestination.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.BackupDestination.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetBackupDestinationRequest, GetBackupDestinationResponse>() {
+                            @Override
+                            public GetBackupDestinationResponse apply(
+                                    GetBackupDestinationRequest request) {
+                                return client.getBackupDestination(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetBackupDestinationResponse>() {
+                            @Override
+                            public boolean apply(GetBackupDestinationResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getBackupDestination().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.BackupDestination.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<
                     GetDataGuardAssociationRequest, GetDataGuardAssociationResponse>
             forDataGuardAssociation(
@@ -1811,6 +2101,117 @@ public class DatabaseWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+            forExadataInfrastructure(
+                    GetExadataInfrastructureRequest request,
+                    com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forExadataInfrastructure(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+            forExadataInfrastructure(
+                    GetExadataInfrastructureRequest request,
+                    com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forExadataInfrastructure(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+            forExadataInfrastructure(
+                    GetExadataInfrastructureRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forExadataInfrastructure(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for ExadataInfrastructure.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetExadataInfrastructureRequest, GetExadataInfrastructureResponse>
+            forExadataInfrastructure(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetExadataInfrastructureRequest request,
+                    final com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetExadataInfrastructureRequest,
+                                GetExadataInfrastructureResponse>() {
+                            @Override
+                            public GetExadataInfrastructureResponse apply(
+                                    GetExadataInfrastructureRequest request) {
+                                return client.getExadataInfrastructure(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetExadataInfrastructureResponse>() {
+                            @Override
+                            public boolean apply(GetExadataInfrastructureResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getExadataInfrastructure().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.ExadataInfrastructure.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetExadataIormConfigRequest, GetExadataIormConfigResponse>
             forExadataIormConfig(
                     GetExadataIormConfigRequest request,
@@ -2007,6 +2408,207 @@ public class DatabaseWaiters {
                             }
                         },
                         false),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterRequest, GetVmClusterResponse> forVmCluster(
+            GetVmClusterRequest request,
+            com.oracle.bmc.database.model.VmCluster.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forVmCluster(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterRequest, GetVmClusterResponse> forVmCluster(
+            GetVmClusterRequest request,
+            com.oracle.bmc.database.model.VmCluster.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forVmCluster(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterRequest, GetVmClusterResponse> forVmCluster(
+            GetVmClusterRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.database.model.VmCluster.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forVmCluster(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for VmCluster.
+    private com.oracle.bmc.waiter.Waiter<GetVmClusterRequest, GetVmClusterResponse> forVmCluster(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetVmClusterRequest request,
+            final com.oracle.bmc.database.model.VmCluster.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.VmCluster.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetVmClusterRequest, GetVmClusterResponse>() {
+                            @Override
+                            public GetVmClusterResponse apply(GetVmClusterRequest request) {
+                                return client.getVmCluster(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetVmClusterResponse>() {
+                            @Override
+                            public boolean apply(GetVmClusterResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getVmCluster().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.VmCluster.LifecycleState.Terminated)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+            forVmClusterNetwork(
+                    GetVmClusterNetworkRequest request,
+                    com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forVmClusterNetwork(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+            forVmClusterNetwork(
+                    GetVmClusterNetworkRequest request,
+                    com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forVmClusterNetwork(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+            forVmClusterNetwork(
+                    GetVmClusterNetworkRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forVmClusterNetwork(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for VmClusterNetwork.
+    private com.oracle.bmc.waiter.Waiter<GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>
+            forVmClusterNetwork(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetVmClusterNetworkRequest request,
+                    final com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetVmClusterNetworkRequest, GetVmClusterNetworkResponse>() {
+                            @Override
+                            public GetVmClusterNetworkResponse apply(
+                                    GetVmClusterNetworkRequest request) {
+                                return client.getVmClusterNetwork(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetVmClusterNetworkResponse>() {
+                            @Override
+                            public boolean apply(GetVmClusterNetworkResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getVmClusterNetwork().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.VmClusterNetwork.LifecycleState
+                                        .Terminated)),
                 request);
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ActivateExadataInfrastructureConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ActivateExadataInfrastructureConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ActivateExadataInfrastructureConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ActivateExadataInfrastructureRequest interceptRequest(
+            ActivateExadataInfrastructureRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ActivateExadataInfrastructureRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notNull(
+                request.getActivateExadataInfrastructureDetails(),
+                "activateExadataInfrastructureDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("actions")
+                        .path("activate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ActivateExadataInfrastructureResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ActivateExadataInfrastructureResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ActivateExadataInfrastructureResponse>() {
+                            @Override
+                            public ActivateExadataInfrastructureResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ActivateExadataInfrastructureResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ExadataInfrastructure>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ExadataInfrastructure.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ExadataInfrastructure>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ActivateExadataInfrastructureResponse.Builder builder =
+                                        ActivateExadataInfrastructureResponse.builder();
+
+                                builder.exadataInfrastructure(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ActivateExadataInfrastructureResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeBackupDestinationCompartmentConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeBackupDestinationCompartmentConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeBackupDestinationCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeBackupDestinationCompartmentRequest interceptRequest(
+            ChangeBackupDestinationCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeBackupDestinationCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getChangeCompartmentDetails(), "changeCompartmentDetails is required");
+        Validate.notBlank(
+                request.getBackupDestinationId(), "backupDestinationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("backupDestinations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBackupDestinationId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeBackupDestinationCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeBackupDestinationCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ChangeBackupDestinationCompartmentResponse>() {
+                            @Override
+                            public ChangeBackupDestinationCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeBackupDestinationCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeBackupDestinationCompartmentResponse.Builder builder =
+                                        ChangeBackupDestinationCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeBackupDestinationCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeExadataInfrastructureCompartmentConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeExadataInfrastructureCompartmentConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeExadataInfrastructureCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeExadataInfrastructureCompartmentRequest interceptRequest(
+            ChangeExadataInfrastructureCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeExadataInfrastructureCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getChangeExadataInfrastructureCompartmentDetails(),
+                "changeExadataInfrastructureCompartmentDetails is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeExadataInfrastructureCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeExadataInfrastructureCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ChangeExadataInfrastructureCompartmentResponse>() {
+                            @Override
+                            public ChangeExadataInfrastructureCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeExadataInfrastructureCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeExadataInfrastructureCompartmentResponse.Builder builder =
+                                        ChangeExadataInfrastructureCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeExadataInfrastructureCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeVmClusterCompartmentConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ChangeVmClusterCompartmentConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeVmClusterCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ChangeVmClusterCompartmentRequest interceptRequest(
+            ChangeVmClusterCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ChangeVmClusterCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getChangeVmClusterCompartmentDetails(),
+                "changeVmClusterCompartmentDetails is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ChangeVmClusterCompartmentResponse>() {
+                            @Override
+                            public ChangeVmClusterCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ChangeVmClusterCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ChangeVmClusterCompartmentResponse.Builder builder =
+                                        ChangeVmClusterCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ChangeVmClusterCompartmentResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateBackupDestinationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateBackupDestinationConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateBackupDestinationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateBackupDestinationRequest interceptRequest(
+            CreateBackupDestinationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateBackupDestinationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateBackupDestinationDetails(),
+                "createBackupDestinationDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("backupDestinations");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateBackupDestinationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateBackupDestinationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateBackupDestinationResponse>() {
+                            @Override
+                            public CreateBackupDestinationResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateBackupDestinationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BackupDestination>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BackupDestination.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BackupDestination>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateBackupDestinationResponse.Builder builder =
+                                        CreateBackupDestinationResponse.builder();
+
+                                builder.backupDestination(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateBackupDestinationResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateExadataInfrastructureConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateExadataInfrastructureConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateExadataInfrastructureConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateExadataInfrastructureRequest interceptRequest(
+            CreateExadataInfrastructureRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateExadataInfrastructureRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateExadataInfrastructureDetails(),
+                "createExadataInfrastructureDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("exadataInfrastructures");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateExadataInfrastructureResponse>() {
+                            @Override
+                            public CreateExadataInfrastructureResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateExadataInfrastructureResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ExadataInfrastructure>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ExadataInfrastructure.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ExadataInfrastructure>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateExadataInfrastructureResponse.Builder builder =
+                                        CreateExadataInfrastructureResponse.builder();
+
+                                builder.exadataInfrastructure(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateExadataInfrastructureResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateVmClusterConverter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateVmClusterRequest interceptRequest(CreateVmClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, CreateVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateVmClusterDetails(), "createVmClusterDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("vmClusters");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateVmClusterResponse>() {
+                            @Override
+                            public CreateVmClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for CreateVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<VmCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(VmCluster.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmCluster> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateVmClusterResponse.Builder builder =
+                                        CreateVmClusterResponse.builder();
+
+                                builder.vmCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateVmClusterResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/CreateVmClusterNetworkConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateVmClusterNetworkRequest interceptRequest(
+            CreateVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, CreateVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notNull(
+                request.getVmClusterNetworkDetails(), "vmClusterNetworkDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateVmClusterNetworkResponse>() {
+                            @Override
+                            public CreateVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VmClusterNetwork>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VmClusterNetwork.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmClusterNetwork>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateVmClusterNetworkResponse.Builder builder =
+                                        CreateVmClusterNetworkResponse.builder();
+
+                                builder.vmClusterNetwork(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateVmClusterNetworkResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteBackupDestinationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteBackupDestinationConverter.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteBackupDestinationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteBackupDestinationRequest interceptRequest(
+            DeleteBackupDestinationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DeleteBackupDestinationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getBackupDestinationId(), "backupDestinationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("backupDestinations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBackupDestinationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteBackupDestinationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteBackupDestinationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteBackupDestinationResponse>() {
+                            @Override
+                            public DeleteBackupDestinationResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteBackupDestinationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteBackupDestinationResponse.Builder builder =
+                                        DeleteBackupDestinationResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteBackupDestinationResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteExadataInfrastructureConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteExadataInfrastructureConverter.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteExadataInfrastructureConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteExadataInfrastructureRequest interceptRequest(
+            DeleteExadataInfrastructureRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DeleteExadataInfrastructureRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteExadataInfrastructureResponse>() {
+                            @Override
+                            public DeleteExadataInfrastructureResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteExadataInfrastructureResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteExadataInfrastructureResponse.Builder builder =
+                                        DeleteExadataInfrastructureResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteExadataInfrastructureResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteVmClusterConverter.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteVmClusterRequest interceptRequest(DeleteVmClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteVmClusterResponse>() {
+                            @Override
+                            public DeleteVmClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for DeleteVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteVmClusterResponse.Builder builder =
+                                        DeleteVmClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteVmClusterResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DeleteVmClusterNetworkConverter.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteVmClusterNetworkRequest interceptRequest(
+            DeleteVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, DeleteVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notBlank(request.getVmClusterNetworkId(), "vmClusterNetworkId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterNetworkId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteVmClusterNetworkResponse>() {
+                            @Override
+                            public DeleteVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteVmClusterNetworkResponse.Builder builder =
+                                        DeleteVmClusterNetworkResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteVmClusterNetworkResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DownloadExadataInfrastructureConfigFileConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DownloadExadataInfrastructureConfigFileConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DownloadExadataInfrastructureConfigFileConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DownloadExadataInfrastructureConfigFileRequest interceptRequest(
+            DownloadExadataInfrastructureConfigFileRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DownloadExadataInfrastructureConfigFileRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("actions")
+                        .path("downloadConfigFile");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept("application/octet-stream");
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DownloadExadataInfrastructureConfigFileResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadExadataInfrastructureConfigFileResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                DownloadExadataInfrastructureConfigFileResponse>() {
+                            @Override
+                            public DownloadExadataInfrastructureConfigFileResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DownloadExadataInfrastructureConfigFileResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DownloadExadataInfrastructureConfigFileResponse.Builder builder =
+                                        DownloadExadataInfrastructureConfigFileResponse.builder();
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLengthHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-length");
+                                if (contentLengthHeader.isPresent()) {
+                                    builder.contentLength(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-length",
+                                                    contentLengthHeader.get().get(0),
+                                                    Long.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        lastModifiedHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "last-modified");
+                                if (lastModifiedHeader.isPresent()) {
+                                    builder.lastModified(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "last-modified",
+                                                    lastModifiedHeader.get().get(0),
+                                                    java.util.Date.class));
+                                }
+
+                                DownloadExadataInfrastructureConfigFileResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DownloadVmClusterNetworkConfigFileConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DownloadVmClusterNetworkConfigFileConverter.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DownloadVmClusterNetworkConfigFileConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DownloadVmClusterNetworkConfigFileRequest interceptRequest(
+            DownloadVmClusterNetworkConfigFileRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DownloadVmClusterNetworkConfigFileRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notBlank(request.getVmClusterNetworkId(), "vmClusterNetworkId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterNetworkId()))
+                        .path("actions")
+                        .path("downloadConfigFile");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept("application/octet-stream");
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DownloadVmClusterNetworkConfigFileResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DownloadVmClusterNetworkConfigFileResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                DownloadVmClusterNetworkConfigFileResponse>() {
+                            @Override
+                            public DownloadVmClusterNetworkConfigFileResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DownloadVmClusterNetworkConfigFileResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DownloadVmClusterNetworkConfigFileResponse.Builder builder =
+                                        DownloadVmClusterNetworkConfigFileResponse.builder();
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLengthHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-length");
+                                if (contentLengthHeader.isPresent()) {
+                                    builder.contentLength(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-length",
+                                                    contentLengthHeader.get().get(0),
+                                                    Long.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        lastModifiedHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "last-modified");
+                                if (lastModifiedHeader.isPresent()) {
+                                    builder.lastModified(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "last-modified",
+                                                    lastModifiedHeader.get().get(0),
+                                                    java.util.Date.class));
+                                }
+
+                                DownloadVmClusterNetworkConfigFileResponse responseWrapper =
+                                        builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GenerateRecommendedVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GenerateRecommendedVmClusterNetworkConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GenerateRecommendedVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GenerateRecommendedVmClusterNetworkRequest interceptRequest(
+            GenerateRecommendedVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GenerateRecommendedVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notNull(
+                request.getGenerateRecommendedNetworkDetails(),
+                "generateRecommendedNetworkDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path("actions")
+                        .path("generateRecommendedNetwork");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GenerateRecommendedVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateRecommendedVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                GenerateRecommendedVmClusterNetworkResponse>() {
+                            @Override
+                            public GenerateRecommendedVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GenerateRecommendedVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VmClusterNetworkDetails>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VmClusterNetworkDetails.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmClusterNetworkDetails>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GenerateRecommendedVmClusterNetworkResponse.Builder builder =
+                                        GenerateRecommendedVmClusterNetworkResponse.builder();
+
+                                builder.vmClusterNetworkDetails(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GenerateRecommendedVmClusterNetworkResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetBackupDestinationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetBackupDestinationConverter.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetBackupDestinationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetBackupDestinationRequest interceptRequest(
+            GetBackupDestinationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetBackupDestinationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getBackupDestinationId(), "backupDestinationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("backupDestinations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBackupDestinationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetBackupDestinationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetBackupDestinationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetBackupDestinationResponse>() {
+                            @Override
+                            public GetBackupDestinationResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetBackupDestinationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BackupDestination>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BackupDestination.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BackupDestination>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetBackupDestinationResponse.Builder builder =
+                                        GetBackupDestinationResponse.builder();
+
+                                builder.backupDestination(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetBackupDestinationResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetExadataInfrastructureConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetExadataInfrastructureConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetExadataInfrastructureConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetExadataInfrastructureRequest interceptRequest(
+            GetExadataInfrastructureRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            GetExadataInfrastructureRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetExadataInfrastructureResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetExadataInfrastructureResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetExadataInfrastructureResponse>() {
+                            @Override
+                            public GetExadataInfrastructureResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetExadataInfrastructureResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ExadataInfrastructure>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ExadataInfrastructure.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ExadataInfrastructure>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetExadataInfrastructureResponse.Builder builder =
+                                        GetExadataInfrastructureResponse.builder();
+
+                                builder.exadataInfrastructure(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetExadataInfrastructureResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterConverter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetVmClusterRequest interceptRequest(GetVmClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetVmClusterResponse>() {
+                            @Override
+                            public GetVmClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for GetVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<VmCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(VmCluster.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmCluster> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetVmClusterResponse.Builder builder =
+                                        GetVmClusterResponse.builder();
+
+                                builder.vmCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetVmClusterResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterNetworkConverter.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static GetVmClusterNetworkRequest interceptRequest(GetVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, GetVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notBlank(request.getVmClusterNetworkId(), "vmClusterNetworkId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterNetworkId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, GetVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, GetVmClusterNetworkResponse>() {
+                            @Override
+                            public GetVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for GetVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VmClusterNetwork>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VmClusterNetwork.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmClusterNetwork>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                GetVmClusterNetworkResponse.Builder builder =
+                                        GetVmClusterNetworkResponse.builder();
+
+                                builder.vmClusterNetwork(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                GetVmClusterNetworkResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListBackupDestinationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListBackupDestinationConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListBackupDestinationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListBackupDestinationRequest interceptRequest(
+            ListBackupDestinationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListBackupDestinationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("backupDestinations");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getType() != null) {
+            target =
+                    target.queryParam(
+                            "type",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getType()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListBackupDestinationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBackupDestinationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListBackupDestinationResponse>() {
+                            @Override
+                            public ListBackupDestinationResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListBackupDestinationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<BackupDestinationSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        BackupDestinationSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<BackupDestinationSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListBackupDestinationResponse.Builder builder =
+                                        ListBackupDestinationResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListBackupDestinationResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbHomesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbHomesConverter.java
@@ -43,6 +43,14 @@ public class ListDbHomesConverter {
                                     request.getDbSystemId()));
         }
 
+        if (request.getVmClusterId() != null) {
+            target =
+                    target.queryParam(
+                            "vmClusterId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVmClusterId()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbNodesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbNodesConverter.java
@@ -43,6 +43,14 @@ public class ListDbNodesConverter {
                                     request.getDbSystemId()));
         }
 
+        if (request.getVmClusterId() != null) {
+            target =
+                    target.queryParam(
+                            "vmClusterId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVmClusterId()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemShapesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbSystemShapesConverter.java
@@ -24,17 +24,18 @@ public class ListDbSystemShapesConverter {
     public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
             com.oracle.bmc.http.internal.RestClient client, ListDbSystemShapesRequest request) {
         Validate.notNull(request, "request instance is required");
-        Validate.notNull(request.getAvailabilityDomain(), "availabilityDomain is required");
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20160918").path("dbSystemShapes");
 
-        target =
-                target.queryParam(
-                        "availabilityDomain",
-                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                request.getAvailabilityDomain()));
+        if (request.getAvailabilityDomain() != null) {
+            target =
+                    target.queryParam(
+                            "availabilityDomain",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getAvailabilityDomain()));
+        }
 
         target =
                 target.queryParam(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListExadataInfrastructuresConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListExadataInfrastructuresConverter.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListExadataInfrastructuresConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListExadataInfrastructuresRequest interceptRequest(
+            ListExadataInfrastructuresRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ListExadataInfrastructuresRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("exadataInfrastructures");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListExadataInfrastructuresResponse>() {
+                            @Override
+                            public ListExadataInfrastructuresResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListExadataInfrastructuresResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                ExadataInfrastructureSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ExadataInfrastructureSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ExadataInfrastructureSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListExadataInfrastructuresResponse.Builder builder =
+                                        ListExadataInfrastructuresResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListExadataInfrastructuresResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListGiVersionsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListGiVersionsConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListGiVersionsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListGiVersionsRequest interceptRequest(ListGiVersionsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListGiVersionsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("giVersions");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getShape() != null) {
+            target =
+                    target.queryParam(
+                            "shape",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getShape()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<javax.ws.rs.core.Response, ListGiVersionsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListGiVersionsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListGiVersionsResponse>() {
+                            @Override
+                            public ListGiVersionsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for ListGiVersionsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<GiVersionSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        GiVersionSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<GiVersionSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListGiVersionsResponse.Builder builder =
+                                        ListGiVersionsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListGiVersionsResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterNetworksConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterNetworksConverter.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListVmClusterNetworksConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListVmClusterNetworksRequest interceptRequest(
+            ListVmClusterNetworksRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListVmClusterNetworksRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListVmClusterNetworksResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVmClusterNetworksResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListVmClusterNetworksResponse>() {
+                            @Override
+                            public ListVmClusterNetworksResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListVmClusterNetworksResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<VmClusterNetworkSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        VmClusterNetworkSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<VmClusterNetworkSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListVmClusterNetworksResponse.Builder builder =
+                                        ListVmClusterNetworksResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListVmClusterNetworksResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClustersConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClustersConverter.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListVmClustersConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListVmClustersRequest interceptRequest(ListVmClustersRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, ListVmClustersRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("vmClusters");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getExadataInfrastructureId() != null) {
+            target =
+                    target.queryParam(
+                            "exadataInfrastructureId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getExadataInfrastructureId()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClustersResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClustersResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ListVmClustersResponse>() {
+                            @Override
+                            public ListVmClustersResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for ListVmClustersResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<VmClusterSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        VmClusterSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<VmClusterSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListVmClustersResponse.Builder builder =
+                                        ListVmClustersResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListVmClustersResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateBackupDestinationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateBackupDestinationConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateBackupDestinationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateBackupDestinationRequest interceptRequest(
+            UpdateBackupDestinationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateBackupDestinationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getBackupDestinationId(), "backupDestinationId must not be blank");
+        Validate.notNull(
+                request.getUpdateBackupDestinationDetails(),
+                "updateBackupDestinationDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("backupDestinations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBackupDestinationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateBackupDestinationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateBackupDestinationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateBackupDestinationResponse>() {
+                            @Override
+                            public UpdateBackupDestinationResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateBackupDestinationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BackupDestination>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BackupDestination.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<BackupDestination>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateBackupDestinationResponse.Builder builder =
+                                        UpdateBackupDestinationResponse.builder();
+
+                                builder.backupDestination(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateBackupDestinationResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateExadataInfrastructureConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateExadataInfrastructureConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateExadataInfrastructureConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateExadataInfrastructureRequest interceptRequest(
+            UpdateExadataInfrastructureRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateExadataInfrastructureRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notNull(
+                request.getUpdateExadataInfrastructureDetails(),
+                "updateExadataInfrastructureDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateExadataInfrastructureResponse>() {
+                            @Override
+                            public UpdateExadataInfrastructureResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateExadataInfrastructureResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ExadataInfrastructure>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ExadataInfrastructure.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ExadataInfrastructure>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateExadataInfrastructureResponse.Builder builder =
+                                        UpdateExadataInfrastructureResponse.builder();
+
+                                builder.exadataInfrastructure(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateExadataInfrastructureResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateVmClusterConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateVmClusterRequest interceptRequest(UpdateVmClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+        Validate.notNull(request.getUpdateVmClusterDetails(), "updateVmClusterDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateVmClusterResponse>() {
+                            @Override
+                            public UpdateVmClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace("Transform function invoked for UpdateVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<VmCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(VmCluster.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmCluster> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateVmClusterResponse.Builder builder =
+                                        UpdateVmClusterResponse.builder();
+
+                                builder.vmCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateVmClusterResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateVmClusterNetworkConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateVmClusterNetworkRequest interceptRequest(
+            UpdateVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client, UpdateVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notBlank(request.getVmClusterNetworkId(), "vmClusterNetworkId must not be blank");
+        Validate.notNull(
+                request.getUpdateVmClusterNetworkDetails(),
+                "updateVmClusterNetworkDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterNetworkId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateVmClusterNetworkResponse>() {
+                            @Override
+                            public UpdateVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VmClusterNetwork>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VmClusterNetwork.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmClusterNetwork>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateVmClusterNetworkResponse.Builder builder =
+                                        UpdateVmClusterNetworkResponse.builder();
+
+                                builder.vmClusterNetwork(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateVmClusterNetworkResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ValidateVmClusterNetworkConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ValidateVmClusterNetworkConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ValidateVmClusterNetworkConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ValidateVmClusterNetworkRequest interceptRequest(
+            ValidateVmClusterNetworkRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ValidateVmClusterNetworkRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId must not be blank");
+        Validate.notBlank(request.getVmClusterNetworkId(), "vmClusterNetworkId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("exadataInfrastructures")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExadataInfrastructureId()))
+                        .path("vmClusterNetworks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterNetworkId()))
+                        .path("actions")
+                        .path("validate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, ValidateVmClusterNetworkResponse>() {
+                            @Override
+                            public ValidateVmClusterNetworkResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ValidateVmClusterNetworkResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VmClusterNetwork>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VmClusterNetwork.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VmClusterNetwork>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ValidateVmClusterNetworkResponse.Builder builder =
+                                        ValidateVmClusterNetworkResponse.builder();
+
+                                builder.vmClusterNetwork(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ValidateVmClusterNetworkResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ActivateExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ActivateExadataInfrastructureDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The activation details for the Exadata infrastructure.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ActivateExadataInfrastructureDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ActivateExadataInfrastructureDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("activationFile")
+        private byte[] activationFile;
+
+        public Builder activationFile(byte[] activationFile) {
+            this.activationFile = activationFile;
+            this.__explicitlySet__.add("activationFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ActivateExadataInfrastructureDetails build() {
+            ActivateExadataInfrastructureDetails __instance__ =
+                    new ActivateExadataInfrastructureDetails(activationFile);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ActivateExadataInfrastructureDetails o) {
+            Builder copiedBuilder = activationFile(o.getActivationFile());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The activation zip file.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("activationFile")
+    byte[] activationFile;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AssociatedDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AssociatedDatabaseDetails.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Databases associated with a backup destination
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AssociatedDatabaseDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AssociatedDatabaseDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+        private String dbName;
+
+        public Builder dbName(String dbName) {
+            this.dbName = dbName;
+            this.__explicitlySet__.add("dbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AssociatedDatabaseDetails build() {
+            AssociatedDatabaseDetails __instance__ = new AssociatedDatabaseDetails(id, dbName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AssociatedDatabaseDetails o) {
+            Builder copiedBuilder = id(o.getId()).dbName(o.getDbName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The display name of the database that is associated with the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+    String dbName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestination.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestination.java
@@ -1,0 +1,377 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Backup destination details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BackupDestination.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BackupDestination {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private Type type;
+
+        public Builder type(Type type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("associatedDatabases")
+        private java.util.List<AssociatedDatabaseDetails> associatedDatabases;
+
+        public Builder associatedDatabases(
+                java.util.List<AssociatedDatabaseDetails> associatedDatabases) {
+            this.associatedDatabases = associatedDatabases;
+            this.__explicitlySet__.add("associatedDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+        private String connectionString;
+
+        public Builder connectionString(String connectionString) {
+            this.connectionString = connectionString;
+            this.__explicitlySet__.add("connectionString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+        private java.util.List<String> vpcUsers;
+
+        public Builder vpcUsers(java.util.List<String> vpcUsers) {
+            this.vpcUsers = vpcUsers;
+            this.__explicitlySet__.add("vpcUsers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+        private String localMountPointPath;
+
+        public Builder localMountPointPath(String localMountPointPath) {
+            this.localMountPointPath = localMountPointPath;
+            this.__explicitlySet__.add("localMountPointPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BackupDestination build() {
+            BackupDestination __instance__ =
+                    new BackupDestination(
+                            id,
+                            displayName,
+                            compartmentId,
+                            type,
+                            associatedDatabases,
+                            connectionString,
+                            vpcUsers,
+                            localMountPointPath,
+                            lifecycleState,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BackupDestination o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .type(o.getType())
+                            .associatedDatabases(o.getAssociatedDatabases())
+                            .connectionString(o.getConnectionString())
+                            .vpcUsers(o.getVpcUsers())
+                            .localMountPointPath(o.getLocalMountPointPath())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The user-provided name of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * Type of the backup destination.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        Nfs("NFS"),
+        RecoveryAppliance("RECOVERY_APPLIANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    Type type;
+
+    /**
+     * List of databases associated with the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("associatedDatabases")
+    java.util.List<AssociatedDatabaseDetails> associatedDatabases;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+    String connectionString;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+    java.util.List<String> vpcUsers;
+
+    /**
+     * The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+    String localMountPointPath;
+    /**
+     * The current lifecycle state of the backup destination.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Failed("FAILED"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current lifecycle state of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the backup destination was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * A descriptive text associated with the lifecycleState.
+     * Typically contains additional displayable text
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestinationDetails.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Backup destination details
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BackupDestinationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BackupDestinationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private Type type;
+
+        public Builder type(Type type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcUser")
+        private String vpcUser;
+
+        public Builder vpcUser(String vpcUser) {
+            this.vpcUser = vpcUser;
+            this.__explicitlySet__.add("vpcUser");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcPassword")
+        private String vpcPassword;
+
+        public Builder vpcPassword(String vpcPassword) {
+            this.vpcPassword = vpcPassword;
+            this.__explicitlySet__.add("vpcPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BackupDestinationDetails build() {
+            BackupDestinationDetails __instance__ =
+                    new BackupDestinationDetails(
+                            type, id, vpcUser, vpcPassword, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BackupDestinationDetails o) {
+            Builder copiedBuilder =
+                    type(o.getType())
+                            .id(o.getId())
+                            .vpcUser(o.getVpcUser())
+                            .vpcPassword(o.getVpcPassword())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of the database backup destination.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        Nfs("NFS"),
+        RecoveryAppliance("RECOVERY_APPLIANCE"),
+        ObjectStore("OBJECT_STORE"),
+        Local("LOCAL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of the database backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    Type type;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) user that is used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcUser")
+    String vpcUser;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the password for the VPC user that is used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcPassword")
+    String vpcPassword;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestinationSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupDestinationSummary.java
@@ -1,0 +1,377 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Backup destination details, including the list of databases using the backup destination.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BackupDestinationSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BackupDestinationSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private Type type;
+
+        public Builder type(Type type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("associatedDatabases")
+        private java.util.List<AssociatedDatabaseDetails> associatedDatabases;
+
+        public Builder associatedDatabases(
+                java.util.List<AssociatedDatabaseDetails> associatedDatabases) {
+            this.associatedDatabases = associatedDatabases;
+            this.__explicitlySet__.add("associatedDatabases");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+        private String connectionString;
+
+        public Builder connectionString(String connectionString) {
+            this.connectionString = connectionString;
+            this.__explicitlySet__.add("connectionString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+        private java.util.List<String> vpcUsers;
+
+        public Builder vpcUsers(java.util.List<String> vpcUsers) {
+            this.vpcUsers = vpcUsers;
+            this.__explicitlySet__.add("vpcUsers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+        private String localMountPointPath;
+
+        public Builder localMountPointPath(String localMountPointPath) {
+            this.localMountPointPath = localMountPointPath;
+            this.__explicitlySet__.add("localMountPointPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BackupDestinationSummary build() {
+            BackupDestinationSummary __instance__ =
+                    new BackupDestinationSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            type,
+                            associatedDatabases,
+                            connectionString,
+                            vpcUsers,
+                            localMountPointPath,
+                            lifecycleState,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BackupDestinationSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .type(o.getType())
+                            .associatedDatabases(o.getAssociatedDatabases())
+                            .connectionString(o.getConnectionString())
+                            .vpcUsers(o.getVpcUsers())
+                            .localMountPointPath(o.getLocalMountPointPath())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The user-provided name of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * Type of the backup destination.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        Nfs("NFS"),
+        RecoveryAppliance("RECOVERY_APPLIANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    Type type;
+
+    /**
+     * List of databases associated with the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("associatedDatabases")
+    java.util.List<AssociatedDatabaseDetails> associatedDatabases;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+    String connectionString;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+    java.util.List<String> vpcUsers;
+
+    /**
+     * The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+    String localMountPointPath;
+    /**
+     * The current lifecycle state of the backup destination.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Failed("FAILED"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current lifecycle state of the backup destination.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the backup destination was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * A descriptive text associated with the lifecycleState.
+     * Typically contains additional displayable text
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ChangeExadataInfrastructureCompartmentDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ChangeExadataInfrastructureCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The configuration details for moving the resource.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeExadataInfrastructureCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeExadataInfrastructureCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeExadataInfrastructureCompartmentDetails build() {
+            ChangeExadataInfrastructureCompartmentDetails __instance__ =
+                    new ChangeExadataInfrastructureCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeExadataInfrastructureCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the resource to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ChangeVmClusterCompartmentDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ChangeVmClusterCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The configuration details for moving the VM cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeVmClusterCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChangeVmClusterCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeVmClusterCompartmentDetails build() {
+            ChangeVmClusterCompartmentDetails __instance__ =
+                    new ChangeVmClusterCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeVmClusterCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the VM cluster to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateBackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateBackupDestinationDetails.java
@@ -4,10 +4,7 @@
 package com.oracle.bmc.database.model;
 
 /**
- * Details for creating a database home.
- * <p>
- **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
- *
+ * Details for creating a backup destination.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -26,31 +23,49 @@ package com.oracle.bmc.database.model;
 @com.fasterxml.jackson.annotation.JsonTypeInfo(
     use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
     include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
-    property = "source",
-    defaultImpl = CreateDbHomeWithDbSystemIdBase.class
+    property = "type",
+    defaultImpl = CreateBackupDestinationDetails.class
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = CreateDbHomeWithDbSystemIdFromBackupDetails.class,
-        name = "DB_BACKUP"
+        value = CreateNFSBackupDestinationDetails.class,
+        name = "NFS"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = CreateDbHomeWithDbSystemIdDetails.class,
-        name = "NONE"
+        value = CreateRecoveryApplianceBackupDestinationDetails.class,
+        name = "RECOVERY_APPLIANCE"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class CreateDbHomeWithDbSystemIdBase {
+public class CreateBackupDestinationDetails {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
-    String dbSystemId;
-
-    /**
-     * The user-provided name of the database home.
+     * The user-provided name of the backup destination.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
 }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
@@ -36,6 +36,15 @@ public class CreateDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+        private String dbUniqueName;
+
+        public Builder dbUniqueName(String dbUniqueName) {
+            this.dbUniqueName = dbUniqueName;
+            this.__explicitlySet__.add("dbUniqueName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("pdbName")
         private String pdbName;
 
@@ -116,6 +125,7 @@ public class CreateDatabaseDetails {
             CreateDatabaseDetails __instance__ =
                     new CreateDatabaseDetails(
                             dbName,
+                            dbUniqueName,
                             pdbName,
                             adminPassword,
                             characterSet,
@@ -132,6 +142,7 @@ public class CreateDatabaseDetails {
         public Builder copy(CreateDatabaseDetails o) {
             Builder copiedBuilder =
                     dbName(o.getDbName())
+                            .dbUniqueName(o.getDbUniqueName())
                             .pdbName(o.getPdbName())
                             .adminPassword(o.getAdminPassword())
                             .characterSet(o.getCharacterSet())
@@ -158,6 +169,12 @@ public class CreateDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbName")
     String dbName;
+
+    /**
+     * The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+    String dbUniqueName;
 
     /**
      * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
@@ -51,6 +51,15 @@ public class CreateDatabaseFromBackupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+        private String dbUniqueName;
+
+        public Builder dbUniqueName(String dbUniqueName) {
+            this.dbUniqueName = dbUniqueName;
+            this.__explicitlySet__.add("dbUniqueName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbName")
         private String dbName;
 
@@ -66,7 +75,7 @@ public class CreateDatabaseFromBackupDetails {
         public CreateDatabaseFromBackupDetails build() {
             CreateDatabaseFromBackupDetails __instance__ =
                     new CreateDatabaseFromBackupDetails(
-                            backupId, backupTDEPassword, adminPassword, dbName);
+                            backupId, backupTDEPassword, adminPassword, dbUniqueName, dbName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -77,6 +86,7 @@ public class CreateDatabaseFromBackupDetails {
                     backupId(o.getBackupId())
                             .backupTDEPassword(o.getBackupTDEPassword())
                             .adminPassword(o.getAdminPassword())
+                            .dbUniqueName(o.getDbUniqueName())
                             .dbName(o.getDbName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -108,6 +118,12 @@ public class CreateDatabaseFromBackupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
     String adminPassword;
+
+    /**
+     * The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+    String dbUniqueName;
 
     /**
      * The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeBase.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for creating a database home.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source",
+    defaultImpl = CreateDbHomeBase.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithDbSystemIdFromBackupDetails.class,
+        name = "DB_BACKUP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithVmClusterIdFromBackupDetails.class,
+        name = "VM_CLUSTER_BACKUP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithDbSystemIdDetails.class,
+        name = "NONE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithVmClusterIdDetails.class,
+        name = "VM_CLUSTER_NEW"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeBase {
+
+    /**
+     * The user-provided name of the database home.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdDetails.java
@@ -27,25 +27,25 @@ package com.oracle.bmc.database.model;
     property = "source"
 )
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeWithDbSystemIdBase {
+public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeBase {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
-        private String dbSystemId;
-
-        public Builder dbSystemId(String dbSystemId) {
-            this.dbSystemId = dbSystemId;
-            this.__explicitlySet__.add("dbSystemId");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
         public Builder displayName(String displayName) {
             this.displayName = displayName;
             this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
             return this;
         }
 
@@ -73,7 +73,7 @@ public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeWithDbSystemI
         public CreateDbHomeWithDbSystemIdDetails build() {
             CreateDbHomeWithDbSystemIdDetails __instance__ =
                     new CreateDbHomeWithDbSystemIdDetails(
-                            dbSystemId, displayName, dbVersion, database);
+                            displayName, dbSystemId, dbVersion, database);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -81,8 +81,8 @@ public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeWithDbSystemI
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDbHomeWithDbSystemIdDetails o) {
             Builder copiedBuilder =
-                    dbSystemId(o.getDbSystemId())
-                            .displayName(o.getDisplayName())
+                    displayName(o.getDisplayName())
+                            .dbSystemId(o.getDbSystemId())
                             .dbVersion(o.getDbVersion())
                             .database(o.getDatabase());
 
@@ -100,14 +100,21 @@ public class CreateDbHomeWithDbSystemIdDetails extends CreateDbHomeWithDbSystemI
 
     @Deprecated
     public CreateDbHomeWithDbSystemIdDetails(
-            String dbSystemId,
             String displayName,
+            String dbSystemId,
             String dbVersion,
             CreateDatabaseDetails database) {
-        super(dbSystemId, displayName);
+        super(displayName);
+        this.dbSystemId = dbSystemId;
         this.dbVersion = dbVersion;
         this.database = database;
     }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
 
     /**
      * A valid Oracle Database version. To get a list of supported versions, use the {@link #listDbVersions(ListDbVersionsRequest) listDbVersions} operation.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromBackupDetails.java
@@ -27,25 +27,25 @@ package com.oracle.bmc.database.model;
     property = "source"
 )
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeWithDbSystemIdBase {
+public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeBase {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
-        private String dbSystemId;
-
-        public Builder dbSystemId(String dbSystemId) {
-            this.dbSystemId = dbSystemId;
-            this.__explicitlySet__.add("dbSystemId");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
         public Builder displayName(String displayName) {
             this.displayName = displayName;
             this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
             return this;
         }
 
@@ -64,7 +64,7 @@ public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeWit
         public CreateDbHomeWithDbSystemIdFromBackupDetails build() {
             CreateDbHomeWithDbSystemIdFromBackupDetails __instance__ =
                     new CreateDbHomeWithDbSystemIdFromBackupDetails(
-                            dbSystemId, displayName, database);
+                            displayName, dbSystemId, database);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -72,8 +72,8 @@ public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeWit
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDbHomeWithDbSystemIdFromBackupDetails o) {
             Builder copiedBuilder =
-                    dbSystemId(o.getDbSystemId())
-                            .displayName(o.getDisplayName())
+                    displayName(o.getDisplayName())
+                            .dbSystemId(o.getDbSystemId())
                             .database(o.getDatabase());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -90,10 +90,17 @@ public class CreateDbHomeWithDbSystemIdFromBackupDetails extends CreateDbHomeWit
 
     @Deprecated
     public CreateDbHomeWithDbSystemIdFromBackupDetails(
-            String dbSystemId, String displayName, CreateDatabaseFromBackupDetails database) {
-        super(dbSystemId, displayName);
+            String displayName, String dbSystemId, CreateDatabaseFromBackupDetails database) {
+        super(displayName);
+        this.dbSystemId = dbSystemId;
         this.database = database;
     }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
 
     @com.fasterxml.jackson.annotation.JsonProperty("database")
     CreateDatabaseFromBackupDetails database;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithVmClusterIdDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithVmClusterIdDetails.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterId` API operation to successfully complete.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbHomeWithVmClusterIdDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeWithVmClusterIdDetails extends CreateDbHomeBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseDetails database;
+
+        public Builder database(CreateDatabaseDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbHomeWithVmClusterIdDetails build() {
+            CreateDbHomeWithVmClusterIdDetails __instance__ =
+                    new CreateDbHomeWithVmClusterIdDetails(
+                            displayName, vmClusterId, dbVersion, database);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbHomeWithVmClusterIdDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .vmClusterId(o.getVmClusterId())
+                            .dbVersion(o.getDbVersion())
+                            .database(o.getDatabase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDbHomeWithVmClusterIdDetails(
+            String displayName,
+            String vmClusterId,
+            String dbVersion,
+            CreateDatabaseDetails database) {
+        super(displayName);
+        this.vmClusterId = vmClusterId;
+        this.dbVersion = dbVersion;
+        this.database = database;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
+
+    /**
+     * A valid Oracle Database version. To get a list of supported versions, use the {@link #listDbVersions(ListDbVersionsRequest) listDbVersions} operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+    String dbVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("database")
+    CreateDatabaseDetails database;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithVmClusterIdFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithVmClusterIdFromBackupDetails.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Note that a valid `vmClusterId` value must be supplied for the `CreateDbHomeWithVmClusterIdFromBackup` API operation to successfully complete.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbHomeWithVmClusterIdFromBackupDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeWithVmClusterIdFromBackupDetails extends CreateDbHomeBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseFromBackupDetails database;
+
+        public Builder database(CreateDatabaseFromBackupDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbHomeWithVmClusterIdFromBackupDetails build() {
+            CreateDbHomeWithVmClusterIdFromBackupDetails __instance__ =
+                    new CreateDbHomeWithVmClusterIdFromBackupDetails(
+                            displayName, vmClusterId, database);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbHomeWithVmClusterIdFromBackupDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .vmClusterId(o.getVmClusterId())
+                            .database(o.getDatabase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDbHomeWithVmClusterIdFromBackupDetails(
+            String displayName, String vmClusterId, CreateDatabaseFromBackupDetails database) {
+        super(displayName);
+        this.vmClusterId = vmClusterId;
+        this.database = database;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("database")
+    CreateDatabaseFromBackupDetails database;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateExadataInfrastructureDetails.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Request to create Exadata infrastructure.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateExadataInfrastructureDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateExadataInfrastructureDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+        private String cloudControlPlaneServer1;
+
+        public Builder cloudControlPlaneServer1(String cloudControlPlaneServer1) {
+            this.cloudControlPlaneServer1 = cloudControlPlaneServer1;
+            this.__explicitlySet__.add("cloudControlPlaneServer1");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+        private String cloudControlPlaneServer2;
+
+        public Builder cloudControlPlaneServer2(String cloudControlPlaneServer2) {
+            this.cloudControlPlaneServer2 = cloudControlPlaneServer2;
+            this.__explicitlySet__.add("cloudControlPlaneServer2");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+        private String adminNetworkCIDR;
+
+        public Builder adminNetworkCIDR(String adminNetworkCIDR) {
+            this.adminNetworkCIDR = adminNetworkCIDR;
+            this.__explicitlySet__.add("adminNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+        private String infiniBandNetworkCIDR;
+
+        public Builder infiniBandNetworkCIDR(String infiniBandNetworkCIDR) {
+            this.infiniBandNetworkCIDR = infiniBandNetworkCIDR;
+            this.__explicitlySet__.add("infiniBandNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+        private String corporateProxy;
+
+        public Builder corporateProxy(String corporateProxy) {
+            this.corporateProxy = corporateProxy;
+            this.__explicitlySet__.add("corporateProxy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+        private java.util.List<String> dnsServer;
+
+        public Builder dnsServer(java.util.List<String> dnsServer) {
+            this.dnsServer = dnsServer;
+            this.__explicitlySet__.add("dnsServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+        private java.util.List<String> ntpServer;
+
+        public Builder ntpServer(java.util.List<String> ntpServer) {
+            this.ntpServer = ntpServer;
+            this.__explicitlySet__.add("ntpServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateExadataInfrastructureDetails build() {
+            CreateExadataInfrastructureDetails __instance__ =
+                    new CreateExadataInfrastructureDetails(
+                            compartmentId,
+                            displayName,
+                            shape,
+                            timeZone,
+                            cloudControlPlaneServer1,
+                            cloudControlPlaneServer2,
+                            netmask,
+                            gateway,
+                            adminNetworkCIDR,
+                            infiniBandNetworkCIDR,
+                            corporateProxy,
+                            dnsServer,
+                            ntpServer,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateExadataInfrastructureDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .shape(o.getShape())
+                            .timeZone(o.getTimeZone())
+                            .cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
+                            .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
+                            .netmask(o.getNetmask())
+                            .gateway(o.getGateway())
+                            .adminNetworkCIDR(o.getAdminNetworkCIDR())
+                            .infiniBandNetworkCIDR(o.getInfiniBandNetworkCIDR())
+                            .corporateProxy(o.getCorporateProxy())
+                            .dnsServer(o.getDnsServer())
+                            .ntpServer(o.getNtpServer())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * The IP address for the first control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+    String cloudControlPlaneServer1;
+
+    /**
+     * The IP address for the second control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+    String cloudControlPlaneServer2;
+
+    /**
+     * The netmask for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The gateway for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The CIDR block for the Exadata administration network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+    String adminNetworkCIDR;
+
+    /**
+     * The CIDR block for the Exadata InfiniBand interconnect.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+    String infiniBandNetworkCIDR;
+
+    /**
+     * The corporate network proxy for access to the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+    String corporateProxy;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+    java.util.List<String> dnsServer;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+    java.util.List<String> ntpServer;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateNFSBackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateNFSBackupDestinationDetails.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Used for creating NFS backup destinations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateNFSBackupDestinationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateNFSBackupDestinationDetails extends CreateBackupDestinationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+        private String localMountPointPath;
+
+        public Builder localMountPointPath(String localMountPointPath) {
+            this.localMountPointPath = localMountPointPath;
+            this.__explicitlySet__.add("localMountPointPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateNFSBackupDestinationDetails build() {
+            CreateNFSBackupDestinationDetails __instance__ =
+                    new CreateNFSBackupDestinationDetails(
+                            displayName,
+                            compartmentId,
+                            freeformTags,
+                            definedTags,
+                            localMountPointPath);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateNFSBackupDestinationDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .localMountPointPath(o.getLocalMountPointPath());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateNFSBackupDestinationDetails(
+            String displayName,
+            String compartmentId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String localMountPointPath) {
+        super(displayName, compartmentId, freeformTags, definedTags);
+        this.localMountPointPath = localMountPointPath;
+    }
+
+    /**
+     * The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+    String localMountPointPath;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRecoveryApplianceBackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRecoveryApplianceBackupDestinationDetails.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Used for creating Recovery Appliance backup destinations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateRecoveryApplianceBackupDestinationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateRecoveryApplianceBackupDestinationDetails
+        extends CreateBackupDestinationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+        private String connectionString;
+
+        public Builder connectionString(String connectionString) {
+            this.connectionString = connectionString;
+            this.__explicitlySet__.add("connectionString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+        private java.util.List<String> vpcUsers;
+
+        public Builder vpcUsers(java.util.List<String> vpcUsers) {
+            this.vpcUsers = vpcUsers;
+            this.__explicitlySet__.add("vpcUsers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateRecoveryApplianceBackupDestinationDetails build() {
+            CreateRecoveryApplianceBackupDestinationDetails __instance__ =
+                    new CreateRecoveryApplianceBackupDestinationDetails(
+                            displayName,
+                            compartmentId,
+                            freeformTags,
+                            definedTags,
+                            connectionString,
+                            vpcUsers);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateRecoveryApplianceBackupDestinationDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .connectionString(o.getConnectionString())
+                            .vpcUsers(o.getVpcUsers());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateRecoveryApplianceBackupDestinationDetails(
+            String displayName,
+            String compartmentId,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            String connectionString,
+            java.util.List<String> vpcUsers) {
+        super(displayName, compartmentId, freeformTags, definedTags);
+        this.connectionString = connectionString;
+        this.vpcUsers = vpcUsers;
+    }
+
+    /**
+     * The connection string for connecting to the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+    String connectionString;
+
+    /**
+     * The Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+    java.util.List<String> vpcUsers;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for the create VM cluster operation.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateVmClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateVmClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+        private java.util.List<String> sshPublicKeys;
+
+        public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
+            this.sshPublicKeys = sshPublicKeys;
+            this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+        private String vmClusterNetworkId;
+
+        public Builder vmClusterNetworkId(String vmClusterNetworkId) {
+            this.vmClusterNetworkId = vmClusterNetworkId;
+            this.__explicitlySet__.add("vmClusterNetworkId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+        private LicenseModel licenseModel;
+
+        public Builder licenseModel(LicenseModel licenseModel) {
+            this.licenseModel = licenseModel;
+            this.__explicitlySet__.add("licenseModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+        private Boolean isSparseDiskgroupEnabled;
+
+        public Builder isSparseDiskgroupEnabled(Boolean isSparseDiskgroupEnabled) {
+            this.isSparseDiskgroupEnabled = isSparseDiskgroupEnabled;
+            this.__explicitlySet__.add("isSparseDiskgroupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+        private Boolean isLocalBackupEnabled;
+
+        public Builder isLocalBackupEnabled(Boolean isLocalBackupEnabled) {
+            this.isLocalBackupEnabled = isLocalBackupEnabled;
+            this.__explicitlySet__.add("isLocalBackupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+        private String giVersion;
+
+        public Builder giVersion(String giVersion) {
+            this.giVersion = giVersion;
+            this.__explicitlySet__.add("giVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateVmClusterDetails build() {
+            CreateVmClusterDetails __instance__ =
+                    new CreateVmClusterDetails(
+                            compartmentId,
+                            displayName,
+                            exadataInfrastructureId,
+                            cpuCoreCount,
+                            sshPublicKeys,
+                            vmClusterNetworkId,
+                            licenseModel,
+                            isSparseDiskgroupEnabled,
+                            isLocalBackupEnabled,
+                            timeZone,
+                            giVersion,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateVmClusterDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .vmClusterNetworkId(o.getVmClusterNetworkId())
+                            .licenseModel(o.getLicenseModel())
+                            .isSparseDiskgroupEnabled(o.getIsSparseDiskgroupEnabled())
+                            .isLocalBackupEnabled(o.getIsLocalBackupEnabled())
+                            .timeZone(o.getTimeZone())
+                            .giVersion(o.getGiVersion())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the VM cluster. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * The number of CPU cores to enable for the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The public key portion of one or more key pairs used for SSH access to the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+    java.util.List<String> sshPublicKeys;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+    String vmClusterNetworkId;
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LicenseModel: " + key);
+        }
+    };
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    /**
+     * If true, the sparse disk group is configured for the VM cluster. If false, the sparse disk group is not created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+    Boolean isSparseDiskgroupEnabled;
+
+    /**
+     * If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+    Boolean isLocalBackupEnabled;
+
+    /**
+     * The time zone to use for the VM cluster. For details, see [DB System Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * The Oracle Grid Infrastructure software version for the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+    String giVersion;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbBackupConfig.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbBackupConfig.java
@@ -51,12 +51,26 @@ public class DbBackupConfig {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("backupDestinationDetails")
+        private java.util.List<BackupDestinationDetails> backupDestinationDetails;
+
+        public Builder backupDestinationDetails(
+                java.util.List<BackupDestinationDetails> backupDestinationDetails) {
+            this.backupDestinationDetails = backupDestinationDetails;
+            this.__explicitlySet__.add("backupDestinationDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DbBackupConfig build() {
             DbBackupConfig __instance__ =
-                    new DbBackupConfig(autoBackupEnabled, recoveryWindowInDays, autoBackupWindow);
+                    new DbBackupConfig(
+                            autoBackupEnabled,
+                            recoveryWindowInDays,
+                            autoBackupWindow,
+                            backupDestinationDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -66,7 +80,8 @@ public class DbBackupConfig {
             Builder copiedBuilder =
                     autoBackupEnabled(o.getAutoBackupEnabled())
                             .recoveryWindowInDays(o.getRecoveryWindowInDays())
-                            .autoBackupWindow(o.getAutoBackupWindow());
+                            .autoBackupWindow(o.getAutoBackupWindow())
+                            .backupDestinationDetails(o.getBackupDestinationDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -161,6 +176,12 @@ public class DbBackupConfig {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("autoBackupWindow")
     AutoBackupWindow autoBackupWindow;
+
+    /**
+     * Backup destination details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupDestinationDetails")
+    java.util.List<BackupDestinationDetails> backupDestinationDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHome.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHome.java
@@ -76,6 +76,15 @@ public class DbHome {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
         private String dbVersion;
 
@@ -106,6 +115,7 @@ public class DbHome {
                             lastPatchHistoryEntryId,
                             lifecycleState,
                             dbSystemId,
+                            vmClusterId,
                             dbVersion,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -121,6 +131,7 @@ public class DbHome {
                             .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
                             .lifecycleState(o.getLifecycleState())
                             .dbSystemId(o.getDbSystemId())
+                            .vmClusterId(o.getVmClusterId())
                             .dbVersion(o.getDbVersion())
                             .timeCreated(o.getTimeCreated());
 
@@ -220,6 +231,12 @@ public class DbHome {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
     String dbSystemId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
 
     /**
      * The Oracle Database version.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHomeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbHomeSummary.java
@@ -85,6 +85,15 @@ public class DbHomeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
         private String dbVersion;
 
@@ -115,6 +124,7 @@ public class DbHomeSummary {
                             lastPatchHistoryEntryId,
                             lifecycleState,
                             dbSystemId,
+                            vmClusterId,
                             dbVersion,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -130,6 +140,7 @@ public class DbHomeSummary {
                             .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
                             .lifecycleState(o.getLifecycleState())
                             .dbSystemId(o.getDbSystemId())
+                            .vmClusterId(o.getVmClusterId())
                             .dbVersion(o.getDbVersion())
                             .timeCreated(o.getTimeCreated());
 
@@ -229,6 +240,12 @@ public class DbHomeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
     String dbSystemId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
 
     /**
      * The Oracle Database version.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
@@ -38,6 +38,15 @@ public class DbSystemShapeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeFamily")
+        private String shapeFamily;
+
+        public Builder shapeFamily(String shapeFamily) {
+            this.shapeFamily = shapeFamily;
+            this.__explicitlySet__.add("shapeFamily");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("shape")
         private String shape;
 
@@ -99,6 +108,7 @@ public class DbSystemShapeSummary {
             DbSystemShapeSummary __instance__ =
                     new DbSystemShapeSummary(
                             name,
+                            shapeFamily,
                             shape,
                             availableCoreCount,
                             minimumCoreCount,
@@ -113,6 +123,7 @@ public class DbSystemShapeSummary {
         public Builder copy(DbSystemShapeSummary o) {
             Builder copiedBuilder =
                     name(o.getName())
+                            .shapeFamily(o.getShapeFamily())
                             .shape(o.getShape())
                             .availableCoreCount(o.getAvailableCoreCount())
                             .minimumCoreCount(o.getMinimumCoreCount())
@@ -137,6 +148,12 @@ public class DbSystemShapeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    /**
+     * The family of the shape used for the DB system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeFamily")
+    String shapeFamily;
 
     /**
      * Deprecated. Use `name` instead of `shape`.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
@@ -1,0 +1,474 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * ExadataInfrastructure
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ExadataInfrastructure.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ExadataInfrastructure {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+        private Integer cpusEnabled;
+
+        public Builder cpusEnabled(Integer cpusEnabled) {
+            this.cpusEnabled = cpusEnabled;
+            this.__explicitlySet__.add("cpusEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Integer dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+        private String cloudControlPlaneServer1;
+
+        public Builder cloudControlPlaneServer1(String cloudControlPlaneServer1) {
+            this.cloudControlPlaneServer1 = cloudControlPlaneServer1;
+            this.__explicitlySet__.add("cloudControlPlaneServer1");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+        private String cloudControlPlaneServer2;
+
+        public Builder cloudControlPlaneServer2(String cloudControlPlaneServer2) {
+            this.cloudControlPlaneServer2 = cloudControlPlaneServer2;
+            this.__explicitlySet__.add("cloudControlPlaneServer2");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+        private String adminNetworkCIDR;
+
+        public Builder adminNetworkCIDR(String adminNetworkCIDR) {
+            this.adminNetworkCIDR = adminNetworkCIDR;
+            this.__explicitlySet__.add("adminNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+        private String infiniBandNetworkCIDR;
+
+        public Builder infiniBandNetworkCIDR(String infiniBandNetworkCIDR) {
+            this.infiniBandNetworkCIDR = infiniBandNetworkCIDR;
+            this.__explicitlySet__.add("infiniBandNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+        private String corporateProxy;
+
+        public Builder corporateProxy(String corporateProxy) {
+            this.corporateProxy = corporateProxy;
+            this.__explicitlySet__.add("corporateProxy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+        private java.util.List<String> dnsServer;
+
+        public Builder dnsServer(java.util.List<String> dnsServer) {
+            this.dnsServer = dnsServer;
+            this.__explicitlySet__.add("dnsServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+        private java.util.List<String> ntpServer;
+
+        public Builder ntpServer(java.util.List<String> ntpServer) {
+            this.ntpServer = ntpServer;
+            this.__explicitlySet__.add("ntpServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExadataInfrastructure build() {
+            ExadataInfrastructure __instance__ =
+                    new ExadataInfrastructure(
+                            id,
+                            compartmentId,
+                            lifecycleState,
+                            displayName,
+                            shape,
+                            timeZone,
+                            cpusEnabled,
+                            dataStorageSizeInTBs,
+                            cloudControlPlaneServer1,
+                            cloudControlPlaneServer2,
+                            netmask,
+                            gateway,
+                            adminNetworkCIDR,
+                            infiniBandNetworkCIDR,
+                            corporateProxy,
+                            dnsServer,
+                            ntpServer,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExadataInfrastructure o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .shape(o.getShape())
+                            .timeZone(o.getTimeZone())
+                            .cpusEnabled(o.getCpusEnabled())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
+                            .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
+                            .netmask(o.getNetmask())
+                            .gateway(o.getGateway())
+                            .adminNetworkCIDR(o.getAdminNetworkCIDR())
+                            .infiniBandNetworkCIDR(o.getInfiniBandNetworkCIDR())
+                            .corporateProxy(o.getCorporateProxy())
+                            .dnsServer(o.getDnsServer())
+                            .ntpServer(o.getNtpServer())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * The current lifecycle state of the Exadata infrastructure.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        RequiresActivation("REQUIRES_ACTIVATION"),
+        Activating("ACTIVATING"),
+        Active("ACTIVE"),
+        ActivationFailed("ACTIVATION_FAILED"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Offline("OFFLINE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current lifecycle state of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * The number of enabled CPU cores.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+    Integer cpusEnabled;
+
+    /**
+     * Size, in terabytes, of the DATA disk group.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Integer dataStorageSizeInTBs;
+
+    /**
+     * The IP address for the first control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+    String cloudControlPlaneServer1;
+
+    /**
+     * The IP address for the second control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+    String cloudControlPlaneServer2;
+
+    /**
+     * The netmask for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The gateway for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The CIDR block for the Exadata administration network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+    String adminNetworkCIDR;
+
+    /**
+     * The CIDR block for the Exadata InfiniBand interconnect.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+    String infiniBandNetworkCIDR;
+
+    /**
+     * The corporate network proxy for access to the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+    String corporateProxy;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+    java.util.List<String> dnsServer;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+    java.util.List<String> ntpServer;
+
+    /**
+     * The date and time the Exadata infrastructure was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
@@ -1,0 +1,474 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the Exadata infrastructure.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ExadataInfrastructureSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ExadataInfrastructureSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+        private Integer cpusEnabled;
+
+        public Builder cpusEnabled(Integer cpusEnabled) {
+            this.cpusEnabled = cpusEnabled;
+            this.__explicitlySet__.add("cpusEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Integer dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+        private String cloudControlPlaneServer1;
+
+        public Builder cloudControlPlaneServer1(String cloudControlPlaneServer1) {
+            this.cloudControlPlaneServer1 = cloudControlPlaneServer1;
+            this.__explicitlySet__.add("cloudControlPlaneServer1");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+        private String cloudControlPlaneServer2;
+
+        public Builder cloudControlPlaneServer2(String cloudControlPlaneServer2) {
+            this.cloudControlPlaneServer2 = cloudControlPlaneServer2;
+            this.__explicitlySet__.add("cloudControlPlaneServer2");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+        private String adminNetworkCIDR;
+
+        public Builder adminNetworkCIDR(String adminNetworkCIDR) {
+            this.adminNetworkCIDR = adminNetworkCIDR;
+            this.__explicitlySet__.add("adminNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+        private String infiniBandNetworkCIDR;
+
+        public Builder infiniBandNetworkCIDR(String infiniBandNetworkCIDR) {
+            this.infiniBandNetworkCIDR = infiniBandNetworkCIDR;
+            this.__explicitlySet__.add("infiniBandNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+        private String corporateProxy;
+
+        public Builder corporateProxy(String corporateProxy) {
+            this.corporateProxy = corporateProxy;
+            this.__explicitlySet__.add("corporateProxy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+        private java.util.List<String> dnsServer;
+
+        public Builder dnsServer(java.util.List<String> dnsServer) {
+            this.dnsServer = dnsServer;
+            this.__explicitlySet__.add("dnsServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+        private java.util.List<String> ntpServer;
+
+        public Builder ntpServer(java.util.List<String> ntpServer) {
+            this.ntpServer = ntpServer;
+            this.__explicitlySet__.add("ntpServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExadataInfrastructureSummary build() {
+            ExadataInfrastructureSummary __instance__ =
+                    new ExadataInfrastructureSummary(
+                            id,
+                            compartmentId,
+                            lifecycleState,
+                            displayName,
+                            shape,
+                            timeZone,
+                            cpusEnabled,
+                            dataStorageSizeInTBs,
+                            cloudControlPlaneServer1,
+                            cloudControlPlaneServer2,
+                            netmask,
+                            gateway,
+                            adminNetworkCIDR,
+                            infiniBandNetworkCIDR,
+                            corporateProxy,
+                            dnsServer,
+                            ntpServer,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExadataInfrastructureSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .shape(o.getShape())
+                            .timeZone(o.getTimeZone())
+                            .cpusEnabled(o.getCpusEnabled())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
+                            .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
+                            .netmask(o.getNetmask())
+                            .gateway(o.getGateway())
+                            .adminNetworkCIDR(o.getAdminNetworkCIDR())
+                            .infiniBandNetworkCIDR(o.getInfiniBandNetworkCIDR())
+                            .corporateProxy(o.getCorporateProxy())
+                            .dnsServer(o.getDnsServer())
+                            .ntpServer(o.getNtpServer())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * The current lifecycle state of the Exadata infrastructure.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        RequiresActivation("REQUIRES_ACTIVATION"),
+        Activating("ACTIVATING"),
+        Active("ACTIVE"),
+        ActivationFailed("ACTIVATION_FAILED"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Offline("OFFLINE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current lifecycle state of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The user-friendly name for the Exadata infrastructure. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * The number of enabled CPU cores.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+    Integer cpusEnabled;
+
+    /**
+     * Size, in terabytes, of the DATA disk group.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Integer dataStorageSizeInTBs;
+
+    /**
+     * The IP address for the first control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+    String cloudControlPlaneServer1;
+
+    /**
+     * The IP address for the second control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+    String cloudControlPlaneServer2;
+
+    /**
+     * The netmask for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The gateway for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The CIDR block for the Exadata administration network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+    String adminNetworkCIDR;
+
+    /**
+     * The CIDR block for the Exadata InfiniBand interconnect.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+    String infiniBandNetworkCIDR;
+
+    /**
+     * The corporate network proxy for access to the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+    String corporateProxy;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+    java.util.List<String> dnsServer;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+    java.util.List<String> ntpServer;
+
+    /**
+     * The date and time the Exadata infrastructure was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/GenerateRecommendedNetworkDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/GenerateRecommendedNetworkDetails.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Generates a recommended VM cluster network configuration.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenerateRecommendedNetworkDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class GenerateRecommendedNetworkDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networks")
+        private java.util.List<InfoForNetworkGenDetails> networks;
+
+        public Builder networks(java.util.List<InfoForNetworkGenDetails> networks) {
+            this.networks = networks;
+            this.__explicitlySet__.add("networks");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dns")
+        private java.util.List<String> dns;
+
+        public Builder dns(java.util.List<String> dns) {
+            this.dns = dns;
+            this.__explicitlySet__.add("dns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+        private java.util.List<String> ntp;
+
+        public Builder ntp(java.util.List<String> ntp) {
+            this.ntp = ntp;
+            this.__explicitlySet__.add("ntp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenerateRecommendedNetworkDetails build() {
+            GenerateRecommendedNetworkDetails __instance__ =
+                    new GenerateRecommendedNetworkDetails(
+                            compartmentId,
+                            displayName,
+                            networks,
+                            dns,
+                            ntp,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenerateRecommendedNetworkDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .networks(o.getNetworks())
+                            .dns(o.getDns())
+                            .ntp(o.getNtp())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the VM cluster network. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * List of parameters for generation of the client and backup networks.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networks")
+    java.util.List<InfoForNetworkGenDetails> networks;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dns")
+    java.util.List<String> dns;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+    java.util.List<String> ntp;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/GiVersionSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/GiVersionSummary.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The Oracle Grid Infrastructure (GI) version.
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're an administrator who needs to write policies to give users access, see [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GiVersionSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class GiVersionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GiVersionSummary build() {
+            GiVersionSummary __instance__ = new GiVersionSummary(version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GiVersionSummary o) {
+            Builder copiedBuilder = version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A valid Oracle Grid Infrastructure (GI) software version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/InfoForNetworkGenDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/InfoForNetworkGenDetails.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Parameters for generation of the client or backup network in a VM cluster network.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InfoForNetworkGenDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class InfoForNetworkGenDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+        private NetworkType networkType;
+
+        public Builder networkType(NetworkType networkType) {
+            this.networkType = networkType;
+            this.__explicitlySet__.add("networkType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vlanId")
+        private String vlanId;
+
+        public Builder vlanId(String vlanId) {
+            this.vlanId = vlanId;
+            this.__explicitlySet__.add("vlanId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cidr")
+        private String cidr;
+
+        public Builder cidr(String cidr) {
+            this.cidr = cidr;
+            this.__explicitlySet__.add("cidr");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("domain")
+        private String domain;
+
+        public Builder domain(String domain) {
+            this.domain = domain;
+            this.__explicitlySet__.add("domain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("prefix")
+        private String prefix;
+
+        public Builder prefix(String prefix) {
+            this.prefix = prefix;
+            this.__explicitlySet__.add("prefix");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InfoForNetworkGenDetails build() {
+            InfoForNetworkGenDetails __instance__ =
+                    new InfoForNetworkGenDetails(
+                            networkType, vlanId, cidr, gateway, netmask, domain, prefix);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InfoForNetworkGenDetails o) {
+            Builder copiedBuilder =
+                    networkType(o.getNetworkType())
+                            .vlanId(o.getVlanId())
+                            .cidr(o.getCidr())
+                            .gateway(o.getGateway())
+                            .netmask(o.getNetmask())
+                            .domain(o.getDomain())
+                            .prefix(o.getPrefix());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The network type.
+     **/
+    public enum NetworkType {
+        Client("CLIENT"),
+        Backup("BACKUP"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, NetworkType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NetworkType v : NetworkType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        NetworkType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NetworkType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid NetworkType: " + key);
+        }
+    };
+    /**
+     * The network type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+    NetworkType networkType;
+
+    /**
+     * The network VLAN ID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vlanId")
+    String vlanId;
+
+    /**
+     * The cidr for the network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidr")
+    String cidr;
+
+    /**
+     * The network gateway.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The network netmask.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The network domain name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("domain")
+    String domain;
+
+    /**
+     * The network domain name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("prefix")
+    String prefix;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/NodeDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/NodeDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Node details associated with a network.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = NodeDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class NodeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ip")
+        private String ip;
+
+        public Builder ip(String ip) {
+            this.ip = ip;
+            this.__explicitlySet__.add("ip");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vipHostname")
+        private String vipHostname;
+
+        public Builder vipHostname(String vipHostname) {
+            this.vipHostname = vipHostname;
+            this.__explicitlySet__.add("vipHostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vip")
+        private String vip;
+
+        public Builder vip(String vip) {
+            this.vip = vip;
+            this.__explicitlySet__.add("vip");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NodeDetails build() {
+            NodeDetails __instance__ = new NodeDetails(hostname, ip, vipHostname, vip);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NodeDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname())
+                            .ip(o.getIp())
+                            .vipHostname(o.getVipHostname())
+                            .vip(o.getVip());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The node host name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * The node IP address.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ip")
+    String ip;
+
+    /**
+     * The node virtual IP (VIP) host name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vipHostname")
+    String vipHostname;
+
+    /**
+     * The node virtual IP (VIP) address.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vip")
+    String vip;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ScanDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ScanDetails.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The Single Client Access Name (SCAN) details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ScanDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ScanDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ips")
+        private java.util.List<String> ips;
+
+        public Builder ips(java.util.List<String> ips) {
+            this.ips = ips;
+            this.__explicitlySet__.add("ips");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ScanDetails build() {
+            ScanDetails __instance__ = new ScanDetails(hostname, port, ips);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ScanDetails o) {
+            Builder copiedBuilder = hostname(o.getHostname()).port(o.getPort()).ips(o.getIps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The SCAN hostname.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * The SCAN port. Default is 1521.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    /**
+     * The list of SCAN IP addresses. Three addresses should be provided.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ips")
+    java.util.List<String> ips;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateBackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateBackupDestinationDetails.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * For a RECOVERY_APPLIANCE backup destination, used to update the connection string and/or the list of VPC users.
+ * For an NFS backup destination, used to update the NFS location.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateBackupDestinationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateBackupDestinationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+        private java.util.List<String> vpcUsers;
+
+        public Builder vpcUsers(java.util.List<String> vpcUsers) {
+            this.vpcUsers = vpcUsers;
+            this.__explicitlySet__.add("vpcUsers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+        private String connectionString;
+
+        public Builder connectionString(String connectionString) {
+            this.connectionString = connectionString;
+            this.__explicitlySet__.add("connectionString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+        private String localMountPointPath;
+
+        public Builder localMountPointPath(String localMountPointPath) {
+            this.localMountPointPath = localMountPointPath;
+            this.__explicitlySet__.add("localMountPointPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateBackupDestinationDetails build() {
+            UpdateBackupDestinationDetails __instance__ =
+                    new UpdateBackupDestinationDetails(
+                            vpcUsers,
+                            connectionString,
+                            localMountPointPath,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateBackupDestinationDetails o) {
+            Builder copiedBuilder =
+                    vpcUsers(o.getVpcUsers())
+                            .connectionString(o.getConnectionString())
+                            .localMountPointPath(o.getLocalMountPointPath())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the Virtual Private Catalog (VPC) users that are used to access the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vpcUsers")
+    java.util.List<String> vpcUsers;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, the connection string for connecting to the Recovery Appliance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionString")
+    String connectionString;
+
+    /**
+     * The local directory path on each VM cluster node where the NFS server location is mounted. The local directory path and the NFS server location must each be the same across all of the VM cluster nodes. Ensure that the NFS mount is maintained continuously on all of the VM cluster nodes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("localMountPointPath")
+    String localMountPointPath;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateExadataInfrastructureDetails.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Updates the Exadata infrastructure.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateExadataInfrastructureDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateExadataInfrastructureDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+        private String cloudControlPlaneServer1;
+
+        public Builder cloudControlPlaneServer1(String cloudControlPlaneServer1) {
+            this.cloudControlPlaneServer1 = cloudControlPlaneServer1;
+            this.__explicitlySet__.add("cloudControlPlaneServer1");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+        private String cloudControlPlaneServer2;
+
+        public Builder cloudControlPlaneServer2(String cloudControlPlaneServer2) {
+            this.cloudControlPlaneServer2 = cloudControlPlaneServer2;
+            this.__explicitlySet__.add("cloudControlPlaneServer2");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+        private String adminNetworkCIDR;
+
+        public Builder adminNetworkCIDR(String adminNetworkCIDR) {
+            this.adminNetworkCIDR = adminNetworkCIDR;
+            this.__explicitlySet__.add("adminNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+        private String infiniBandNetworkCIDR;
+
+        public Builder infiniBandNetworkCIDR(String infiniBandNetworkCIDR) {
+            this.infiniBandNetworkCIDR = infiniBandNetworkCIDR;
+            this.__explicitlySet__.add("infiniBandNetworkCIDR");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+        private String corporateProxy;
+
+        public Builder corporateProxy(String corporateProxy) {
+            this.corporateProxy = corporateProxy;
+            this.__explicitlySet__.add("corporateProxy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+        private java.util.List<String> dnsServer;
+
+        public Builder dnsServer(java.util.List<String> dnsServer) {
+            this.dnsServer = dnsServer;
+            this.__explicitlySet__.add("dnsServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+        private java.util.List<String> ntpServer;
+
+        public Builder ntpServer(java.util.List<String> ntpServer) {
+            this.ntpServer = ntpServer;
+            this.__explicitlySet__.add("ntpServer");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateExadataInfrastructureDetails build() {
+            UpdateExadataInfrastructureDetails __instance__ =
+                    new UpdateExadataInfrastructureDetails(
+                            cloudControlPlaneServer1,
+                            cloudControlPlaneServer2,
+                            netmask,
+                            gateway,
+                            adminNetworkCIDR,
+                            infiniBandNetworkCIDR,
+                            corporateProxy,
+                            dnsServer,
+                            ntpServer,
+                            timeZone,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateExadataInfrastructureDetails o) {
+            Builder copiedBuilder =
+                    cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
+                            .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
+                            .netmask(o.getNetmask())
+                            .gateway(o.getGateway())
+                            .adminNetworkCIDR(o.getAdminNetworkCIDR())
+                            .infiniBandNetworkCIDR(o.getInfiniBandNetworkCIDR())
+                            .corporateProxy(o.getCorporateProxy())
+                            .dnsServer(o.getDnsServer())
+                            .ntpServer(o.getNtpServer())
+                            .timeZone(o.getTimeZone())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The IP address for the first control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer1")
+    String cloudControlPlaneServer1;
+
+    /**
+     * The IP address for the second control plane server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudControlPlaneServer2")
+    String cloudControlPlaneServer2;
+
+    /**
+     * The netmask for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The gateway for the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The CIDR block for the Exadata administration network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminNetworkCIDR")
+    String adminNetworkCIDR;
+
+    /**
+     * The CIDR block for the Exadata InfiniBand interconnect.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infiniBandNetworkCIDR")
+    String infiniBandNetworkCIDR;
+
+    /**
+     * The corporate network proxy for access to the control plane network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("corporateProxy")
+    String corporateProxy;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dnsServer")
+    java.util.List<String> dnsServer;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
+    java.util.List<String> ntpServer;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterDetails.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for updating the VM cluster.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateVmClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateVmClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+        private LicenseModel licenseModel;
+
+        public Builder licenseModel(LicenseModel licenseModel) {
+            this.licenseModel = licenseModel;
+            this.__explicitlySet__.add("licenseModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+        private java.util.List<String> sshPublicKeys;
+
+        public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
+            this.sshPublicKeys = sshPublicKeys;
+            this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateVmClusterDetails build() {
+            UpdateVmClusterDetails __instance__ =
+                    new UpdateVmClusterDetails(
+                            cpuCoreCount, licenseModel, sshPublicKeys, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateVmClusterDetails o) {
+            Builder copiedBuilder =
+                    cpuCoreCount(o.getCpuCoreCount())
+                            .licenseModel(o.getLicenseModel())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The number of CPU cores to enable for the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid LicenseModel: " + key);
+        }
+    };
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    /**
+     * The public key portion of one or more key pairs used for SSH access to the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+    java.util.List<String> sshPublicKeys;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterNetworkDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterNetworkDetails.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for a VM cluster network.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateVmClusterNetworkDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateVmClusterNetworkDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("scans")
+        private java.util.List<ScanDetails> scans;
+
+        public Builder scans(java.util.List<ScanDetails> scans) {
+            this.scans = scans;
+            this.__explicitlySet__.add("scans");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dns")
+        private java.util.List<String> dns;
+
+        public Builder dns(java.util.List<String> dns) {
+            this.dns = dns;
+            this.__explicitlySet__.add("dns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+        private java.util.List<String> ntp;
+
+        public Builder ntp(java.util.List<String> ntp) {
+            this.ntp = ntp;
+            this.__explicitlySet__.add("ntp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+        private java.util.List<VmNetworkDetails> vmNetworks;
+
+        public Builder vmNetworks(java.util.List<VmNetworkDetails> vmNetworks) {
+            this.vmNetworks = vmNetworks;
+            this.__explicitlySet__.add("vmNetworks");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateVmClusterNetworkDetails build() {
+            UpdateVmClusterNetworkDetails __instance__ =
+                    new UpdateVmClusterNetworkDetails(
+                            scans, dns, ntp, vmNetworks, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateVmClusterNetworkDetails o) {
+            Builder copiedBuilder =
+                    scans(o.getScans())
+                            .dns(o.getDns())
+                            .ntp(o.getNtp())
+                            .vmNetworks(o.getVmNetworks())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The SCAN details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scans")
+    java.util.List<ScanDetails> scans;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dns")
+    java.util.List<String> dns;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+    java.util.List<String> ntp;
+
+    /**
+     * Details of the client and backup networks.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+    java.util.List<VmNetworkDetails> vmNetworks;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the VM cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VmCluster.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmCluster {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+        private Boolean isLocalBackupEnabled;
+
+        public Builder isLocalBackupEnabled(Boolean isLocalBackupEnabled) {
+            this.isLocalBackupEnabled = isLocalBackupEnabled;
+            this.__explicitlySet__.add("isLocalBackupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+        private Boolean isSparseDiskgroupEnabled;
+
+        public Builder isSparseDiskgroupEnabled(Boolean isSparseDiskgroupEnabled) {
+            this.isSparseDiskgroupEnabled = isSparseDiskgroupEnabled;
+            this.__explicitlySet__.add("isSparseDiskgroupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+        private String vmClusterNetworkId;
+
+        public Builder vmClusterNetworkId(String vmClusterNetworkId) {
+            this.vmClusterNetworkId = vmClusterNetworkId;
+            this.__explicitlySet__.add("vmClusterNetworkId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+        private Integer cpusEnabled;
+
+        public Builder cpusEnabled(Integer cpusEnabled) {
+            this.cpusEnabled = cpusEnabled;
+            this.__explicitlySet__.add("cpusEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Integer dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+        private String giVersion;
+
+        public Builder giVersion(String giVersion) {
+            this.giVersion = giVersion;
+            this.__explicitlySet__.add("giVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+        private java.util.List<String> sshPublicKeys;
+
+        public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
+            this.sshPublicKeys = sshPublicKeys;
+            this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+        private LicenseModel licenseModel;
+
+        public Builder licenseModel(LicenseModel licenseModel) {
+            this.licenseModel = licenseModel;
+            this.__explicitlySet__.add("licenseModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmCluster build() {
+            VmCluster __instance__ =
+                    new VmCluster(
+                            id,
+                            compartmentId,
+                            lifecycleState,
+                            displayName,
+                            timeCreated,
+                            lifecycleDetails,
+                            timeZone,
+                            isLocalBackupEnabled,
+                            exadataInfrastructureId,
+                            isSparseDiskgroupEnabled,
+                            vmClusterNetworkId,
+                            cpusEnabled,
+                            dataStorageSizeInTBs,
+                            shape,
+                            giVersion,
+                            sshPublicKeys,
+                            licenseModel,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmCluster o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeZone(o.getTimeZone())
+                            .isLocalBackupEnabled(o.getIsLocalBackupEnabled())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .isSparseDiskgroupEnabled(o.getIsSparseDiskgroupEnabled())
+                            .vmClusterNetworkId(o.getVmClusterNetworkId())
+                            .cpusEnabled(o.getCpusEnabled())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .shape(o.getShape())
+                            .giVersion(o.getGiVersion())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .licenseModel(o.getLicenseModel())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * The current state of the VM cluster.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Updating("UPDATING"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The user-friendly name for the VM cluster. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time that the VM cluster was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+    Boolean isLocalBackupEnabled;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+    Boolean isSparseDiskgroupEnabled;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+    String vmClusterNetworkId;
+
+    /**
+     * The number of enabled CPU cores.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+    Integer cpusEnabled;
+
+    /**
+     * Size, in terabytes, of the DATA disk group.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Integer dataStorageSizeInTBs;
+
+    /**
+     * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * The Oracle Grid Infrastructure software version for the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+    String giVersion;
+
+    /**
+     * The public key portion of one or more key pairs used for SSH access to the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+    java.util.List<String> sshPublicKeys;
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LicenseModel', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetwork.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetwork.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The VM cluster network.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VmClusterNetwork.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmClusterNetwork {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scans")
+        private java.util.List<ScanDetails> scans;
+
+        public Builder scans(java.util.List<ScanDetails> scans) {
+            this.scans = scans;
+            this.__explicitlySet__.add("scans");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dns")
+        private java.util.List<String> dns;
+
+        public Builder dns(java.util.List<String> dns) {
+            this.dns = dns;
+            this.__explicitlySet__.add("dns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+        private java.util.List<String> ntp;
+
+        public Builder ntp(java.util.List<String> ntp) {
+            this.ntp = ntp;
+            this.__explicitlySet__.add("ntp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+        private java.util.List<VmNetworkDetails> vmNetworks;
+
+        public Builder vmNetworks(java.util.List<VmNetworkDetails> vmNetworks) {
+            this.vmNetworks = vmNetworks;
+            this.__explicitlySet__.add("vmNetworks");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmClusterNetwork build() {
+            VmClusterNetwork __instance__ =
+                    new VmClusterNetwork(
+                            id,
+                            exadataInfrastructureId,
+                            compartmentId,
+                            vmClusterId,
+                            displayName,
+                            scans,
+                            dns,
+                            ntp,
+                            vmNetworks,
+                            lifecycleState,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmClusterNetwork o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .compartmentId(o.getCompartmentId())
+                            .vmClusterId(o.getVmClusterId())
+                            .displayName(o.getDisplayName())
+                            .scans(o.getScans())
+                            .dns(o.getDns())
+                            .ntp(o.getNtp())
+                            .vmNetworks(o.getVmNetworks())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated VM Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
+
+    /**
+     * The user-friendly name for the VM cluster network. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The SCAN details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scans")
+    java.util.List<ScanDetails> scans;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dns")
+    java.util.List<String> dns;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+    java.util.List<String> ntp;
+
+    /**
+     * Details of the client and backup networks.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+    java.util.List<VmNetworkDetails> vmNetworks;
+    /**
+     * The current state of the VM cluster network.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        RequiresValidation("REQUIRES_VALIDATION"),
+        Validating("VALIDATING"),
+        Validated("VALIDATED"),
+        ValidationFailed("VALIDATION_FAILED"),
+        Updating("UPDATING"),
+        Allocated("ALLOCATED"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time when the VM cluster network was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetworkDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetworkDetails.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for a VM cluster network.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VmClusterNetworkDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmClusterNetworkDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scans")
+        private java.util.List<ScanDetails> scans;
+
+        public Builder scans(java.util.List<ScanDetails> scans) {
+            this.scans = scans;
+            this.__explicitlySet__.add("scans");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dns")
+        private java.util.List<String> dns;
+
+        public Builder dns(java.util.List<String> dns) {
+            this.dns = dns;
+            this.__explicitlySet__.add("dns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+        private java.util.List<String> ntp;
+
+        public Builder ntp(java.util.List<String> ntp) {
+            this.ntp = ntp;
+            this.__explicitlySet__.add("ntp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+        private java.util.List<VmNetworkDetails> vmNetworks;
+
+        public Builder vmNetworks(java.util.List<VmNetworkDetails> vmNetworks) {
+            this.vmNetworks = vmNetworks;
+            this.__explicitlySet__.add("vmNetworks");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmClusterNetworkDetails build() {
+            VmClusterNetworkDetails __instance__ =
+                    new VmClusterNetworkDetails(
+                            compartmentId,
+                            displayName,
+                            scans,
+                            dns,
+                            ntp,
+                            vmNetworks,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmClusterNetworkDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .scans(o.getScans())
+                            .dns(o.getDns())
+                            .ntp(o.getNtp())
+                            .vmNetworks(o.getVmNetworks())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the VM cluster network. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The SCAN details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scans")
+    java.util.List<ScanDetails> scans;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dns")
+    java.util.List<String> dns;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+    java.util.List<String> ntp;
+
+    /**
+     * Details of the client and backup networks.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+    java.util.List<VmNetworkDetails> vmNetworks;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetworkSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterNetworkSummary.java
@@ -1,0 +1,353 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the VM cluster network.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VmClusterNetworkSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmClusterNetworkSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+        private String vmClusterId;
+
+        public Builder vmClusterId(String vmClusterId) {
+            this.vmClusterId = vmClusterId;
+            this.__explicitlySet__.add("vmClusterId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scans")
+        private java.util.List<ScanDetails> scans;
+
+        public Builder scans(java.util.List<ScanDetails> scans) {
+            this.scans = scans;
+            this.__explicitlySet__.add("scans");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dns")
+        private java.util.List<String> dns;
+
+        public Builder dns(java.util.List<String> dns) {
+            this.dns = dns;
+            this.__explicitlySet__.add("dns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+        private java.util.List<String> ntp;
+
+        public Builder ntp(java.util.List<String> ntp) {
+            this.ntp = ntp;
+            this.__explicitlySet__.add("ntp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+        private java.util.List<VmNetworkDetails> vmNetworks;
+
+        public Builder vmNetworks(java.util.List<VmNetworkDetails> vmNetworks) {
+            this.vmNetworks = vmNetworks;
+            this.__explicitlySet__.add("vmNetworks");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmClusterNetworkSummary build() {
+            VmClusterNetworkSummary __instance__ =
+                    new VmClusterNetworkSummary(
+                            id,
+                            exadataInfrastructureId,
+                            compartmentId,
+                            vmClusterId,
+                            displayName,
+                            scans,
+                            dns,
+                            ntp,
+                            vmNetworks,
+                            lifecycleState,
+                            timeCreated,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmClusterNetworkSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .compartmentId(o.getCompartmentId())
+                            .vmClusterId(o.getVmClusterId())
+                            .displayName(o.getDisplayName())
+                            .scans(o.getScans())
+                            .dns(o.getDns())
+                            .ntp(o.getNtp())
+                            .vmNetworks(o.getVmNetworks())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated VM Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterId")
+    String vmClusterId;
+
+    /**
+     * The user-friendly name for the VM cluster network. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The SCAN details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scans")
+    java.util.List<ScanDetails> scans;
+
+    /**
+     * The list of DNS server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dns")
+    java.util.List<String> dns;
+
+    /**
+     * The list of NTP server IP addresses. Maximum of 3 allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ntp")
+    java.util.List<String> ntp;
+
+    /**
+     * Details of the client and backup networks.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmNetworks")
+    java.util.List<VmNetworkDetails> vmNetworks;
+    /**
+     * The current state of the VM cluster network.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        RequiresValidation("REQUIRES_VALIDATION"),
+        Validating("VALIDATING"),
+        Validated("VALIDATED"),
+        ValidationFailed("VALIDATION_FAILED"),
+        Updating("UPDATING"),
+        Allocated("ALLOCATED"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time when the VM cluster network was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the VM cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VmClusterSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmClusterSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+        private Boolean isLocalBackupEnabled;
+
+        public Builder isLocalBackupEnabled(Boolean isLocalBackupEnabled) {
+            this.isLocalBackupEnabled = isLocalBackupEnabled;
+            this.__explicitlySet__.add("isLocalBackupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+        private Boolean isSparseDiskgroupEnabled;
+
+        public Builder isSparseDiskgroupEnabled(Boolean isSparseDiskgroupEnabled) {
+            this.isSparseDiskgroupEnabled = isSparseDiskgroupEnabled;
+            this.__explicitlySet__.add("isSparseDiskgroupEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+        private String vmClusterNetworkId;
+
+        public Builder vmClusterNetworkId(String vmClusterNetworkId) {
+            this.vmClusterNetworkId = vmClusterNetworkId;
+            this.__explicitlySet__.add("vmClusterNetworkId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+        private Integer cpusEnabled;
+
+        public Builder cpusEnabled(Integer cpusEnabled) {
+            this.cpusEnabled = cpusEnabled;
+            this.__explicitlySet__.add("cpusEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Integer dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+        private String giVersion;
+
+        public Builder giVersion(String giVersion) {
+            this.giVersion = giVersion;
+            this.__explicitlySet__.add("giVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+        private java.util.List<String> sshPublicKeys;
+
+        public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
+            this.sshPublicKeys = sshPublicKeys;
+            this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+        private LicenseModel licenseModel;
+
+        public Builder licenseModel(LicenseModel licenseModel) {
+            this.licenseModel = licenseModel;
+            this.__explicitlySet__.add("licenseModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmClusterSummary build() {
+            VmClusterSummary __instance__ =
+                    new VmClusterSummary(
+                            id,
+                            compartmentId,
+                            lifecycleState,
+                            displayName,
+                            timeCreated,
+                            lifecycleDetails,
+                            timeZone,
+                            isLocalBackupEnabled,
+                            exadataInfrastructureId,
+                            isSparseDiskgroupEnabled,
+                            vmClusterNetworkId,
+                            cpusEnabled,
+                            dataStorageSizeInTBs,
+                            shape,
+                            giVersion,
+                            sshPublicKeys,
+                            licenseModel,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmClusterSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .lifecycleState(o.getLifecycleState())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeZone(o.getTimeZone())
+                            .isLocalBackupEnabled(o.getIsLocalBackupEnabled())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .isSparseDiskgroupEnabled(o.getIsSparseDiskgroupEnabled())
+                            .vmClusterNetworkId(o.getVmClusterNetworkId())
+                            .cpusEnabled(o.getCpusEnabled())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .shape(o.getShape())
+                            .giVersion(o.getGiVersion())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .licenseModel(o.getLicenseModel())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+    /**
+     * The current state of the VM cluster.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Updating("UPDATING"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The user-friendly name for the VM cluster. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time that the VM cluster was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The time zone of the Exadata infrastructure. For details, see [Exadata Infrastructure Time Zones](https://docs.cloud.oracle.com/Content/Database/References/timezones.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    String timeZone;
+
+    /**
+     * If true, database backup on local Exadata storage is configured for the VM cluster. If false, database backup on local Exadata storage is not available in the VM cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLocalBackupEnabled")
+    Boolean isLocalBackupEnabled;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * If true, sparse disk group is configured for the VM cluster. If false, sparse disk group is not created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSparseDiskgroupEnabled")
+    Boolean isSparseDiskgroupEnabled;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster network.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterNetworkId")
+    String vmClusterNetworkId;
+
+    /**
+     * The number of enabled CPU cores.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpusEnabled")
+    Integer cpusEnabled;
+
+    /**
+     * Size, in terabytes, of the DATA disk group.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Integer dataStorageSizeInTBs;
+
+    /**
+     * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * The Oracle Grid Infrastructure software version for the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
+    String giVersion;
+
+    /**
+     * The public key portion of one or more key pairs used for SSH access to the VM cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+    java.util.List<String> sshPublicKeys;
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LicenseModel', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle license model that applies to the VM cluster. The default is LICENSE_INCLUDED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmNetworkDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmNetworkDetails.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the client or backup networks in a VM cluster network.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VmNetworkDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class VmNetworkDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vlanId")
+        private String vlanId;
+
+        public Builder vlanId(String vlanId) {
+            this.vlanId = vlanId;
+            this.__explicitlySet__.add("vlanId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+        private NetworkType networkType;
+
+        public Builder networkType(NetworkType networkType) {
+            this.networkType = networkType;
+            this.__explicitlySet__.add("networkType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+        private String netmask;
+
+        public Builder netmask(String netmask) {
+            this.netmask = netmask;
+            this.__explicitlySet__.add("netmask");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+        private String gateway;
+
+        public Builder gateway(String gateway) {
+            this.gateway = gateway;
+            this.__explicitlySet__.add("gateway");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("domainName")
+        private String domainName;
+
+        public Builder domainName(String domainName) {
+            this.domainName = domainName;
+            this.__explicitlySet__.add("domainName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<NodeDetails> nodes;
+
+        public Builder nodes(java.util.List<NodeDetails> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VmNetworkDetails build() {
+            VmNetworkDetails __instance__ =
+                    new VmNetworkDetails(vlanId, networkType, netmask, gateway, domainName, nodes);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VmNetworkDetails o) {
+            Builder copiedBuilder =
+                    vlanId(o.getVlanId())
+                            .networkType(o.getNetworkType())
+                            .netmask(o.getNetmask())
+                            .gateway(o.getGateway())
+                            .domainName(o.getDomainName())
+                            .nodes(o.getNodes());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The network VLAN ID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vlanId")
+    String vlanId;
+    /**
+     * The network type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum NetworkType {
+        Client("CLIENT"),
+        Backup("BACKUP"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, NetworkType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NetworkType v : NetworkType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        NetworkType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NetworkType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'NetworkType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The network type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+    NetworkType networkType;
+
+    /**
+     * The network netmask.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("netmask")
+    String netmask;
+
+    /**
+     * The network gateway.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("gateway")
+    String gateway;
+
+    /**
+     * The network domain name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("domainName")
+    String domainName;
+
+    /**
+     * The list of node details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<NodeDetails> nodes;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ActivateExadataInfrastructureRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ActivateExadataInfrastructureRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ActivateExadataInfrastructureRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The activation details for the Exadata infrastructure.
+     */
+    private ActivateExadataInfrastructureDetails activateExadataInfrastructureDetails;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ActivateExadataInfrastructureRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            activateExadataInfrastructureDetails(o.getActivateExadataInfrastructureDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ActivateExadataInfrastructureRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ActivateExadataInfrastructureRequest
+         */
+        public ActivateExadataInfrastructureRequest build() {
+            ActivateExadataInfrastructureRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeBackupDestinationCompartmentRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeBackupDestinationCompartmentRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeBackupDestinationCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to move backup destination to a different compartment
+     *
+     */
+    private ChangeCompartmentDetails changeCompartmentDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     */
+    private String backupDestinationId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBackupDestinationCompartmentRequest o) {
+            changeCompartmentDetails(o.getChangeCompartmentDetails());
+            backupDestinationId(o.getBackupDestinationId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeBackupDestinationCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeBackupDestinationCompartmentRequest
+         */
+        public ChangeBackupDestinationCompartmentRequest build() {
+            ChangeBackupDestinationCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeExadataInfrastructureCompartmentRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeExadataInfrastructureCompartmentRequest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeExadataInfrastructureCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to move Exadata infrastructure to a different compartment
+     */
+    private ChangeExadataInfrastructureCompartmentDetails
+            changeExadataInfrastructureCompartmentDetails;
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeExadataInfrastructureCompartmentRequest o) {
+            changeExadataInfrastructureCompartmentDetails(
+                    o.getChangeExadataInfrastructureCompartmentDetails());
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeExadataInfrastructureCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeExadataInfrastructureCompartmentRequest
+         */
+        public ChangeExadataInfrastructureCompartmentRequest build() {
+            ChangeExadataInfrastructureCompartmentRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeVmClusterCompartmentRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ChangeVmClusterCompartmentRequest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeVmClusterCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to move VM cluster to a different compartment
+     */
+    private ChangeVmClusterCompartmentDetails changeVmClusterCompartmentDetails;
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeVmClusterCompartmentRequest o) {
+            changeVmClusterCompartmentDetails(o.getChangeVmClusterCompartmentDetails());
+            vmClusterId(o.getVmClusterId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeVmClusterCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeVmClusterCompartmentRequest
+         */
+        public ChangeVmClusterCompartmentRequest build() {
+            ChangeVmClusterCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateBackupDestinationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateBackupDestinationRequest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateBackupDestinationRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to create a new backup destination.
+     *
+     */
+    private CreateBackupDestinationDetails createBackupDestinationDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBackupDestinationRequest o) {
+            createBackupDestinationDetails(o.getCreateBackupDestinationDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateBackupDestinationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateBackupDestinationRequest
+         */
+        public CreateBackupDestinationRequest build() {
+            CreateBackupDestinationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateDbHomeRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateDbHomeRequest.java
@@ -13,7 +13,7 @@ public class CreateDbHomeRequest extends com.oracle.bmc.requests.BmcRequest {
     /**
      * Request to create a new database home.
      */
-    private CreateDbHomeWithDbSystemIdBase createDbHomeWithDbSystemIdDetails;
+    private CreateDbHomeBase createDbHomeWithDbSystemIdDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case of a timeout or

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateExadataInfrastructureRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateExadataInfrastructureRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateExadataInfrastructureRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to create Exadata infrastructure.
+     */
+    private CreateExadataInfrastructureDetails createExadataInfrastructureDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateExadataInfrastructureRequest o) {
+            createExadataInfrastructureDetails(o.getCreateExadataInfrastructureDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateExadataInfrastructureRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateExadataInfrastructureRequest
+         */
+        public CreateExadataInfrastructureRequest build() {
+            CreateExadataInfrastructureRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateVmClusterNetworkRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * Request to create the VM cluster network.
+     */
+    private VmClusterNetworkDetails vmClusterNetworkDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkDetails(o.getVmClusterNetworkDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateVmClusterNetworkRequest
+         */
+        public CreateVmClusterNetworkRequest build() {
+            CreateVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/CreateVmClusterRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateVmClusterRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to create a VM cluster.
+     */
+    private CreateVmClusterDetails createVmClusterDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVmClusterRequest o) {
+            createVmClusterDetails(o.getCreateVmClusterDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateVmClusterRequest
+         */
+        public CreateVmClusterRequest build() {
+            CreateVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteBackupDestinationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteBackupDestinationRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteBackupDestinationRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     */
+    private String backupDestinationId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBackupDestinationRequest o) {
+            backupDestinationId(o.getBackupDestinationId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteBackupDestinationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteBackupDestinationRequest
+         */
+        public DeleteBackupDestinationRequest build() {
+            DeleteBackupDestinationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteExadataInfrastructureRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteExadataInfrastructureRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteExadataInfrastructureRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteExadataInfrastructureRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteExadataInfrastructureRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteExadataInfrastructureRequest
+         */
+        public DeleteExadataInfrastructureRequest build() {
+            DeleteExadataInfrastructureRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteVmClusterNetworkRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The VM cluster network [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterNetworkId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkId(o.getVmClusterNetworkId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteVmClusterNetworkRequest
+         */
+        public DeleteVmClusterNetworkRequest build() {
+            DeleteVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeleteVmClusterRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteVmClusterRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVmClusterRequest o) {
+            vmClusterId(o.getVmClusterId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteVmClusterRequest
+         */
+        public DeleteVmClusterRequest build() {
+            DeleteVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DownloadExadataInfrastructureConfigFileRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DownloadExadataInfrastructureConfigFileRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DownloadExadataInfrastructureConfigFileRequest
+        extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DownloadExadataInfrastructureConfigFileRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DownloadExadataInfrastructureConfigFileRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DownloadExadataInfrastructureConfigFileRequest
+         */
+        public DownloadExadataInfrastructureConfigFileRequest build() {
+            DownloadExadataInfrastructureConfigFileRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DownloadVmClusterNetworkConfigFileRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DownloadVmClusterNetworkConfigFileRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DownloadVmClusterNetworkConfigFileRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The VM cluster network [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterNetworkId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DownloadVmClusterNetworkConfigFileRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkId(o.getVmClusterNetworkId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DownloadVmClusterNetworkConfigFileRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DownloadVmClusterNetworkConfigFileRequest
+         */
+        public DownloadVmClusterNetworkConfigFileRequest build() {
+            DownloadVmClusterNetworkConfigFileRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GenerateRecommendedVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GenerateRecommendedVmClusterNetworkRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GenerateRecommendedVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * Request to generate a recommended VM cluster network configuration.
+     */
+    private GenerateRecommendedNetworkDetails generateRecommendedNetworkDetails;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateRecommendedVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            generateRecommendedNetworkDetails(o.getGenerateRecommendedNetworkDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GenerateRecommendedVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GenerateRecommendedVmClusterNetworkRequest
+         */
+        public GenerateRecommendedVmClusterNetworkRequest build() {
+            GenerateRecommendedVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetBackupDestinationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetBackupDestinationRequest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetBackupDestinationRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     */
+    private String backupDestinationId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBackupDestinationRequest o) {
+            backupDestinationId(o.getBackupDestinationId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetBackupDestinationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetBackupDestinationRequest
+         */
+        public GetBackupDestinationRequest build() {
+            GetBackupDestinationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetExadataInfrastructureRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetExadataInfrastructureRequest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetExadataInfrastructureRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetExadataInfrastructureRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetExadataInfrastructureRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetExadataInfrastructureRequest
+         */
+        public GetExadataInfrastructureRequest build() {
+            GetExadataInfrastructureRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterNetworkRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The VM cluster network [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterNetworkId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkId(o.getVmClusterNetworkId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVmClusterNetworkRequest
+         */
+        public GetVmClusterNetworkRequest build() {
+            GetVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterRequest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetVmClusterRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterRequest o) {
+            vmClusterId(o.getVmClusterId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVmClusterRequest
+         */
+        public GetVmClusterRequest build() {
+            GetVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListBackupDestinationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListBackupDestinationRequest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListBackupDestinationRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A filter to return only resources that match the given type of the Backup Destination.
+     */
+    private String type;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBackupDestinationRequest o) {
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            type(o.getType());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBackupDestinationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBackupDestinationRequest
+         */
+        public ListBackupDestinationRequest build() {
+            ListBackupDestinationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbHomesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbHomesRequest.java
@@ -21,6 +21,11 @@ public class ListDbHomesRequest extends com.oracle.bmc.requests.BmcRequest {
     private String dbSystemId;
 
     /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     */
+    private String vmClusterId;
+
+    /**
      * The maximum number of items to return per page.
      */
     private Integer limit;
@@ -157,6 +162,7 @@ public class ListDbHomesRequest extends com.oracle.bmc.requests.BmcRequest {
         public Builder copy(ListDbHomesRequest o) {
             compartmentId(o.getCompartmentId());
             dbSystemId(o.getDbSystemId());
+            vmClusterId(o.getVmClusterId());
             limit(o.getLimit());
             page(o.getPage());
             sortBy(o.getSortBy());

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbNodesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbNodesRequest.java
@@ -21,6 +21,11 @@ public class ListDbNodesRequest extends com.oracle.bmc.requests.BmcRequest {
     private String dbSystemId;
 
     /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM cluster.
+     */
+    private String vmClusterId;
+
+    /**
      * The maximum number of items to return per page.
      */
     private Integer limit;
@@ -151,6 +156,7 @@ public class ListDbNodesRequest extends com.oracle.bmc.requests.BmcRequest {
         public Builder copy(ListDbNodesRequest o) {
             compartmentId(o.getCompartmentId());
             dbSystemId(o.getDbSystemId());
+            vmClusterId(o.getVmClusterId());
             limit(o.getLimit());
             page(o.getPage());
             sortBy(o.getSortBy());

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemShapesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbSystemShapesRequest.java
@@ -11,14 +11,14 @@ import com.oracle.bmc.database.model.*;
 public class ListDbSystemShapesRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The name of the Availability Domain.
-     */
-    private String availabilityDomain;
-
-    /**
      * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
      */
     private String compartmentId;
+
+    /**
+     * The name of the Availability Domain.
+     */
+    private String availabilityDomain;
 
     /**
      * The maximum number of items to return per page.
@@ -63,8 +63,8 @@ public class ListDbSystemShapesRequest extends com.oracle.bmc.requests.BmcReques
          * @return this builder instance
          */
         public Builder copy(ListDbSystemShapesRequest o) {
-            availabilityDomain(o.getAvailabilityDomain());
             compartmentId(o.getCompartmentId());
+            availabilityDomain(o.getAvailabilityDomain());
             limit(o.getLimit());
             page(o.getPage());
             invocationCallback(o.getInvocationCallback());

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListExadataInfrastructuresRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListExadataInfrastructuresRequest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListExadataInfrastructuresRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortBy: " + key);
+        }
+    };
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortOrder: " + key);
+        }
+    };
+
+    /**
+     * A filter to return only resources that match the given lifecycle state exactly.
+     */
+    private ExadataInfrastructureSummary.LifecycleState lifecycleState;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListExadataInfrastructuresRequest o) {
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListExadataInfrastructuresRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListExadataInfrastructuresRequest
+         */
+        public ListExadataInfrastructuresRequest build() {
+            ListExadataInfrastructuresRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListGiVersionsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListGiVersionsRequest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListGiVersionsRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortOrder: " + key);
+        }
+    };
+
+    /**
+     * If provided, filters the results for the given shape.
+     */
+    private String shape;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListGiVersionsRequest o) {
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            shape(o.getShape());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListGiVersionsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListGiVersionsRequest
+         */
+        public ListGiVersionsRequest build() {
+            ListGiVersionsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterNetworksRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterNetworksRequest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListVmClusterNetworksRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortBy: " + key);
+        }
+    };
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortOrder: " + key);
+        }
+    };
+
+    /**
+     * A filter to return only resources that match the given lifecycle state exactly.
+     */
+    private VmClusterNetworkSummary.LifecycleState lifecycleState;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterNetworksRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVmClusterNetworksRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVmClusterNetworksRequest
+         */
+        public ListVmClusterNetworksRequest build() {
+            ListVmClusterNetworksRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClustersRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClustersRequest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListVmClustersRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * If provided, filters the results for the given Exadata Infrastructure.
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortBy: " + key);
+        }
+    };
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new RuntimeException("Invalid SortOrder: " + key);
+        }
+    };
+
+    /**
+     * A filter to return only resources that match the given lifecycle state exactly.
+     */
+    private VmClusterSummary.LifecycleState lifecycleState;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClustersRequest o) {
+            compartmentId(o.getCompartmentId());
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVmClustersRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVmClustersRequest
+         */
+        public ListVmClustersRequest build() {
+            ListVmClustersRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateBackupDestinationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateBackupDestinationRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateBackupDestinationRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup destination.
+     */
+    private String backupDestinationId;
+
+    /**
+     * For a RECOVERY_APPLIANCE backup destination, request to update the connection string and/or the list of VPC users.
+     * For an NFS backup destination, request to update the NFS location.
+     *
+     */
+    private UpdateBackupDestinationDetails updateBackupDestinationDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBackupDestinationRequest o) {
+            backupDestinationId(o.getBackupDestinationId());
+            updateBackupDestinationDetails(o.getUpdateBackupDestinationDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateBackupDestinationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateBackupDestinationRequest
+         */
+        public UpdateBackupDestinationRequest build() {
+            UpdateBackupDestinationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateExadataInfrastructureRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateExadataInfrastructureRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateExadataInfrastructureRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * Request to update the properties of an Exadata infrastructure
+     */
+    private UpdateExadataInfrastructureDetails updateExadataInfrastructureDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateExadataInfrastructureRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            updateExadataInfrastructureDetails(o.getUpdateExadataInfrastructureDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateExadataInfrastructureRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateExadataInfrastructureRequest
+         */
+        public UpdateExadataInfrastructureRequest build() {
+            UpdateExadataInfrastructureRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateVmClusterNetworkRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The VM cluster network [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterNetworkId;
+
+    /**
+     * Request to update the properties of a VM cluster network.
+     */
+    private UpdateVmClusterNetworkDetails updateVmClusterNetworkDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkId(o.getVmClusterNetworkId());
+            updateVmClusterNetworkDetails(o.getUpdateVmClusterNetworkDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateVmClusterNetworkRequest
+         */
+        public UpdateVmClusterNetworkRequest build() {
+            UpdateVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateVmClusterRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateVmClusterRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * Request to update the attributes of a VM cluster.
+     */
+    private UpdateVmClusterDetails updateVmClusterDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVmClusterRequest o) {
+            vmClusterId(o.getVmClusterId());
+            updateVmClusterDetails(o.getUpdateVmClusterDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateVmClusterRequest
+         */
+        public UpdateVmClusterRequest build() {
+            UpdateVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ValidateVmClusterNetworkRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ValidateVmClusterNetworkRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ValidateVmClusterNetworkRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The Exadata infrastructure [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The VM cluster network [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterNetworkId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ValidateVmClusterNetworkRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            vmClusterNetworkId(o.getVmClusterNetworkId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ValidateVmClusterNetworkRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ValidateVmClusterNetworkRequest
+         */
+        public ValidateVmClusterNetworkRequest build() {
+            ValidateVmClusterNetworkRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ActivateExadataInfrastructureResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ActivateExadataInfrastructureResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ActivateExadataInfrastructureResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ExadataInfrastructure instance.
+     */
+    private ExadataInfrastructure exadataInfrastructure;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ActivateExadataInfrastructureResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            exadataInfrastructure(o.getExadataInfrastructure());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeBackupDestinationCompartmentResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeBackupDestinationCompartmentResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeBackupDestinationCompartmentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier of the work request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBackupDestinationCompartmentResponse o) {
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeExadataInfrastructureCompartmentResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeExadataInfrastructureCompartmentResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeExadataInfrastructureCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier of the work request.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeExadataInfrastructureCompartmentResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeVmClusterCompartmentResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ChangeVmClusterCompartmentResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeVmClusterCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier of the work request.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeVmClusterCompartmentResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateBackupDestinationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateBackupDestinationResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateBackupDestinationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BackupDestination instance.
+     */
+    private BackupDestination backupDestination;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBackupDestinationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            backupDestination(o.getBackupDestination());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateExadataInfrastructureResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateExadataInfrastructureResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateExadataInfrastructureResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ExadataInfrastructure instance.
+     */
+    private ExadataInfrastructure exadataInfrastructure;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateExadataInfrastructureResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            exadataInfrastructure(o.getExadataInfrastructure());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateVmClusterNetworkResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateVmClusterNetworkResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmClusterNetwork instance.
+     */
+    private VmClusterNetwork vmClusterNetwork;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVmClusterNetworkResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmClusterNetwork(o.getVmClusterNetwork());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/CreateVmClusterResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateVmClusterResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmCluster instance.
+     */
+    private VmCluster vmCluster;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVmClusterResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmCluster(o.getVmCluster());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteBackupDestinationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteBackupDestinationResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteBackupDestinationResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBackupDestinationResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteExadataInfrastructureResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteExadataInfrastructureResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteExadataInfrastructureResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteExadataInfrastructureResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteVmClusterNetworkResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteVmClusterNetworkResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVmClusterNetworkResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DeleteVmClusterResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteVmClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVmClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DownloadExadataInfrastructureConfigFileResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DownloadExadataInfrastructureConfigFileResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DownloadExadataInfrastructureConfigFileResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Size of the file.
+     */
+    private Long contentLength;
+
+    /**
+     * The date and time the configuration file was created, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     */
+    private java.util.Date lastModified;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DownloadExadataInfrastructureConfigFileResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            contentLength(o.getContentLength());
+            lastModified(o.getLastModified());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DownloadVmClusterNetworkConfigFileResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DownloadVmClusterNetworkConfigFileResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DownloadVmClusterNetworkConfigFileResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Size of the file.
+     */
+    private Long contentLength;
+
+    /**
+     * The date and time the configuration file was created, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     */
+    private java.util.Date lastModified;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DownloadVmClusterNetworkConfigFileResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            contentLength(o.getContentLength());
+            lastModified(o.getLastModified());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GenerateRecommendedVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GenerateRecommendedVmClusterNetworkResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GenerateRecommendedVmClusterNetworkResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmClusterNetworkDetails instance.
+     */
+    private VmClusterNetworkDetails vmClusterNetworkDetails;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateRecommendedVmClusterNetworkResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmClusterNetworkDetails(o.getVmClusterNetworkDetails());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetBackupDestinationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetBackupDestinationResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetBackupDestinationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BackupDestination instance.
+     */
+    private BackupDestination backupDestination;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBackupDestinationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            backupDestination(o.getBackupDestination());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetExadataInfrastructureResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetExadataInfrastructureResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetExadataInfrastructureResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ExadataInfrastructure instance.
+     */
+    private ExadataInfrastructure exadataInfrastructure;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetExadataInfrastructureResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            exadataInfrastructure(o.getExadataInfrastructure());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterNetworkResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetVmClusterNetworkResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmClusterNetwork instance.
+     */
+    private VmClusterNetwork vmClusterNetwork;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterNetworkResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmClusterNetwork(o.getVmClusterNetwork());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetVmClusterResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmCluster instance.
+     */
+    private VmCluster vmCluster;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmCluster(o.getVmCluster());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListBackupDestinationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListBackupDestinationResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListBackupDestinationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of BackupDestinationSummary instances.
+     */
+    private java.util.List<BackupDestinationSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBackupDestinationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListExadataInfrastructuresResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListExadataInfrastructuresResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListExadataInfrastructuresResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of ExadataInfrastructureSummary instances.
+     */
+    private java.util.List<ExadataInfrastructureSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListExadataInfrastructuresResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListGiVersionsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListGiVersionsResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListGiVersionsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of GiVersionSummary instances.
+     */
+    private java.util.List<GiVersionSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListGiVersionsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterNetworksResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterNetworksResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListVmClusterNetworksResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of VmClusterNetworkSummary instances.
+     */
+    private java.util.List<VmClusterNetworkSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterNetworksResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClustersResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClustersResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListVmClustersResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of VmClusterSummary instances.
+     */
+    private java.util.List<VmClusterSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClustersResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateBackupDestinationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateBackupDestinationResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateBackupDestinationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned BackupDestination instance.
+     */
+    private BackupDestination backupDestination;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBackupDestinationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            backupDestination(o.getBackupDestination());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateExadataInfrastructureResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateExadataInfrastructureResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateExadataInfrastructureResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ExadataInfrastructure instance.
+     */
+    private ExadataInfrastructure exadataInfrastructure;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateExadataInfrastructureResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            exadataInfrastructure(o.getExadataInfrastructure());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateVmClusterNetworkResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateVmClusterNetworkResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmClusterNetwork instance.
+     */
+    private VmClusterNetwork vmClusterNetwork;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVmClusterNetworkResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmClusterNetwork(o.getVmClusterNetwork());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateVmClusterResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateVmClusterResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmCluster instance.
+     */
+    private VmCluster vmCluster;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVmClusterResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmCluster(o.getVmCluster());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ValidateVmClusterNetworkResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ValidateVmClusterNetworkResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ValidateVmClusterNetworkResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmClusterNetwork instance.
+     */
+    private VmClusterNetwork vmClusterNetwork;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ValidateVmClusterNetworkResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmClusterNetwork(o.getVmClusterNetwork());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/AutonomousTransactionProcessingSharedExample.java
+++ b/bmc-examples/src/main/java/AutonomousTransactionProcessingSharedExample.java
@@ -50,14 +50,25 @@ public class AutonomousTransactionProcessingSharedExample {
         // Create
         CreateAutonomousDatabaseDetails createRequest = createAtpRequest(compartmentId);
 
+        CreateAutonomousDatabaseDetails createFreeRequest = createFreeTierAtpRequest(compartmentId);
+
         System.out.println(
                 "Creating Autonomous Transaction Processing Shared with request : "
                         + createRequest);
         AutonomousDatabase atpShared = createATP(dbClient, createRequest);
         System.out.println("ATP Shared instance is provisioning : " + atpShared);
 
+        System.out.println(
+                "Creating Free Autonomous Transaction Processing Shared with request : "
+                        + createFreeRequest);
+        AutonomousDatabase freeAtpShared = createATP(dbClient, createFreeRequest);
+        System.out.println("Free ATP Shared instance is provisioning : " + freeAtpShared);
+
         atpShared = waitForInstanceToBecomeAvailable(dbClient, atpShared.getId());
+        freeAtpShared = waitForInstanceToBecomeAvailable(dbClient, freeAtpShared.getId());
+
         System.out.println("Instance is provisioned:" + atpShared);
+        System.out.println("Free Instance is provisioned:" + freeAtpShared);
 
         //Clone
         CreateAutonomousDatabaseCloneDetails createAutonomousDatabaseCloneDetails =
@@ -179,6 +190,22 @@ public class AutonomousTransactionProcessingSharedExample {
                                 AutonomousDatabase.LifecycleState.Terminated)
                         .execute();
 
+        // Delete Free Tier Database
+        System.out.println(
+                "Deleting Free Autonomous Transaction Processing Shared : " + freeAtpShared);
+        dbClient.deleteAutonomousDatabase(
+                DeleteAutonomousDatabaseRequest.builder()
+                        .autonomousDatabaseId(freeAtpShared.getId())
+                        .build());
+        waiter = dbClient.getWaiters();
+        response =
+                waiter.forAutonomousDatabase(
+                                GetAutonomousDatabaseRequest.builder()
+                                        .autonomousDatabaseId(freeAtpShared.getId())
+                                        .build(),
+                                AutonomousDatabase.LifecycleState.Terminated)
+                        .execute();
+
         dbClient.close();
     }
 
@@ -250,6 +277,23 @@ public class AutonomousTransactionProcessingSharedExample {
                 .isAutoScalingEnabled(Boolean.FALSE)
                 .licenseModel(CreateAutonomousDatabaseDetails.LicenseModel.LicenseIncluded)
                 .isPreviewVersionWithServiceTermsAccepted(Boolean.FALSE)
+                .build();
+    }
+
+    private static CreateAutonomousDatabaseDetails createFreeTierAtpRequest(String compartmentId) {
+        Random rand = new Random();
+        return CreateAutonomousDatabaseDetails.builder()
+                .cpuCoreCount(1)
+                .dataStorageSizeInTBs(1)
+                .displayName("javaSdkExample")
+                .adminPassword("DBaaS12345_#")
+                .dbName("javaSdkExam" + rand.nextInt(500))
+                .compartmentId(compartmentId)
+                .dbWorkload(CreateAutonomousDatabaseDetails.DbWorkload.Oltp)
+                .isAutoScalingEnabled(Boolean.FALSE)
+                .licenseModel(CreateAutonomousDatabaseDetails.LicenseModel.LicenseIncluded)
+                .isPreviewVersionWithServiceTermsAccepted(Boolean.FALSE)
+                .isFreeTier(Boolean.TRUE)
                 .build();
     }
 

--- a/bmc-examples/src/main/java/BackupDestinationExample.java
+++ b/bmc-examples/src/main/java/BackupDestinationExample.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.database.DatabaseClient;
+import com.oracle.bmc.database.DatabaseWaiters;
+import com.oracle.bmc.database.model.CreateBackupDestinationDetails;
+import com.oracle.bmc.database.model.CreateNFSBackupDestinationDetails;
+import com.oracle.bmc.database.model.CreateRecoveryApplianceBackupDestinationDetails;
+import com.oracle.bmc.database.model.UpdateBackupDestinationDetails;
+import com.oracle.bmc.database.requests.CreateBackupDestinationRequest;
+import com.oracle.bmc.database.requests.DeleteBackupDestinationRequest;
+import com.oracle.bmc.database.requests.GetBackupDestinationRequest;
+import com.oracle.bmc.database.requests.UpdateBackupDestinationRequest;
+import com.oracle.bmc.database.responses.CreateBackupDestinationResponse;
+import com.oracle.bmc.database.responses.DeleteBackupDestinationResponse;
+import com.oracle.bmc.database.responses.GetBackupDestinationResponse;
+import com.oracle.bmc.database.responses.UpdateBackupDestinationResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides an example of CRUD(Create, read, update, delete) operations on BackupDestination using the Java SDK.
+ * <p></p>
+ * <ul>
+ *   <li>
+ *     For general documentation refer to :-
+ *       <a href="https://docs.us-phoenix-1.oraclecloud.com/Content/Database/Concepts/overview.htm">overview</a>
+ *       for more information</li>
+ * </ul>
+ */
+public class BackupDestinationExample {
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+    private static final String displayName = "displayName";
+
+    private static DatabaseClient databaseClient = null;
+    private static final Map<String, Opts> mappings =
+            Arrays.stream(Opts.values()).collect(Collectors.toMap(Opts::getArgName, o -> o));
+
+    /**
+     * Defines the arguments for this example.
+     */
+    @AllArgsConstructor
+    private enum Opts {
+        COMPARTMENT_OCID("--compartmentOcid", "The OCID of compartment.", true),
+        BACKUP_DESTINATION_TYPE("--backupDestinationType", "Type of backup destination", true),
+        VPC_USER("--vpcUser", "vpcuser for the ZDLRA type of backup destination", false),
+        LOCAL_MOUNT_PATH(
+                "--localMountPath", "localMountPath for NFS type of backup destination", false),
+        CONNECTION_STRING(
+                "--connectionString",
+                "connectionString for ZDLRA type of backup destination",
+                false);
+        @Getter public final String argName;
+        @Getter public final String description;
+        @Getter public final boolean required;
+    }
+
+    /**
+     * A helper method for parsing command line arguments.
+     *
+     * @param argv the arguments as passed
+     * @return a mapping of argument to its value. Arguments may be missing from the map if they were not supplied by
+     * the user and not required.
+     */
+    private static Map<Opts, String> parseOpts(@NonNull String[] argv) {
+        final Iterable<String> iterable = Arrays.asList(argv);
+        final Iterator<String> iterator = iterable.iterator();
+        final Map<Opts, String> argsMap = new HashMap<>();
+
+        while (iterator.hasNext()) {
+            String token = iterator.next();
+            if (mappings.containsKey(token)) {
+                if (iterator.hasNext()) {
+                    argsMap.put(mappings.get(token), iterator.next());
+                } else {
+                    throw new IllegalArgumentException("Missing value for parameter " + token);
+                }
+            } else {
+                throw new IllegalArgumentException("Unknown parameter " + token);
+            }
+        }
+
+        Arrays.stream(Opts.values())
+                .filter(Opts::isRequired)
+                .filter(opt -> !argsMap.containsKey(opt))
+                .findAny()
+                .ifPresent(
+                        opts -> {
+                            throw new IllegalArgumentException(
+                                    "Missing required parameter " + opts.argName);
+                        });
+
+        return argsMap;
+    }
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     *             <ul>
+     *             <li>Compartment OCID</li>
+     *             </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        final Map<Opts, String> argumentMap = parseOpts(args);
+
+        final String compartmentId = argumentMap.get(Opts.COMPARTMENT_OCID);
+        final String backupdestinationType = argumentMap.get(Opts.BACKUP_DESTINATION_TYPE);
+        final String localMountPath = argumentMap.get(Opts.LOCAL_MOUNT_PATH);
+        final String vpcUser = argumentMap.getOrDefault(Opts.VPC_USER, null);
+        final String connectionString = argumentMap.getOrDefault(Opts.CONNECTION_STRING, null);
+
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(CONFIG_LOCATION, CONFIG_PROFILE);
+        databaseClient = new DatabaseClient(provider);
+
+        List<String> vpcusers = new ArrayList<>();
+        vpcusers.add(vpcUser);
+
+        //Create Backup Destination
+        CreateBackupDestinationDetails backupDestinationDetails =
+                createBackupDestinationDetails(
+                        compartmentId,
+                        backupdestinationType,
+                        vpcusers,
+                        connectionString,
+                        localMountPath);
+
+        CreateBackupDestinationResponse createBackupDestinationResponse =
+                databaseClient.createBackupDestination(
+                        CreateBackupDestinationRequest.builder()
+                                .createBackupDestinationDetails(backupDestinationDetails)
+                                .build());
+
+        com.oracle.bmc.database.model.BackupDestination backupDestination =
+                createBackupDestinationResponse.getBackupDestination();
+
+        //Get Backup Destination
+        backupDestination =
+                databaseClient
+                        .getBackupDestination(
+                                GetBackupDestinationRequest.builder()
+                                        .backupDestinationId(backupDestination.getId())
+                                        .build())
+                        .getBackupDestination();
+
+        System.out.println("GET request returned :" + backupDestination);
+
+        //Update
+        UpdateBackupDestinationDetails updateBackupDestinationDetails =
+                updateBackupDestinationDetails(backupdestinationType, vpcusers);
+        UpdateBackupDestinationResponse updateResponse =
+                databaseClient.updateBackupDestination(
+                        UpdateBackupDestinationRequest.builder()
+                                .updateBackupDestinationDetails(updateBackupDestinationDetails)
+                                .backupDestinationId(backupDestination.getId())
+                                .build());
+
+        backupDestination = updateResponse.getBackupDestination();
+
+        //Delete
+        DeleteBackupDestinationResponse deleteResponse =
+                databaseClient.deleteBackupDestination(
+                        DeleteBackupDestinationRequest.builder()
+                                .backupDestinationId(backupDestination.getId())
+                                .build());
+
+        DatabaseWaiters waiter = databaseClient.getWaiters();
+        GetBackupDestinationResponse response =
+                waiter.forBackupDestination(
+                                GetBackupDestinationRequest.builder()
+                                        .backupDestinationId(backupDestination.getId())
+                                        .build(),
+                                com.oracle.bmc.database.model.BackupDestination.LifecycleState
+                                        .Deleted)
+                        .execute();
+
+        databaseClient.close();
+    }
+
+    private static UpdateBackupDestinationDetails updateBackupDestinationDetails(
+            String type, List<String> vpcUsers) throws Exception {
+        UpdateBackupDestinationDetails updateBackupDestinationDetails = null;
+
+        switch (type) {
+            case "ZDLRA":
+                vpcUsers.add("New User");
+                updateBackupDestinationDetails =
+                        UpdateBackupDestinationDetails.builder().vpcUsers(vpcUsers).build();
+                break;
+            case "NFS":
+                updateBackupDestinationDetails =
+                        UpdateBackupDestinationDetails.builder()
+                                .localMountPointPath("Updated Path")
+                                .build();
+                break;
+            default:
+                throw new Exception("Enter a valid type value from NFS or ZDLRA");
+        }
+
+        return updateBackupDestinationDetails;
+    }
+
+    private static CreateBackupDestinationDetails createBackupDestinationDetails(
+            String compartmentId,
+            String type,
+            List<String> vpcUsers,
+            String connectionString,
+            String localMountPath)
+            throws Exception {
+        CreateBackupDestinationDetails createBackupDestinationDetails = null;
+
+        switch (type) {
+            case "ZDLRA":
+                createBackupDestinationDetails =
+                        CreateRecoveryApplianceBackupDestinationDetails.builder()
+                                .compartmentId(compartmentId)
+                                .displayName(displayName)
+                                .vpcUsers(vpcUsers)
+                                .connectionString(connectionString)
+                                .build();
+                break;
+            case "NFS":
+                createBackupDestinationDetails =
+                        CreateNFSBackupDestinationDetails.builder()
+                                .compartmentId(compartmentId)
+                                .displayName(displayName)
+                                .localMountPointPath(localMountPath)
+                                .build();
+                break;
+            default:
+                throw new Exception("Enter a valid type value from NFS or ZDLRA");
+        }
+
+        return createBackupDestinationDetails;
+    }
+}

--- a/bmc-examples/src/main/java/BackupDestinationHelper.java
+++ b/bmc-examples/src/main/java/BackupDestinationHelper.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.database.model.BackupDestinationDetails;
+
+public class BackupDestinationHelper {
+
+    public static BackupDestinationDetails backupDestinationDetailsCreater(
+            String type, String backupdestinationOcid, String vpcUser, String vpcPassword)
+            throws Exception {
+        BackupDestinationDetails backupDestinationDetails = null;
+
+        switch (type) {
+            case "ZDLRA":
+                backupDestinationDetails =
+                        BackupDestinationDetails.builder()
+                                .id(backupdestinationOcid)
+                                .type(BackupDestinationDetails.Type.RecoveryAppliance)
+                                .vpcUser(vpcUser)
+                                .vpcPassword(vpcPassword)
+                                .build();
+                break;
+            case "NFS":
+                backupDestinationDetails =
+                        BackupDestinationDetails.builder()
+                                .id(backupdestinationOcid)
+                                .type(BackupDestinationDetails.Type.Nfs)
+                                .build();
+                break;
+            case "ObjectStorage":
+                backupDestinationDetails =
+                        BackupDestinationDetails.builder()
+                                .id(backupdestinationOcid)
+                                .type(BackupDestinationDetails.Type.ObjectStore)
+                                .build();
+                break;
+            case "Local":
+                backupDestinationDetails =
+                        BackupDestinationDetails.builder()
+                                .id(backupdestinationOcid)
+                                .type(BackupDestinationDetails.Type.Local)
+                                .build();
+                break;
+            default:
+                throw new Exception(
+                        "Enter a valid type value from NFS, ZDLRA, Local, ObjectStorage");
+        }
+
+        return backupDestinationDetails;
+    }
+}

--- a/bmc-examples/src/main/java/CreateDbHomeBackupDestinationExample.java
+++ b/bmc-examples/src/main/java/CreateDbHomeBackupDestinationExample.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.database.DatabaseClient;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides a basic example of how to create a DbHome with BackupDestination using the Java SDK. This will cover:
+ * <p></p>
+ * <ul>
+ *   <li>Create a BackupDestination for the DbHome to be created.</li>
+ *   <li>
+ *     Creating DBHome with BackupDestination. See:
+ *       <a href="https://docs.us-phoenix-1.oraclecloud.com/Content/Database/Concepts/overview.htm">overview</a>
+ *       for more information</li>
+ * </ul>
+ */
+public class CreateDbHomeBackupDestinationExample {
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+    private static final String DEFAULT_VERSION = "18.0.0.0";
+    private static DatabaseClient databaseClient = null;
+    private static final Map<String, Opts> mappings =
+            Arrays.stream(Opts.values()).collect(Collectors.toMap(Opts::getArgName, o -> o));
+
+    /**
+     * Defines the arguments for this example.
+     */
+    @AllArgsConstructor
+    private enum Opts {
+        VM_CLUSTER_OCID("--vmClusterOcid", "The OCID of a VmCluster.", true, null),
+        DB_NAME(
+                "--dbName",
+                "A DbName. Generates a value if not specified.",
+                false,
+                o -> RandomStringUtils.randomAlphabetic(8)),
+        DB_UNIQUE_NAME(
+                "--dbUniqueName",
+                "A DbUniqueName. Generates a value if not specified.",
+                false,
+                dbName -> dbName + "_" + RandomStringUtils.randomAlphabetic(2, 16)),
+        DB_PASSWORD(
+                "--dbPassword",
+                "The admin password for your DB. Generates a value if not specified.",
+                false,
+                o ->
+                        RandomStringUtils.random(16, "abcdefgABCDEFG#-_1234567890")
+                                + RandomStringUtils.random(2, "abcdefg")
+                                + RandomStringUtils.random(2, "ABCDEFG")
+                                + RandomStringUtils.random(2, "#-_")
+                                + RandomStringUtils.random(2, "1234567890")),
+        DB_VERSION(
+                "--dbVersion",
+                String.format(
+                        "The version to use. Defaults to %s if not specified.", DEFAULT_VERSION),
+                false,
+                o -> DEFAULT_VERSION),
+        BACKUP_DESTINATION_OCID(
+                "--backupDestinationOcid", "The OCID of a backup destination.", true, null),
+        BACKUP_DESTINATION_TYPE(
+                "--backupDestinationType", "Type of backup destination", true, null),
+        VPC_USER("--vpcUser", "vpcuser for the ZDLRA type of backup destination", false, null),
+        VPC_PASSWORD(
+                "--vpcPassword",
+                "vpcPassword for the ZDLRA type of backup destination",
+                false,
+                null);
+        @Getter public final String argName;
+        @Getter public final String description;
+        @Getter public final boolean required;
+        @Getter public final Function<Object, String> defaultSupplier;
+    }
+
+    /**
+     * A helper method for parsing command line arguments.
+     *
+     * @param argv the arguments as passed
+     * @return a mapping of argument to its value. Arguments may be missing from the map if they were not supplied by
+     * the user and not required.
+     */
+    private static Map<Opts, String> parseOpts(@NonNull String[] argv) {
+        final Iterable<String> iterable = Arrays.asList(argv);
+        final Iterator<String> iterator = iterable.iterator();
+        final Map<Opts, String> argsMap = new HashMap<>();
+
+        while (iterator.hasNext()) {
+            String token = iterator.next();
+            if (mappings.containsKey(token)) {
+                if (iterator.hasNext()) {
+                    argsMap.put(mappings.get(token), iterator.next());
+                } else {
+                    throw new IllegalArgumentException("Missing value for parameter " + token);
+                }
+            } else {
+                throw new IllegalArgumentException("Unknown parameter " + token);
+            }
+        }
+
+        Arrays.stream(Opts.values())
+                .filter(Opts::isRequired)
+                .filter(opt -> !argsMap.containsKey(opt))
+                .findAny()
+                .ifPresent(
+                        opts -> {
+                            throw new IllegalArgumentException(
+                                    "Missing required parameter " + opts.argName);
+                        });
+
+        return argsMap;
+    }
+
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     *             <ul>
+     *             <li>VM-cluster OCID</li>
+     *             <li>Compartment OCID</li>
+     *             <li>Database Name</li>
+     *             <li>Database Unique Name</li>
+     *             <li>Database Password</li>
+     *             <li>DatabaseVersion</li>
+     *             </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        final Map<Opts, String> argumentMap = parseOpts(args);
+        final String vmClusterOcid = argumentMap.get(Opts.VM_CLUSTER_OCID);
+        final String dbName =
+                argumentMap.getOrDefault(
+                        Opts.DB_NAME, Opts.DB_NAME.getDefaultSupplier().apply(null));
+        final String dbUniqueName =
+                argumentMap.getOrDefault(
+                        Opts.DB_UNIQUE_NAME,
+                        Opts.DB_UNIQUE_NAME.getDefaultSupplier().apply(dbName));
+        final String dbPassword =
+                argumentMap.getOrDefault(
+                        Opts.DB_PASSWORD, Opts.DB_PASSWORD.getDefaultSupplier().apply(null));
+        final String version =
+                argumentMap.getOrDefault(
+                        Opts.DB_VERSION, Opts.DB_VERSION.getDefaultSupplier().apply(null));
+        final String backupDestinationId = argumentMap.get(Opts.BACKUP_DESTINATION_OCID);
+        final String backupDestinationType = argumentMap.get(Opts.BACKUP_DESTINATION_TYPE);
+        final String vpcUser = argumentMap.getOrDefault(Opts.VPC_USER, null);
+        final String vpcPassword = argumentMap.getOrDefault(Opts.VPC_PASSWORD, null);
+
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(CONFIG_LOCATION, CONFIG_PROFILE);
+        databaseClient = new DatabaseClient(provider);
+
+        final BackupDestinationDetails backupDestinationDetails =
+                BackupDestinationHelper.backupDestinationDetailsCreater(
+                        backupDestinationType, backupDestinationId, vpcUser, vpcPassword);
+
+        List<BackupDestinationDetails> list = new ArrayList<>();
+        list.add(backupDestinationDetails);
+
+        final CreateDatabaseDetails databaseDetails =
+                CreateDatabaseDetails.builder()
+                        .adminPassword(dbPassword)
+                        .dbName(dbName)
+                        .dbBackupConfig(
+                                DbBackupConfig.builder().backupDestinationDetails(list).build())
+                        .dbUniqueName(dbUniqueName)
+                        .build();
+
+        final CreateDbHomeBase details =
+                CreateDbHomeWithVmClusterIdDetails.builder()
+                        .displayName(RandomStringUtils.randomPrint(4, 96))
+                        .database(databaseDetails)
+                        .vmClusterId(vmClusterOcid)
+                        .dbVersion(version)
+                        .build();
+
+        final CreateDbHomeRequest request =
+                CreateDbHomeRequest.builder().createDbHomeWithDbSystemIdDetails(details).build();
+
+        CreateDbHomeResponse response = databaseClient.createDbHome(request);
+
+        if (response == null) {
+            throw new RuntimeException("Response from server was null.");
+        } else if (response.getDbHome() == null
+                || StringUtils.isBlank(response.getDbHome().getId())) {
+            throw new RuntimeException(
+                    "Response from server did not contain expected data! request id: "
+                            + response.getOpcRequestId());
+        } else {
+            System.out.println(response.getDbHome().getId());
+        }
+    }
+}

--- a/bmc-examples/src/main/java/UpdateDbBackupDestinationExample.java
+++ b/bmc-examples/src/main/java/UpdateDbBackupDestinationExample.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.database.DatabaseClient;
+import com.oracle.bmc.database.model.BackupDestinationDetails;
+import com.oracle.bmc.database.model.DbBackupConfig;
+import com.oracle.bmc.database.model.UpdateDatabaseDetails;
+import com.oracle.bmc.database.requests.UpdateDatabaseRequest;
+import com.oracle.bmc.database.responses.UpdateDatabaseResponse;
+import com.oracle.bmc.http.ResteasyClientConfigurator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This class provides a basic example of how to update a database with BackupDestination using the Java SDK.
+ * <p></p>
+ * <ul>
+ *   <li>
+ *     Updating database with backupDestination. See:
+ *       <a href="https://docs.us-phoenix-1.oraclecloud.com/Content/Database/Concepts/overview.htm">overview</a>
+ *       for more information</li>
+ * </ul>
+ */
+public class UpdateDbBackupDestinationExample {
+
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+    private static DatabaseClient databaseClient = null;
+
+    private static final Map<String, Opts> mappings =
+            Arrays.stream(Opts.values()).collect(Collectors.toMap(Opts::getArgName, o -> o));
+
+    /**
+     * Defines the arguments for this example.
+     */
+    @AllArgsConstructor
+    private enum Opts {
+        DATABASE_OCID("--databaseOcid", "The OCID of a database.", true),
+        BACKUP_DESTINATION_OCID(
+                "--backupDestinationOcid", "The OCID of a backup destination.", true),
+        BACKUP_DESTINATION_TYPE("--backupDestinationType", "Type of backup destination", true),
+        VPC_USER("--vpcUser", "vpcuser for the ZDLRA type of backup destination", false),
+        VPC_PASSWORD(
+                "--vpcPassword", "vpcPassword for the ZDLRA type of backup destination", false);
+        @Getter public final String argName;
+        @Getter public final String description;
+        @Getter public final boolean required;
+    }
+
+    /**
+     * A helper method for parsing command line arguments.
+     *
+     * @param argv the arguments as passed
+     * @return a mapping of argument to its value. Arguments may be missing from the map if they were not supplied by
+     * the user and not required.
+     */
+    private static Map<Opts, String> parseOpts(@NonNull String[] argv) {
+        final Iterable<String> iterable = Arrays.asList(argv);
+        final Iterator<String> iterator = iterable.iterator();
+        final Map<Opts, String> argsMap = new HashMap<>();
+
+        while (iterator.hasNext()) {
+            String token = iterator.next();
+            if (mappings.containsKey(token)) {
+                if (iterator.hasNext()) {
+                    argsMap.put(mappings.get(token), iterator.next());
+                } else {
+                    throw new IllegalArgumentException("Missing value for parameter " + token);
+                }
+            } else {
+                throw new IllegalArgumentException("Unknown parameter " + token);
+            }
+        }
+
+        Arrays.stream(Opts.values())
+                .filter(Opts::isRequired)
+                .filter(opt -> !argsMap.containsKey(opt))
+                .findAny()
+                .ifPresent(
+                        opts -> {
+                            throw new IllegalArgumentException(
+                                    "Missing required parameter " + opts.argName);
+                        });
+
+        return argsMap;
+    }
+
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     *             <ul>
+     *             <li>Database OCID</li>
+     *             <li>BackupDestination OCID</li>
+     *             <li>BackupDestination Type</li>
+     *             </ul>
+     *             vpcUser and vpcPassword arguments are required for ZDLRA case.
+     */
+    public static void main(String[] args) throws Exception {
+
+        final Map<Opts, String> argumentMap = parseOpts(args);
+
+        final String databaseId = argumentMap.get(Opts.DATABASE_OCID);
+        final String backupdestinationId = argumentMap.get(Opts.BACKUP_DESTINATION_OCID);
+        final String backupdestinationType = argumentMap.get(Opts.BACKUP_DESTINATION_TYPE);
+        final String vpcUser = argumentMap.getOrDefault(Opts.VPC_USER, null);
+        final String vpcPassword = argumentMap.getOrDefault(Opts.VPC_PASSWORD, null);
+
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(CONFIG_LOCATION, CONFIG_PROFILE);
+
+        databaseClient = new DatabaseClient(provider);
+
+        final BackupDestinationDetails backupDestinationDetails =
+                BackupDestinationHelper.backupDestinationDetailsCreater(
+                        backupdestinationType, backupdestinationId, vpcUser, vpcPassword);
+
+        List<BackupDestinationDetails> list = new ArrayList<>();
+        list.add(backupDestinationDetails);
+
+        UpdateDatabaseDetails updateDatabaseDetails =
+                UpdateDatabaseDetails.builder()
+                        .dbBackupConfig(
+                                DbBackupConfig.builder().backupDestinationDetails(list).build())
+                        .build();
+
+        final UpdateDatabaseRequest request =
+                UpdateDatabaseRequest.builder()
+                        .databaseId(databaseId)
+                        .updateDatabaseDetails(updateDatabaseDetails)
+                        .build();
+
+        UpdateDatabaseResponse response = databaseClient.updateDatabase(request);
+
+        if (response == null) {
+            throw new RuntimeException("Response from server was null.");
+        } else if (response.getDatabase() == null
+                || StringUtils.isBlank(response.getDatabase().getId())) {
+            throw new RuntimeException(
+                    "Response from server did not contain expected data! request id: "
+                            + response.getOpcRequestId());
+        } else {
+            System.out.println(response.getDatabase().getId() + " is updated.");
+        }
+    }
+}

--- a/bmc-examples/src/main/java/exacc/ExadataCloudAtCustomerResourcesExample.java
+++ b/bmc-examples/src/main/java/exacc/ExadataCloudAtCustomerResourcesExample.java
@@ -1,0 +1,509 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package exacc;
+
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.database.DatabaseClient;
+import com.oracle.bmc.database.model.ActivateExadataInfrastructureDetails;
+import com.oracle.bmc.database.model.CreateExadataInfrastructureDetails;
+import com.oracle.bmc.database.model.CreateVmClusterDetails;
+import com.oracle.bmc.database.model.ExadataInfrastructure;
+import com.oracle.bmc.database.model.ExadataInfrastructureSummary;
+import com.oracle.bmc.database.model.GenerateRecommendedNetworkDetails;
+import com.oracle.bmc.database.model.InfoForNetworkGenDetails;
+import com.oracle.bmc.database.model.UpdateExadataInfrastructureDetails;
+import com.oracle.bmc.database.model.UpdateVmClusterDetails;
+import com.oracle.bmc.database.model.UpdateVmClusterNetworkDetails;
+import com.oracle.bmc.database.model.VmCluster;
+import com.oracle.bmc.database.model.VmClusterNetwork;
+import com.oracle.bmc.database.model.VmClusterNetworkDetails;
+import com.oracle.bmc.database.requests.ActivateExadataInfrastructureRequest;
+import com.oracle.bmc.database.requests.CreateExadataInfrastructureRequest;
+import com.oracle.bmc.database.requests.CreateVmClusterNetworkRequest;
+import com.oracle.bmc.database.requests.CreateVmClusterRequest;
+import com.oracle.bmc.database.requests.DeleteExadataInfrastructureRequest;
+import com.oracle.bmc.database.requests.DeleteVmClusterNetworkRequest;
+import com.oracle.bmc.database.requests.DeleteVmClusterRequest;
+import com.oracle.bmc.database.requests.GenerateRecommendedVmClusterNetworkRequest;
+import com.oracle.bmc.database.requests.GetExadataInfrastructureRequest;
+import com.oracle.bmc.database.requests.GetVmClusterNetworkRequest;
+import com.oracle.bmc.database.requests.GetVmClusterRequest;
+import com.oracle.bmc.database.requests.ListExadataInfrastructuresRequest;
+import com.oracle.bmc.database.requests.UpdateExadataInfrastructureRequest;
+import com.oracle.bmc.database.requests.UpdateVmClusterNetworkRequest;
+import com.oracle.bmc.database.requests.UpdateVmClusterRequest;
+import com.oracle.bmc.database.requests.ValidateVmClusterNetworkRequest;
+import com.oracle.bmc.database.responses.CreateExadataInfrastructureResponse;
+import com.oracle.bmc.database.responses.CreateVmClusterNetworkResponse;
+import com.oracle.bmc.database.responses.CreateVmClusterResponse;
+import com.oracle.bmc.database.responses.ListExadataInfrastructuresResponse;
+import com.oracle.bmc.database.responses.UpdateVmClusterNetworkResponse;
+import com.oracle.bmc.database.responses.UpdateVmClusterResponse;
+import com.oracle.bmc.waiter.ExponentialBackoffDelayStrategy;
+import com.oracle.bmc.waiter.MaxTimeTerminationStrategy;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.commons.io.FileUtils.readFileToByteArray;
+
+/**
+ * This class provides a basic example of CRUD(Create, read, update, delete) operations on Exadata Cloud at Customer (ExaCC) Resources: Exadata Infrastructure, VmClusterNetwork and VmCluster using the Java SDK.
+ *  * <p></p>
+ *  * Resources created by this class will be removed when this example is done.
+ *  * <p></p>
+ *  * This class also makes assumptions on the following parameters:
+ *  * <p></p>
+ *  * <ul>
+ *  *   <li>OCID of the compartment</li>
+ *  *   <li>Activation Key File path or activating Exadata Infrastructure<</li>
+ *  *   <li>SSH Public key for Vm Cluster<</li>
+ *  * </ul>
+ */
+public class ExadataCloudAtCustomerResourcesExample {
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+    private static final String shape = "Exadata.Quarter3.100";
+
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     *             <ul>
+     *             <li>The OCID of the compartment</li>
+     *             <li>Activation Key File path for activating Exadata Infrastructure</li>
+     *             </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            throw new IllegalAccessException(
+                    "This example expects two arguments: "
+                            + "a compartment OCID,  Activation Key file path and SSH Public key for Vm Cluster");
+        }
+
+        final String compartmentId = args[0];
+        final String activationFilePath = args[1];
+        final String sshPublicKey = args[2];
+
+        final ConfigFileReader.ConfigFile configFile =
+                ConfigFileReader.parse(CONFIG_LOCATION, CONFIG_PROFILE);
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+        final DatabaseClient databaseClient = new DatabaseClient(provider);
+        final String exadataInfrastructureId =
+                createExadataInfrastructure(databaseClient, compartmentId);
+
+        // Get
+        waitForExadataInfrastructure(
+                databaseClient,
+                exadataInfrastructureId,
+                ExadataInfrastructure.LifecycleState.RequiresActivation);
+
+        System.out.println(
+                "ExaCC Infrastructure is in REQUIRES_ACTIVATION state " + exadataInfrastructureId);
+        System.out.println("===========================");
+
+        // Update
+        UpdateExadataInfrastructureDetails updateExadataInfrastructureDetails =
+                UpdateExadataInfrastructureDetails.builder().netmask("255.255.240.1").build();
+
+        UpdateExadataInfrastructureRequest updateExadataInfrastructureRequest =
+                UpdateExadataInfrastructureRequest.builder()
+                        .exadataInfrastructureId(exadataInfrastructureId)
+                        .updateExadataInfrastructureDetails(updateExadataInfrastructureDetails)
+                        .build();
+
+        databaseClient.updateExadataInfrastructure(updateExadataInfrastructureRequest);
+
+        waitForExadataInfrastructure(
+                databaseClient,
+                exadataInfrastructureId,
+                ExadataInfrastructure.LifecycleState.RequiresActivation);
+
+        // List
+        ListExadataInfrastructuresResponse listExadataInfrastructures =
+                databaseClient.listExadataInfrastructures(
+                        ListExadataInfrastructuresRequest.builder()
+                                .compartmentId(compartmentId)
+                                .build());
+        System.out.println("List of Exadata Infrastructures: ");
+
+        for (ExadataInfrastructureSummary exadataInfrastructureSummary :
+                listExadataInfrastructures.getItems()) {
+            System.out.println(
+                    "Exadata Infrastructure : "
+                            + exadataInfrastructureSummary.getId()
+                            + " is in "
+                            + exadataInfrastructureSummary.getLifecycleState()
+                            + " state.");
+        }
+
+        activateExadataInfrastructure(databaseClient, exadataInfrastructureId, activationFilePath);
+
+        final String vmClusterNetworkId =
+                createVmClusterNetwork(databaseClient, compartmentId, exadataInfrastructureId);
+
+        System.out.println("VM cluster Network OCID : " + vmClusterNetworkId);
+
+        waitForVmClusterNetwork(
+                databaseClient,
+                exadataInfrastructureId,
+                vmClusterNetworkId,
+                VmClusterNetwork.LifecycleState.RequiresValidation);
+
+        System.out.println("VM Cluster Network is in REQUIRES_VALIDATION state ");
+        System.out.println("===========================");
+
+        final String new_dns = "10.89.138.33";
+        List<String> dns = new ArrayList<>();
+        dns.add(new_dns);
+
+        UpdateVmClusterNetworkDetails updateVmClusterNetworkDetails =
+                UpdateVmClusterNetworkDetails.builder().dns(dns).build();
+
+        UpdateVmClusterNetworkResponse updateVmClusterNetworkResponse =
+                databaseClient.updateVmClusterNetwork(
+                        UpdateVmClusterNetworkRequest.builder()
+                                .vmClusterNetworkId(vmClusterNetworkId)
+                                .exadataInfrastructureId(exadataInfrastructureId)
+                                .updateVmClusterNetworkDetails(updateVmClusterNetworkDetails)
+                                .build());
+
+        waitForVmClusterNetwork(
+                databaseClient,
+                exadataInfrastructureId,
+                vmClusterNetworkId,
+                VmClusterNetwork.LifecycleState.RequiresValidation);
+
+        System.out.println(
+                "state after update: "
+                        + updateVmClusterNetworkResponse.getVmClusterNetwork().getLifecycleState());
+
+        System.out.println(
+                "DNS after update: "
+                        + updateVmClusterNetworkResponse.getVmClusterNetwork().getDns());
+
+        ValidateVmClusterNetworkRequest validateVmClusterNetworkRequest =
+                ValidateVmClusterNetworkRequest.builder()
+                        .vmClusterNetworkId(vmClusterNetworkId)
+                        .exadataInfrastructureId(exadataInfrastructureId)
+                        .build();
+
+        databaseClient.validateVmClusterNetwork(validateVmClusterNetworkRequest);
+
+        waitForVmClusterNetwork(
+                databaseClient,
+                exadataInfrastructureId,
+                vmClusterNetworkId,
+                VmClusterNetwork.LifecycleState.Validated);
+
+        final String vmClusterId =
+                createVmCluster(
+                        databaseClient,
+                        compartmentId,
+                        exadataInfrastructureId,
+                        vmClusterNetworkId,
+                        sshPublicKey);
+
+        System.out.println("VM cluster OCID : " + vmClusterId);
+        waitForVmCluster(databaseClient, vmClusterId, VmCluster.LifecycleState.Available);
+
+        UpdateVmClusterDetails updateVmClusterDetails =
+                UpdateVmClusterDetails.builder()
+                        .licenseModel(UpdateVmClusterDetails.LicenseModel.LicenseIncluded)
+                        .build();
+        UpdateVmClusterResponse updateVmClusterResponse =
+                databaseClient.updateVmCluster(
+                        UpdateVmClusterRequest.builder()
+                                .updateVmClusterDetails(updateVmClusterDetails)
+                                .vmClusterId(vmClusterId)
+                                .build());
+        waitForVmCluster(databaseClient, vmClusterId, VmCluster.LifecycleState.Available);
+
+        System.out.println(
+                "new license model for vm cluster: "
+                        + updateVmClusterResponse.getVmCluster().getLicenseModel());
+
+        deleteVmCluster(databaseClient, vmClusterId);
+        deleteVmClusterNetwork(databaseClient, vmClusterNetworkId, exadataInfrastructureId);
+        deleteExadataInfrastructure(databaseClient, exadataInfrastructureId);
+    }
+
+    private static String createExadataInfrastructure(
+            DatabaseClient databaseClient, String compartmentId) {
+
+        final String dns_server = "10.89.138.33";
+        final String ntp_server = "10.89.138.33";
+        final String adminNetworkCIDR = "10.31.16.0/20";
+        final String cloudControlPlaneServer1 = "10.31.153.83";
+        final String cloudControlPlaneServer2 = "10.31.153.84";
+        final String corporateProxy = "fake-proxy.us.oracle.com";
+        final String displayName = "ExaCC_Infra";
+        final String gateway = "10.31.16.1";
+        final String infiniBandNetworkCIDR = "192.168.31.0/24";
+        final String netmask = "255.255.240.0";
+        final String timeZone = "UTC";
+
+        List<String> dnsServer = new ArrayList();
+        dnsServer.add(dns_server);
+
+        List<String> ntpServer = new ArrayList();
+        ntpServer.add(ntp_server);
+
+        CreateExadataInfrastructureDetails createExadataInfrastructureDetails =
+                CreateExadataInfrastructureDetails.builder()
+                        .adminNetworkCIDR(adminNetworkCIDR)
+                        .cloudControlPlaneServer1(cloudControlPlaneServer1)
+                        .cloudControlPlaneServer2(cloudControlPlaneServer2)
+                        .compartmentId(compartmentId)
+                        .corporateProxy(corporateProxy)
+                        .displayName(displayName)
+                        .dnsServer(dnsServer)
+                        .gateway(gateway)
+                        .infiniBandNetworkCIDR(infiniBandNetworkCIDR)
+                        .netmask(netmask)
+                        .ntpServer(ntpServer)
+                        .shape(shape)
+                        .timeZone(timeZone)
+                        .build();
+
+        CreateExadataInfrastructureResponse createExadataInfrastructureResponse =
+                databaseClient.createExadataInfrastructure(
+                        CreateExadataInfrastructureRequest.builder()
+                                .createExadataInfrastructureDetails(
+                                        createExadataInfrastructureDetails)
+                                .build());
+
+        System.out.println("Created Exadata Infrastructre.");
+        return createExadataInfrastructureResponse.getExadataInfrastructure().getId();
+    }
+
+    private static String createVmClusterNetwork(
+            DatabaseClient databaseClient, String compartmentId, String exadataInfrastructureId) {
+
+        CreateVmClusterNetworkRequest createVmClusterNetworkRequest =
+                CreateVmClusterNetworkRequest.builder()
+                        .exadataInfrastructureId(exadataInfrastructureId)
+                        .vmClusterNetworkDetails(
+                                generateRecommendedVmClusterNetwork(databaseClient, compartmentId))
+                        .build();
+
+        CreateVmClusterNetworkResponse createVmClusterNetworkResponse =
+                databaseClient.createVmClusterNetwork(createVmClusterNetworkRequest);
+
+        System.out.println("Created Vm Cluster Network");
+        return createVmClusterNetworkResponse.getVmClusterNetwork().getId();
+    }
+
+    private static String createVmCluster(
+            DatabaseClient databaseClient,
+            String compartmentId,
+            String exadataInfrastructureId,
+            String vmClusterNetworkId,
+            String sshPublicKey) {
+
+        final int cpuCoreCount = 22;
+        final String giVersion = "18.0.0.0";
+        final String displayName = "vmcluster";
+
+        CreateVmClusterDetails createVmClusterDetails =
+                CreateVmClusterDetails.builder()
+                        .compartmentId(compartmentId)
+                        .cpuCoreCount(cpuCoreCount)
+                        .displayName(displayName)
+                        .exadataInfrastructureId(exadataInfrastructureId)
+                        .giVersion(giVersion)
+                        .licenseModel(CreateVmClusterDetails.LicenseModel.BringYourOwnLicense)
+                        .sshPublicKeys(Arrays.asList(sshPublicKey))
+                        .vmClusterNetworkId(vmClusterNetworkId)
+                        .build();
+
+        CreateVmClusterRequest createVmClusterRequest =
+                CreateVmClusterRequest.builder()
+                        .createVmClusterDetails(createVmClusterDetails)
+                        .build();
+
+        CreateVmClusterResponse createVmClusterResponse =
+                databaseClient.createVmCluster(createVmClusterRequest);
+        return createVmClusterResponse.getVmCluster().getId();
+    }
+
+    //Once we're done with the ExaCC Infrastructure, we can terminate it and wait for it to be terminated.
+    private static void deleteExadataInfrastructure(DatabaseClient databaseClient, String ocid)
+            throws Exception {
+        databaseClient.deleteExadataInfrastructure(
+                DeleteExadataInfrastructureRequest.builder().exadataInfrastructureId(ocid).build());
+        waitForExadataInfrastructure(
+                databaseClient, ocid, ExadataInfrastructure.LifecycleState.Deleted);
+        System.out.println("Terminated ExaCC Infrastructure");
+    }
+
+    //Once we're done with the Vm Cluster Network , we can terminate it and wait for it to be terminated.
+    private static void deleteVmClusterNetwork(
+            DatabaseClient databaseClient,
+            String vmClusterNetworkOcid,
+            String exadataInfrastructureOcid)
+            throws Exception {
+        databaseClient.deleteVmClusterNetwork(
+                DeleteVmClusterNetworkRequest.builder()
+                        .vmClusterNetworkId(vmClusterNetworkOcid)
+                        .exadataInfrastructureId(exadataInfrastructureOcid)
+                        .build());
+        waitForVmClusterNetwork(
+                databaseClient,
+                exadataInfrastructureOcid,
+                vmClusterNetworkOcid,
+                VmClusterNetwork.LifecycleState.Terminated);
+        System.out.println("Terminated VM Cluster Network");
+    }
+
+    //Once we're done with the Vm Cluster, we can terminate it and wait for it to be terminated.
+    private static void deleteVmCluster(DatabaseClient databaseClient, String ocid)
+            throws Exception {
+
+        databaseClient.deleteVmCluster(DeleteVmClusterRequest.builder().vmClusterId(ocid).build());
+        waitForVmCluster(databaseClient, ocid, VmCluster.LifecycleState.Terminated);
+        System.out.println("Terminated VM Cluster");
+    }
+
+    private static void waitForExadataInfrastructure(
+            DatabaseClient databaseClient,
+            String ocid,
+            ExadataInfrastructure.LifecycleState targetState)
+            throws Exception {
+        databaseClient
+                .getWaiters()
+                .forExadataInfrastructure(
+                        GetExadataInfrastructureRequest.builder()
+                                .exadataInfrastructureId(ocid)
+                                .build(),
+                        targetState,
+                        new MaxTimeTerminationStrategy(21600L * 1000),
+                        new ExponentialBackoffDelayStrategy(900L * 1000))
+                .execute();
+    }
+
+    private static void waitForVmClusterNetwork(
+            DatabaseClient databaseClient,
+            String exadataInfrastructureId,
+            String vmClusterNetworkId,
+            VmClusterNetwork.LifecycleState targetState)
+            throws Exception {
+
+        databaseClient
+                .getWaiters()
+                .forVmClusterNetwork(
+                        GetVmClusterNetworkRequest.builder()
+                                .exadataInfrastructureId(exadataInfrastructureId)
+                                .vmClusterNetworkId(vmClusterNetworkId)
+                                .build(),
+                        targetState,
+                        new MaxTimeTerminationStrategy(21600L * 1000),
+                        new ExponentialBackoffDelayStrategy(900L * 1000))
+                .execute();
+    }
+
+    private static void waitForVmCluster(
+            DatabaseClient databaseClient, String ocid, VmCluster.LifecycleState targetState)
+            throws Exception {
+        databaseClient
+                .getWaiters()
+                .forVmCluster(
+                        GetVmClusterRequest.builder().vmClusterId(ocid).build(),
+                        targetState,
+                        new MaxTimeTerminationStrategy(21600L * 1000),
+                        new ExponentialBackoffDelayStrategy(900L * 1000))
+                .execute();
+    }
+
+    private static void activateExadataInfrastructure(
+            DatabaseClient databaseClient,
+            String exadataInfrastructureId,
+            String ACTIVATION_KEY_FILE)
+            throws Exception {
+
+        File file = new File(ACTIVATION_KEY_FILE);
+
+        byte[] bArray = new byte[1024];
+        try {
+            bArray = readFileToByteArray(file);
+        } catch (Exception e) {
+            System.out.println("Failed to read file " + ACTIVATION_KEY_FILE);
+            e.printStackTrace();
+        }
+
+        ActivateExadataInfrastructureDetails activateExadataInfrastructureDetails =
+                ActivateExadataInfrastructureDetails.builder().activationFile(bArray).build();
+
+        ActivateExadataInfrastructureRequest activateExadataInfrastructureRequest =
+                ActivateExadataInfrastructureRequest.builder()
+                        .activateExadataInfrastructureDetails(activateExadataInfrastructureDetails)
+                        .exadataInfrastructureId(exadataInfrastructureId)
+                        .build();
+
+        databaseClient.activateExadataInfrastructure(activateExadataInfrastructureRequest);
+
+        waitForExadataInfrastructure(
+                databaseClient,
+                exadataInfrastructureId,
+                ExadataInfrastructure.LifecycleState.Active);
+    }
+
+    private static VmClusterNetworkDetails generateRecommendedVmClusterNetwork(
+            DatabaseClient databaseClient, String compartmentId) {
+        final String cidr = "192.168.10.0/16";
+        final String domain = "oracleclient.com";
+        final String gateway = "192.168.10.1";
+        final String netmask = "255.255.0.0";
+        final String prefix = "exacc";
+        final String vlanId = "223";
+        final String cidr2 = "172.168.10.0/16";
+        final String domain2 = "oraclebkp.com";
+        final String gateway2 = "192.168.10.5";
+        final String netmask2 = "255.255.0.0";
+        final String prefix2 = "exacc-bkp";
+        final String vlanId2 = "224";
+
+        InfoForNetworkGenDetails networkGenDetails =
+                InfoForNetworkGenDetails.builder()
+                        .cidr(cidr)
+                        .domain(domain)
+                        .gateway(gateway)
+                        .netmask(netmask)
+                        .networkType(InfoForNetworkGenDetails.NetworkType.Client)
+                        .prefix(prefix)
+                        .vlanId(vlanId)
+                        .build();
+
+        InfoForNetworkGenDetails networkGenDetails2 =
+                InfoForNetworkGenDetails.builder()
+                        .cidr(cidr2)
+                        .domain(domain2)
+                        .gateway(gateway2)
+                        .netmask(netmask2)
+                        .networkType(InfoForNetworkGenDetails.NetworkType.Backup)
+                        .prefix(prefix2)
+                        .vlanId(vlanId2)
+                        .build();
+
+        List<InfoForNetworkGenDetails> networks =
+                Arrays.asList(networkGenDetails, networkGenDetails2);
+        GenerateRecommendedVmClusterNetworkRequest generateRecommendedVmClusterNetworkRequest =
+                GenerateRecommendedVmClusterNetworkRequest.builder()
+                        .generateRecommendedNetworkDetails(
+                                GenerateRecommendedNetworkDetails.builder()
+                                        .compartmentId(compartmentId)
+                                        .displayName("vmClusterNetwork")
+                                        .networks(networks)
+                                        .build())
+                        .build();
+        return databaseClient
+                .generateRecommendedVmClusterNetwork(generateRecommendedVmClusterNetworkRequest)
+                .getVmClusterNetworkDetails();
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ApplyJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ApplyJobOperationDetails.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to apply operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApplyJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ApplyJobOperationDetails extends JobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+        private String executionPlanJobId;
+
+        public Builder executionPlanJobId(String executionPlanJobId) {
+            this.executionPlanJobId = executionPlanJobId;
+            this.__explicitlySet__.add("executionPlanJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApplyJobOperationDetails build() {
+            ApplyJobOperationDetails __instance__ =
+                    new ApplyJobOperationDetails(executionPlanStrategy, executionPlanJobId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApplyJobOperationDetails o) {
+            Builder copiedBuilder =
+                    executionPlanStrategy(o.getExecutionPlanStrategy())
+                            .executionPlanJobId(o.getExecutionPlanJobId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ApplyJobOperationDetails(
+            ExecutionPlanStrategy executionPlanStrategy, String executionPlanJobId) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+        this.executionPlanJobId = executionPlanJobId;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Use `AUTO_APPROVED` to run the job without an execution plan.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExecutionPlanStrategy {
+        FromPlanJobId("FROM_PLAN_JOB_ID"),
+        FromLatestPlanJob("FROM_LATEST_PLAN_JOB"),
+        AutoApproved("AUTO_APPROVED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExecutionPlanStrategy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExecutionPlanStrategy v : ExecutionPlanStrategy.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExecutionPlanStrategy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExecutionPlanStrategy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExecutionPlanStrategy', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Use `AUTO_APPROVED` to run the job without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    ExecutionPlanStrategy executionPlanStrategy;
+
+    /**
+     * The OCID of the plan job that contains the execution plan used for this job,
+     * or `null` if no execution plan was used.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+    String executionPlanJobId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ApplyJobOperationDetailsSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ApplyJobOperationDetailsSummary.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to apply operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApplyJobOperationDetailsSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ApplyJobOperationDetailsSummary extends JobOperationDetailsSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(
+                ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+        private String executionPlanJobId;
+
+        public Builder executionPlanJobId(String executionPlanJobId) {
+            this.executionPlanJobId = executionPlanJobId;
+            this.__explicitlySet__.add("executionPlanJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApplyJobOperationDetailsSummary build() {
+            ApplyJobOperationDetailsSummary __instance__ =
+                    new ApplyJobOperationDetailsSummary(executionPlanStrategy, executionPlanJobId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApplyJobOperationDetailsSummary o) {
+            Builder copiedBuilder =
+                    executionPlanStrategy(o.getExecutionPlanStrategy())
+                            .executionPlanJobId(o.getExecutionPlanJobId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ApplyJobOperationDetailsSummary(
+            ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy,
+            String executionPlanJobId) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+        this.executionPlanJobId = executionPlanJobId;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Use `AUTO_APPROVED` to run the job without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+    /**
+     * The OCID of the plan job that contains the execution plan used for this job,
+     * or `null` if no execution plan was used.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+    String executionPlanJobId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateApplyJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateApplyJobOperationDetails.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to apply operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateApplyJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateApplyJobOperationDetails extends CreateJobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(
+                ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+        private String executionPlanJobId;
+
+        public Builder executionPlanJobId(String executionPlanJobId) {
+            this.executionPlanJobId = executionPlanJobId;
+            this.__explicitlySet__.add("executionPlanJobId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateApplyJobOperationDetails build() {
+            CreateApplyJobOperationDetails __instance__ =
+                    new CreateApplyJobOperationDetails(executionPlanStrategy, executionPlanJobId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateApplyJobOperationDetails o) {
+            Builder copiedBuilder =
+                    executionPlanStrategy(o.getExecutionPlanStrategy())
+                            .executionPlanJobId(o.getExecutionPlanJobId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateApplyJobOperationDetails(
+            ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy,
+            String executionPlanJobId) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+        this.executionPlanJobId = executionPlanJobId;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Use `AUTO_APPROVED` to run the job without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    ApplyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+    /**
+     * The OCID of a plan job, for use when specifying `FROM_PLAN_JOB_ID` as the `executionPlanStrategy`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanJobId")
+    String executionPlanJobId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateDestroyJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateDestroyJobOperationDetails.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to destroy operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDestroyJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDestroyJobOperationDetails extends CreateJobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(
+                DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDestroyJobOperationDetails build() {
+            CreateDestroyJobOperationDetails __instance__ =
+                    new CreateDestroyJobOperationDetails(executionPlanStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDestroyJobOperationDetails o) {
+            Builder copiedBuilder = executionPlanStrategy(o.getExecutionPlanStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDestroyJobOperationDetails(
+            DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+     * will be run without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateImportTfStateJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateImportTfStateJobOperationDetails.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to import Terraform state operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateImportTfStateJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateImportTfStateJobOperationDetails extends CreateJobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("tfStateBase64Encoded")
+        private byte[] tfStateBase64Encoded;
+
+        public Builder tfStateBase64Encoded(byte[] tfStateBase64Encoded) {
+            this.tfStateBase64Encoded = tfStateBase64Encoded;
+            this.__explicitlySet__.add("tfStateBase64Encoded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateImportTfStateJobOperationDetails build() {
+            CreateImportTfStateJobOperationDetails __instance__ =
+                    new CreateImportTfStateJobOperationDetails(tfStateBase64Encoded);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateImportTfStateJobOperationDetails o) {
+            Builder copiedBuilder = tfStateBase64Encoded(o.getTfStateBase64Encoded());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateImportTfStateJobOperationDetails(byte[] tfStateBase64Encoded) {
+        super();
+        this.tfStateBase64Encoded = tfStateBase64Encoded;
+    }
+
+    /**
+     * Base64-encoded state file
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tfStateBase64Encoded")
+    byte[] tfStateBase64Encoded;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateJobDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateJobDetails.java
@@ -50,6 +50,15 @@ public class CreateJobDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+        private CreateJobOperationDetails jobOperationDetails;
+
+        public Builder jobOperationDetails(CreateJobOperationDetails jobOperationDetails) {
+            this.jobOperationDetails = jobOperationDetails;
+            this.__explicitlySet__.add("jobOperationDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("applyJobPlanResolution")
         private ApplyJobPlanResolution applyJobPlanResolution;
 
@@ -87,6 +96,7 @@ public class CreateJobDetails {
                             stackId,
                             displayName,
                             operation,
+                            jobOperationDetails,
                             applyJobPlanResolution,
                             freeformTags,
                             definedTags);
@@ -100,6 +110,7 @@ public class CreateJobDetails {
                     stackId(o.getStackId())
                             .displayName(o.getDisplayName())
                             .operation(o.getOperation())
+                            .jobOperationDetails(o.getJobOperationDetails())
                             .applyJobPlanResolution(o.getApplyJobPlanResolution())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
@@ -134,6 +145,15 @@ public class CreateJobDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("operation")
     Job.Operation operation;
 
+    /**
+     * Job details that are specific to the operation type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+    CreateJobOperationDetails jobOperationDetails;
+
+    /**
+     * Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("applyJobPlanResolution")
     ApplyJobPlanResolution applyJobPlanResolution;
 

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateJobOperationDetails.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to the operation type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation",
+    defaultImpl = CreateJobOperationDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateImportTfStateJobOperationDetails.class,
+        name = "IMPORT_TF_STATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateApplyJobOperationDetails.class,
+        name = "APPLY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreatePlanJobOperationDetails.class,
+        name = "PLAN"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDestroyJobOperationDetails.class,
+        name = "DESTROY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateJobOperationDetails {}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreatePlanJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreatePlanJobOperationDetails.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to plan operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePlanJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreatePlanJobOperationDetails extends CreateJobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePlanJobOperationDetails build() {
+            CreatePlanJobOperationDetails __instance__ = new CreatePlanJobOperationDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePlanJobOperationDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreatePlanJobOperationDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/DestroyJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/DestroyJobOperationDetails.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to destroy operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DestroyJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class DestroyJobOperationDetails extends JobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DestroyJobOperationDetails build() {
+            DestroyJobOperationDetails __instance__ =
+                    new DestroyJobOperationDetails(executionPlanStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DestroyJobOperationDetails o) {
+            Builder copiedBuilder = executionPlanStrategy(o.getExecutionPlanStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DestroyJobOperationDetails(ExecutionPlanStrategy executionPlanStrategy) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+     * will be run without an execution plan.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExecutionPlanStrategy {
+        AutoApproved("AUTO_APPROVED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExecutionPlanStrategy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExecutionPlanStrategy v : ExecutionPlanStrategy.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExecutionPlanStrategy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExecutionPlanStrategy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExecutionPlanStrategy', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+     * will be run without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    ExecutionPlanStrategy executionPlanStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/DestroyJobOperationDetailsSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/DestroyJobOperationDetailsSummary.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to destroy operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DestroyJobOperationDetailsSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class DestroyJobOperationDetailsSummary extends JobOperationDetailsSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+        private DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+        public Builder executionPlanStrategy(
+                DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+            this.executionPlanStrategy = executionPlanStrategy;
+            this.__explicitlySet__.add("executionPlanStrategy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DestroyJobOperationDetailsSummary build() {
+            DestroyJobOperationDetailsSummary __instance__ =
+                    new DestroyJobOperationDetailsSummary(executionPlanStrategy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DestroyJobOperationDetailsSummary o) {
+            Builder copiedBuilder = executionPlanStrategy(o.getExecutionPlanStrategy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DestroyJobOperationDetailsSummary(
+            DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy) {
+        super();
+        this.executionPlanStrategy = executionPlanStrategy;
+    }
+
+    /**
+     * Specifies the source of the execution plan to apply.
+     * Currently, only `AUTO_APPROVED` is allowed, which indicates that the job
+     * will be run without an execution plan.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionPlanStrategy")
+    DestroyJobOperationDetails.ExecutionPlanStrategy executionPlanStrategy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ImportTfStateJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ImportTfStateJobOperationDetails.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to import Terraform state operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ImportTfStateJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ImportTfStateJobOperationDetails extends JobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ImportTfStateJobOperationDetails build() {
+            ImportTfStateJobOperationDetails __instance__ = new ImportTfStateJobOperationDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ImportTfStateJobOperationDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ImportTfStateJobOperationDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ImportTfStateJobOperationDetailsSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ImportTfStateJobOperationDetailsSummary.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to import Terraform state operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ImportTfStateJobOperationDetailsSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ImportTfStateJobOperationDetailsSummary extends JobOperationDetailsSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ImportTfStateJobOperationDetailsSummary build() {
+            ImportTfStateJobOperationDetailsSummary __instance__ =
+                    new ImportTfStateJobOperationDetailsSummary();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ImportTfStateJobOperationDetailsSummary o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ImportTfStateJobOperationDetailsSummary() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
@@ -11,6 +11,8 @@ package com.oracle.bmc.resourcemanager.model;
  * - **Destroy job**. To clean up the infrastructure controlled by the stack, you run a destroy job.
  * A destroy job does not delete the stack or associated job resources,
  * but instead releases the resources managed by the stack.
+ * - **Import_TF_State job**. An import Terraform state job takes a Terraform state file and sets it as the current
+ * state of the stack. This is used to migrate local Terraform environments to Resource Manager.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -71,6 +73,15 @@ public class Job {
         public Builder operation(Operation operation) {
             this.operation = operation;
             this.__explicitlySet__.add("operation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+        private JobOperationDetails jobOperationDetails;
+
+        public Builder jobOperationDetails(JobOperationDetails jobOperationDetails) {
+            this.jobOperationDetails = jobOperationDetails;
+            this.__explicitlySet__.add("jobOperationDetails");
             return this;
         }
 
@@ -176,6 +187,7 @@ public class Job {
                             compartmentId,
                             displayName,
                             operation,
+                            jobOperationDetails,
                             applyJobPlanResolution,
                             resolvedPlanJobId,
                             timeCreated,
@@ -198,6 +210,7 @@ public class Job {
                             .compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .operation(o.getOperation())
+                            .jobOperationDetails(o.getJobOperationDetails())
                             .applyJobPlanResolution(o.getApplyJobPlanResolution())
                             .resolvedPlanJobId(o.getResolvedPlanJobId())
                             .timeCreated(o.getTimeCreated())
@@ -252,6 +265,7 @@ public class Job {
         Plan("PLAN"),
         Apply("APPLY"),
         Destroy("DESTROY"),
+        ImportTfState("IMPORT_TF_STATE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -297,11 +311,22 @@ public class Job {
     @com.fasterxml.jackson.annotation.JsonProperty("operation")
     Operation operation;
 
+    /**
+     * Job details that are specific to the operation type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+    JobOperationDetails jobOperationDetails;
+
+    /**
+     * Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("applyJobPlanResolution")
     ApplyJobPlanResolution applyJobPlanResolution;
 
     /**
+     * Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
      * The plan job OCID that was used (if this was an apply job and was not auto-approved).
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resolvedPlanJobId")
     String resolvedPlanJobId;

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobOperationDetails.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to the operation type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation",
+    defaultImpl = JobOperationDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ImportTfStateJobOperationDetails.class,
+        name = "IMPORT_TF_STATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PlanJobOperationDetails.class,
+        name = "PLAN"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ApplyJobOperationDetails.class,
+        name = "APPLY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DestroyJobOperationDetails.class,
+        name = "DESTROY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class JobOperationDetails {}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobOperationDetailsSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobOperationDetailsSummary.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to the operation type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation",
+    defaultImpl = JobOperationDetailsSummary.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ImportTfStateJobOperationDetailsSummary.class,
+        name = "IMPORT_TF_STATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PlanJobOperationDetailsSummary.class,
+        name = "PLAN"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DestroyJobOperationDetailsSummary.class,
+        name = "DESTROY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ApplyJobOperationDetailsSummary.class,
+        name = "APPLY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class JobOperationDetailsSummary {}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/JobSummary.java
@@ -67,6 +67,15 @@ public class JobSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+        private JobOperationDetailsSummary jobOperationDetails;
+
+        public Builder jobOperationDetails(JobOperationDetailsSummary jobOperationDetails) {
+            this.jobOperationDetails = jobOperationDetails;
+            this.__explicitlySet__.add("jobOperationDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("applyJobPlanResolution")
         private ApplyJobPlanResolution applyJobPlanResolution;
 
@@ -142,6 +151,7 @@ public class JobSummary {
                             compartmentId,
                             displayName,
                             operation,
+                            jobOperationDetails,
                             applyJobPlanResolution,
                             resolvedPlanJobId,
                             timeCreated,
@@ -161,6 +171,7 @@ public class JobSummary {
                             .compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .operation(o.getOperation())
+                            .jobOperationDetails(o.getJobOperationDetails())
                             .applyJobPlanResolution(o.getApplyJobPlanResolution())
                             .resolvedPlanJobId(o.getResolvedPlanJobId())
                             .timeCreated(o.getTimeCreated())
@@ -211,11 +222,22 @@ public class JobSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("operation")
     Job.Operation operation;
 
+    /**
+     * Job details that are specific to the operation type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobOperationDetails")
+    JobOperationDetailsSummary jobOperationDetails;
+
+    /**
+     * Deprecated. Use the property `executionPlanStrategy` in `jobOperationDetails` instead.
+     **/
     @com.fasterxml.jackson.annotation.JsonProperty("applyJobPlanResolution")
     ApplyJobPlanResolution applyJobPlanResolution;
 
     /**
-     * The plan job OCID that was used (if this was an APPLY job and not auto approved).
+     * Deprecated. Use the property `executionPlanJobId` in `jobOperationDetails` instead.
+     * The plan job OCID that was used (if this was an apply job and was not auto-approved).
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resolvedPlanJobId")
     String resolvedPlanJobId;

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/PlanJobOperationDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/PlanJobOperationDetails.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to plan operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PlanJobOperationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class PlanJobOperationDetails extends JobOperationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PlanJobOperationDetails build() {
+            PlanJobOperationDetails __instance__ = new PlanJobOperationDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PlanJobOperationDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PlanJobOperationDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/PlanJobOperationDetailsSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/PlanJobOperationDetailsSummary.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.resourcemanager.model;
+
+/**
+ * Job details that are specific to plan operations.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180917")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PlanJobOperationDetailsSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "operation"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class PlanJobOperationDetailsSummary extends JobOperationDetailsSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PlanJobOperationDetailsSummary build() {
+            PlanJobOperationDetailsSummary __instance__ = new PlanJobOperationDetailsSummary();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PlanJobOperationDetailsSummary o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PlanJobOperationDetailsSummary() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for importing state files in the Resource Manager service

- Support for Exadata Cloud at Customer in the Database service

- Support for free tier resources and system tags in the Load Balancing service

- Support for free tier resources and system tags in the Compute service

- Support for free tier resources and system tags in the Block Storage service

- Support for free tier and system tags on autonomous databases in the Database service



### Breaking

- The class `com.oracle.bmc.database.model.CreateDbHomeWithDbSystemIdBase` was renamed to `com.oracle.bmc.database.model.CreateDbHomeBase` that impacts the following references:

    - `CreateDbHomeRequest#createDbHomeWithDbSystemIdDetails` parameter type

    - `CreateDbHomeWithDbSystemIdDetails` class extension

    - `CreateDbHomeWithDbSystemIdFromBackupDetails` class extension
