### PR TITLE
Releasing version 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 1.9.0 - 2019-10-08
+### Added
+- Support for the new schema for events in the Audit service
+- Support for entitlements in the Data Transfer service
+- Support for custom scheduled backup policies on volumes in the Block Storage service
+- Support for specifying the network type when launching virtual machine instances in the Compute service
+- Support for Monitoring service integration in the Health Checks service
+
+### Breaking changes
+- For `com.oracle.bmc.dts.model.TransferApplianceEntitlement`:
+	- The `Status` enum has been removed and replaced with `LifecycleState`
+	- The `tenantId` parameter has been renamed as `id`
+- The `eTag` parameter has been removed from `com.oracle.bmc.healthchecks.responses.ChangeHttpMonitorCompartmentResponse`
+- The Audit service version to support the new schema was increased to 20190901.  Older versions of the SDK (< 1.9.0) will continue to function to support Audit service version 20160918
+
 ## 1.8.2 - 2019-10-01
 ### Added
 - Support for required tags in the Identity service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/Audit.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/Audit.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.audit;
 import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 public interface Audit extends AutoCloseable {
 
     /**
@@ -45,7 +45,9 @@ public interface Audit extends AutoCloseable {
     GetConfigurationResponse getConfiguration(GetConfigurationRequest request);
 
     /**
-     * Returns all audit events for the specified compartment that were processed within the specified time range.
+     * Returns all the audit events processed for the specified compartment within the specified
+     * time range.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsync.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.audit;
 import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 public interface AuditAsync extends AutoCloseable {
 
     /**
@@ -52,7 +52,9 @@ public interface AuditAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns all audit events for the specified compartment that were processed within the specified time range.
+     * Returns all the audit events processed for the specified compartment within the specified
+     * time range.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsyncClient.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.audit.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.extern.slf4j.Slf4j
 public class AuditAsyncClient implements AuditAsync {
     /**
@@ -31,6 +31,7 @@ public class AuditAsyncClient implements AuditAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("AUDIT")
                     .serviceEndpointPrefix("audit")
+                    .serviceEndpointTemplate("https://audit.{region}.oraclecloud.com")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditClient.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.audit.internal.http.*;
 import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.extern.slf4j.Slf4j
 public class AuditClient implements Audit {
     /**
@@ -18,6 +18,7 @@ public class AuditClient implements Audit {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("AUDIT")
                     .serviceEndpointPrefix("audit")
+                    .serviceEndpointTemplate("https://audit.{region}.oraclecloud.com")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditPaginators.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/AuditPaginators.java
@@ -24,7 +24,7 @@ import com.oracle.bmc.audit.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.RequiredArgsConstructor
 public class AuditPaginators {
     private final Audit client;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/GetConfigurationConverter.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/GetConfigurationConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.extern.slf4j.Slf4j
 public class GetConfigurationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -27,7 +27,7 @@ public class GetConfigurationConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20160918").path("configuration");
+                client.getBaseTarget().path("/20190901").path("configuration");
 
         target =
                 target.queryParam(

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/ListEventsConverter.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/ListEventsConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.extern.slf4j.Slf4j
 public class ListEventsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -29,7 +29,7 @@ public class ListEventsConverter {
         Validate.notNull(request.getEndTime(), "endTime is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20160918").path("auditEvents");
+                client.getBaseTarget().path("/20190901").path("auditEvents");
 
         target =
                 target.queryParam(

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/UpdateConfigurationConverter.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/internal/http/UpdateConfigurationConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.audit.requests.*;
 import com.oracle.bmc.audit.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.extern.slf4j.Slf4j
 public class UpdateConfigurationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -29,7 +29,7 @@ public class UpdateConfigurationConverter {
                 request.getUpdateConfigurationDetails(), "updateConfigurationDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20160918").path("configuration");
+                client.getBaseTarget().path("/20190901").path("configuration");
 
         target =
                 target.queryParam(

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/AuditEvent.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/AuditEvent.java
@@ -4,6 +4,7 @@
 package com.oracle.bmc.audit.model;
 
 /**
+ * All the attributes of an audit event. For more information, see [Viewing Audit Log Events](https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/viewinglogevents.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -13,7 +14,7 @@ package com.oracle.bmc.audit.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AuditEvent.Builder.class)
@@ -22,30 +23,39 @@ public class AuditEvent {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
-        private String tenantId;
+        @com.fasterxml.jackson.annotation.JsonProperty("eventType")
+        private String eventType;
 
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            this.__explicitlySet__.add("tenantId");
+        public Builder eventType(String eventType) {
+            this.eventType = eventType;
+            this.__explicitlySet__.add("eventType");
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
-        private String compartmentId;
+        @com.fasterxml.jackson.annotation.JsonProperty("cloudEventsVersion")
+        private String cloudEventsVersion;
 
-        public Builder compartmentId(String compartmentId) {
-            this.compartmentId = compartmentId;
-            this.__explicitlySet__.add("compartmentId");
+        public Builder cloudEventsVersion(String cloudEventsVersion) {
+            this.cloudEventsVersion = cloudEventsVersion;
+            this.__explicitlySet__.add("cloudEventsVersion");
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("compartmentName")
-        private String compartmentName;
+        @com.fasterxml.jackson.annotation.JsonProperty("eventTypeVersion")
+        private String eventTypeVersion;
 
-        public Builder compartmentName(String compartmentName) {
-            this.compartmentName = compartmentName;
-            this.__explicitlySet__.add("compartmentName");
+        public Builder eventTypeVersion(String eventTypeVersion) {
+            this.eventTypeVersion = eventTypeVersion;
+            this.__explicitlySet__.add("eventTypeVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private String source;
+
+        public Builder source(String source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
             return this;
         }
 
@@ -58,33 +68,6 @@ public class AuditEvent {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("eventName")
-        private String eventName;
-
-        public Builder eventName(String eventName) {
-            this.eventName = eventName;
-            this.__explicitlySet__.add("eventName");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("eventSource")
-        private String eventSource;
-
-        public Builder eventSource(String eventSource) {
-            this.eventSource = eventSource;
-            this.__explicitlySet__.add("eventSource");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("eventType")
-        private String eventType;
-
-        public Builder eventType(String eventType) {
-            this.eventType = eventType;
-            this.__explicitlySet__.add("eventType");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("eventTime")
         private java.util.Date eventTime;
 
@@ -94,132 +77,21 @@ public class AuditEvent {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("principalId")
-        private String principalId;
+        @com.fasterxml.jackson.annotation.JsonProperty("contentType")
+        private String contentType;
 
-        public Builder principalId(String principalId) {
-            this.principalId = principalId;
-            this.__explicitlySet__.add("principalId");
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
+            this.__explicitlySet__.add("contentType");
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("credentialId")
-        private String credentialId;
+        @com.fasterxml.jackson.annotation.JsonProperty("data")
+        private Data data;
 
-        public Builder credentialId(String credentialId) {
-            this.credentialId = credentialId;
-            this.__explicitlySet__.add("credentialId");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestAction")
-        private String requestAction;
-
-        public Builder requestAction(String requestAction) {
-            this.requestAction = requestAction;
-            this.__explicitlySet__.add("requestAction");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestId")
-        private String requestId;
-
-        public Builder requestId(String requestId) {
-            this.requestId = requestId;
-            this.__explicitlySet__.add("requestId");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestAgent")
-        private String requestAgent;
-
-        public Builder requestAgent(String requestAgent) {
-            this.requestAgent = requestAgent;
-            this.__explicitlySet__.add("requestAgent");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestHeaders")
-        private java.util.Map<String, java.util.List<String>> requestHeaders;
-
-        public Builder requestHeaders(
-                java.util.Map<String, java.util.List<String>> requestHeaders) {
-            this.requestHeaders = requestHeaders;
-            this.__explicitlySet__.add("requestHeaders");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestOrigin")
-        private String requestOrigin;
-
-        public Builder requestOrigin(String requestOrigin) {
-            this.requestOrigin = requestOrigin;
-            this.__explicitlySet__.add("requestOrigin");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestParameters")
-        private java.util.Map<String, java.util.List<String>> requestParameters;
-
-        public Builder requestParameters(
-                java.util.Map<String, java.util.List<String>> requestParameters) {
-            this.requestParameters = requestParameters;
-            this.__explicitlySet__.add("requestParameters");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("requestResource")
-        private String requestResource;
-
-        public Builder requestResource(String requestResource) {
-            this.requestResource = requestResource;
-            this.__explicitlySet__.add("requestResource");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("responseHeaders")
-        private java.util.Map<String, java.util.List<String>> responseHeaders;
-
-        public Builder responseHeaders(
-                java.util.Map<String, java.util.List<String>> responseHeaders) {
-            this.responseHeaders = responseHeaders;
-            this.__explicitlySet__.add("responseHeaders");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("responseStatus")
-        private String responseStatus;
-
-        public Builder responseStatus(String responseStatus) {
-            this.responseStatus = responseStatus;
-            this.__explicitlySet__.add("responseStatus");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("responseTime")
-        private java.util.Date responseTime;
-
-        public Builder responseTime(java.util.Date responseTime) {
-            this.responseTime = responseTime;
-            this.__explicitlySet__.add("responseTime");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("responsePayload")
-        private java.util.Map<String, Object> responsePayload;
-
-        public Builder responsePayload(java.util.Map<String, Object> responsePayload) {
-            this.responsePayload = responsePayload;
-            this.__explicitlySet__.add("responsePayload");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("userName")
-        private String userName;
-
-        public Builder userName(String userName) {
-            this.userName = userName;
-            this.__explicitlySet__.add("userName");
+        public Builder data(Data data) {
+            this.data = data;
+            this.__explicitlySet__.add("data");
             return this;
         }
 
@@ -229,28 +101,14 @@ public class AuditEvent {
         public AuditEvent build() {
             AuditEvent __instance__ =
                     new AuditEvent(
-                            tenantId,
-                            compartmentId,
-                            compartmentName,
-                            eventId,
-                            eventName,
-                            eventSource,
                             eventType,
+                            cloudEventsVersion,
+                            eventTypeVersion,
+                            source,
+                            eventId,
                             eventTime,
-                            principalId,
-                            credentialId,
-                            requestAction,
-                            requestId,
-                            requestAgent,
-                            requestHeaders,
-                            requestOrigin,
-                            requestParameters,
-                            requestResource,
-                            responseHeaders,
-                            responseStatus,
-                            responseTime,
-                            responsePayload,
-                            userName);
+                            contentType,
+                            data);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -258,28 +116,14 @@ public class AuditEvent {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AuditEvent o) {
             Builder copiedBuilder =
-                    tenantId(o.getTenantId())
-                            .compartmentId(o.getCompartmentId())
-                            .compartmentName(o.getCompartmentName())
+                    eventType(o.getEventType())
+                            .cloudEventsVersion(o.getCloudEventsVersion())
+                            .eventTypeVersion(o.getEventTypeVersion())
+                            .source(o.getSource())
                             .eventId(o.getEventId())
-                            .eventName(o.getEventName())
-                            .eventSource(o.getEventSource())
-                            .eventType(o.getEventType())
                             .eventTime(o.getEventTime())
-                            .principalId(o.getPrincipalId())
-                            .credentialId(o.getCredentialId())
-                            .requestAction(o.getRequestAction())
-                            .requestId(o.getRequestId())
-                            .requestAgent(o.getRequestAgent())
-                            .requestHeaders(o.getRequestHeaders())
-                            .requestOrigin(o.getRequestOrigin())
-                            .requestParameters(o.getRequestParameters())
-                            .requestResource(o.getRequestResource())
-                            .responseHeaders(o.getResponseHeaders())
-                            .responseStatus(o.getResponseStatus())
-                            .responseTime(o.getResponseTime())
-                            .responsePayload(o.getResponsePayload())
-                            .userName(o.getUserName());
+                            .contentType(o.getContentType())
+                            .data(o.getData());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -294,140 +138,77 @@ public class AuditEvent {
     }
 
     /**
-     * The OCID of the tenant.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
-    String tenantId;
-
-    /**
-     * The OCID of the compartment.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
-    String compartmentId;
-
-    /**
-     * The name of the compartment. This value is the friendly name associated with compartmentId.
-     * This value can change, but the service logs the value that appeared at the time of the audit event.
+     * The type of event that happened.
+     * <p>
+     * The service that produces the event can also add, remove, or change the meaning of a field.
+     * A service implementing these type changes would publish a new version of an `eventType` and
+     * revise the `eventTypeVersion` field.
+     * <p>
+     * Example: `com.oraclecloud.ComputeApi.GetInstance`
      *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("compartmentName")
-    String compartmentName;
-
-    /**
-     * The GUID of the event.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("eventId")
-    String eventId;
-
-    /**
-     * The name of the event.
-     * Example: `LaunchInstance`
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("eventName")
-    String eventName;
-
-    /**
-     * The source of the event.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("eventSource")
-    String eventSource;
-
-    /**
-     * The type of the event.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("eventType")
     String eventType;
 
     /**
+     * The version of the CloudEvents specification. The structure of the envelope follows the
+     * [CloudEvents](https://github.com/cloudevents/spec) industry standard format hosted by the
+     * [Cloud Native Computing Foundation ( CNCF)](https://www.cncf.io/).
+     * <p>
+     * Audit uses version 0.1 specification of the CloudEvents event envelope.
+     * <p>
+     * Example: `0.1`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cloudEventsVersion")
+    String cloudEventsVersion;
+
+    /**
+     * The version of the event type. This version applies to the payload of the event, not the envelope.
+     * Use `cloudEventsVersion` to determine the version of the envelope.
+     * <p>
+     * Example: `2.0`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventTypeVersion")
+    String eventTypeVersion;
+
+    /**
+     * The source of the event.
+     * <p>
+     * Example: `ComputeApi`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    String source;
+
+    /**
+     * The GUID of the event.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventId")
+    String eventId;
+
+    /**
      * The time the event occurred, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+     * <p>
+     * Example: `2019-09-18T00:10:59.252Z`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("eventTime")
     java.util.Date eventTime;
 
     /**
-     * The OCID of the user whose action triggered the event.
+     * The content type of the data contained in `data`.
+     * <p>
+     * Example: `application/json`
+     *
      **/
-    @com.fasterxml.jackson.annotation.JsonProperty("principalId")
-    String principalId;
+    @com.fasterxml.jackson.annotation.JsonProperty("contentType")
+    String contentType;
 
-    /**
-     * The credential ID of the user. This value is extracted from the HTTP 'Authorization' request header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("credentialId")
-    String credentialId;
-
-    /**
-     * The HTTP method of the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestAction")
-    String requestAction;
-
-    /**
-     * The opc-request-id of the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestId")
-    String requestId;
-
-    /**
-     * The user agent of the client that made the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestAgent")
-    String requestAgent;
-
-    /**
-     * The HTTP header fields and values in the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestHeaders")
-    java.util.Map<String, java.util.List<String>> requestHeaders;
-
-    /**
-     * The IP address of the source of the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestOrigin")
-    String requestOrigin;
-
-    /**
-     * The query parameter fields and values for the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestParameters")
-    java.util.Map<String, java.util.List<String>> requestParameters;
-
-    /**
-     * The resource targeted by the request.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("requestResource")
-    String requestResource;
-
-    /**
-     * The headers of the response.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("responseHeaders")
-    java.util.Map<String, java.util.List<String>> responseHeaders;
-
-    /**
-     * The status code of the response.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("responseStatus")
-    String responseStatus;
-
-    /**
-     * The time of the response to the audited request, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("responseTime")
-    java.util.Date responseTime;
-
-    /**
-     * Metadata of interest from the response payload. For example, the OCID of a resource.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("responsePayload")
-    java.util.Map<String, Object> responsePayload;
-
-    /**
-     * The name of the user or service. This value is the friendly name associated with principalId.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("userName")
-    String userName;
+    @com.fasterxml.jackson.annotation.JsonProperty("data")
+    Data data;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Configuration.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Configuration.java
@@ -4,6 +4,8 @@
 package com.oracle.bmc.audit.model;
 
 /**
+ * The retention period setting, specified in days. For more information, see [Setting Audit
+ * Log Retention Period](https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/settingretentionperiod.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -13,7 +15,7 @@ package com.oracle.bmc.audit.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Configuration.Builder.class)
@@ -57,7 +59,10 @@ public class Configuration {
     }
 
     /**
-     * The retention period days
+     * The retention period setting, specified in days. The minimum is 90, the maximum 365.
+     * <p>
+     * Example: `90`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionPeriodDays")
     Integer retentionPeriodDays;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Data.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Data.java
@@ -1,0 +1,425 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.audit.model;
+
+/**
+ * The payload of the event. Information within `data` comes from the resource emitting the event.
+ * <p>
+ * Example:
+ * <p>
+ * -----
+ *     {
+ *       \"eventGroupingId\": null,
+ *       \"eventName\": \"GetInstance\",
+ *       \"compartmentId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+ *       \"compartmentName\": \"compartmentA\",
+ *       \"resourceName\": \"my_instance\",
+ *       \"resourceId\": \"ocid1.instance.oc1.phx.<unique_ID>\",
+ *       \"availabilityDomain\": \"<availability_domain>\",
+ *       \"freeformTags\": null,
+ *       \"definedTags\": null,
+ *       \"identity\": {
+ *         \"principalName\": \"ExampleName\",
+ *         \"principalId\": \"ocid1.user.oc1..<unique_ID>\",
+ *         \"authType\": \"natv\",
+ *         \"callerName\": null,
+ *         \"callerId\": null,
+ *         \"tenantId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+ *         \"ipAddress\": \"172.24.80.88\",
+ *         \"credentials\": null,
+ *         \"userAgent\": \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\",
+ *         \"consoleSessionId\": null
+ *       },
+ *       \"request\": {
+ *         \"id\": \"<unique_ID>\",
+ *         \"path\": \"/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\",
+ *         \"action\": \"GET\",
+ *         \"parameters\": {},
+ *         \"headers\": {
+ *           \"opc-principal\": [
+ *             \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+ *           ],
+ *           \"Accept\": [
+ *             \"application/json\"
+ *           ],
+ *           \"X-Oracle-Auth-Client-CN\": [
+ *             \"splat-proxy-se-02302.node.ad2.r2\"
+ *           ],
+ *           \"X-Forwarded-Host\": [
+ *             \"compute-api.svc.ad1.r2\"
+ *           ],
+ *           \"Connection\": [
+ *             \"close\"
+ *           ],
+ *           \"User-Agent\": [
+ *             \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+ *           ],
+ *           \"X-Forwarded-For\": [
+ *             \"172.24.80.88\"
+ *           ],
+ *           \"X-Real-IP\": [
+ *             \"172.24.80.88\"
+ *           ],
+ *           \"oci-original-url\": [
+ *             \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+ *           ],
+ *           \"opc-request-id\": [
+ *             \"<unique_ID>\"
+ *           ],
+ *           \"Date\": [
+ *             \"Wed, 18 Sep 2019 00:10:58 UTC\"
+ *           ]
+ *         }
+ *       },
+ *       \"response\": {
+ *         \"status\": \"200\",
+ *         \"responseTime\": \"2019-09-18T00:10:59.278Z\",
+ *         \"headers\": {
+ *           \"ETag\": [
+ *             \"<unique_ID>\"
+ *           ],
+ *           \"Connection\": [
+ *             \"close\"
+ *           ],
+ *           \"Content-Length\": [
+ *             \"1828\"
+ *           ],
+ *           \"opc-request-id\": [
+ *             \"<unique_ID>\"
+ *           ],
+ *           \"Date\": [
+ *             \"Wed, 18 Sep 2019 00:10:59 GMT\"
+ *           ],
+ *           \"Content-Type\": [
+ *             \"application/json\"
+ *           ]
+ *         },
+ *         \"payload\": {
+ *           \"resourceName\": \"my_instance\",
+ *           \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+ *         },
+ *         \"message\": null
+ *       },
+ *       \"stateChange\": {
+ *         \"previous\": null,
+ *         \"current\": null
+ *       },
+ *       \"additionalDetails\": {
+ *         \"imageId\": \"ocid1.image.oc1.phx.<unique_ID>\",
+ *         \"shape\": \"VM.Standard1.1\",
+ *         \"type\": \"CustomerVmi\"
+ *       }
+ *     }
+ *   -----
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Data.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Data {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("eventGroupingId")
+        private String eventGroupingId;
+
+        public Builder eventGroupingId(String eventGroupingId) {
+            this.eventGroupingId = eventGroupingId;
+            this.__explicitlySet__.add("eventGroupingId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("eventName")
+        private String eventName;
+
+        public Builder eventName(String eventName) {
+            this.eventName = eventName;
+            this.__explicitlySet__.add("eventName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentName")
+        private String compartmentName;
+
+        public Builder compartmentName(String compartmentName) {
+            this.compartmentName = compartmentName;
+            this.__explicitlySet__.add("compartmentName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceName")
+        private String resourceName;
+
+        public Builder resourceName(String resourceName) {
+            this.resourceName = resourceName;
+            this.__explicitlySet__.add("resourceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceId")
+        private String resourceId;
+
+        public Builder resourceId(String resourceId) {
+            this.resourceId = resourceId;
+            this.__explicitlySet__.add("resourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identity")
+        private Identity identity;
+
+        public Builder identity(Identity identity) {
+            this.identity = identity;
+            this.__explicitlySet__.add("identity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("request")
+        private Request request;
+
+        public Builder request(Request request) {
+            this.request = request;
+            this.__explicitlySet__.add("request");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("response")
+        private Response response;
+
+        public Builder response(Response response) {
+            this.response = response;
+            this.__explicitlySet__.add("response");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stateChange")
+        private StateChange stateChange;
+
+        public Builder stateChange(StateChange stateChange) {
+            this.stateChange = stateChange;
+            this.__explicitlySet__.add("stateChange");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+        private java.util.Map<String, Object> additionalDetails;
+
+        public Builder additionalDetails(java.util.Map<String, Object> additionalDetails) {
+            this.additionalDetails = additionalDetails;
+            this.__explicitlySet__.add("additionalDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Data build() {
+            Data __instance__ =
+                    new Data(
+                            eventGroupingId,
+                            eventName,
+                            compartmentId,
+                            compartmentName,
+                            resourceName,
+                            resourceId,
+                            availabilityDomain,
+                            freeformTags,
+                            definedTags,
+                            identity,
+                            request,
+                            response,
+                            stateChange,
+                            additionalDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Data o) {
+            Builder copiedBuilder =
+                    eventGroupingId(o.getEventGroupingId())
+                            .eventName(o.getEventName())
+                            .compartmentId(o.getCompartmentId())
+                            .compartmentName(o.getCompartmentName())
+                            .resourceName(o.getResourceName())
+                            .resourceId(o.getResourceId())
+                            .availabilityDomain(o.getAvailabilityDomain())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .identity(o.getIdentity())
+                            .request(o.getRequest())
+                            .response(o.getResponse())
+                            .stateChange(o.getStateChange())
+                            .additionalDetails(o.getAdditionalDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This value links multiple audit events that are part of the same API operation. For example,
+     * a long running API operations that emit an event at the start and the end of an operation
+     * would use the same value in this field for both events.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventGroupingId")
+    String eventGroupingId;
+
+    /**
+     * Name of the API operation that generated this event.
+     * <p>
+     * Example: `GetInstance`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventName")
+    String eventName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment of the resource
+     * emitting the event.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The name of the compartment. This value is the friendly name associated with compartmentId.
+     * This value can change, but the service logs the value that appeared at the time of the audit
+     * event.
+     * <p>
+     * Example: `CompartmentA`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentName")
+    String compartmentName;
+
+    /**
+     * The name of the resource emitting the event.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceName")
+    String resourceName;
+
+    /**
+     * An [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) or some other ID for the resource
+     * emitting the event.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceId")
+    String resourceId;
+
+    /**
+     * The availability domain where the resource resides.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name,
+     * type, or namespace. Exists for cross-compatibility only. For more information,
+     * see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more
+     * information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("identity")
+    Identity identity;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("request")
+    Request request;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("response")
+    Response response;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("stateChange")
+    StateChange stateChange;
+
+    /**
+     * A container object for attribues unique to the resource emitting the event.
+     * <p>
+     * Example:
+     * <p>
+     * -----
+     *     {
+     *       \"imageId\": \"ocid1.image.oc1.phx.<unique_ID>\",
+     *       \"shape\": \"VM.Standard1.1\",
+     *       \"type\": \"CustomerVmi\"
+     *     }
+     *   -----
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+    java.util.Map<String, Object> additionalDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Identity.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Identity.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.audit.model;
+
+/**
+ * A container object for identity attributes.
+ * <p>
+ * Example:
+ * <p>
+ * -----
+ *     {
+ *       \"principalName\": \"ExampleName\",
+ *       \"principalId\": \"ocid1.user.oc1..<unique_ID>\",
+ *       \"authType\": \"natv\",
+ *       \"callerName\": null,
+ *       \"callerId\": null,
+ *       \"tenantId\": \"ocid1.tenancy.oc1..<unique_ID>\",
+ *       \"ipAddress\": \"172.24.80.88\",
+ *       \"credentials\": null,
+ *       \"userAgent\": \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\",
+ *       \"consoleSessionId\": null
+ *     }
+ *   -----
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Identity.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Identity {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("principalName")
+        private String principalName;
+
+        public Builder principalName(String principalName) {
+            this.principalName = principalName;
+            this.__explicitlySet__.add("principalName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("principalId")
+        private String principalId;
+
+        public Builder principalId(String principalId) {
+            this.principalId = principalId;
+            this.__explicitlySet__.add("principalId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("authType")
+        private String authType;
+
+        public Builder authType(String authType) {
+            this.authType = authType;
+            this.__explicitlySet__.add("authType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("callerName")
+        private String callerName;
+
+        public Builder callerName(String callerName) {
+            this.callerName = callerName;
+            this.__explicitlySet__.add("callerName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("callerId")
+        private String callerId;
+
+        public Builder callerId(String callerId) {
+            this.callerId = callerId;
+            this.__explicitlySet__.add("callerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
+        private String tenantId;
+
+        public Builder tenantId(String tenantId) {
+            this.tenantId = tenantId;
+            this.__explicitlySet__.add("tenantId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ipAddress")
+        private String ipAddress;
+
+        public Builder ipAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            this.__explicitlySet__.add("ipAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("credentials")
+        private String credentials;
+
+        public Builder credentials(String credentials) {
+            this.credentials = credentials;
+            this.__explicitlySet__.add("credentials");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("userAgent")
+        private String userAgent;
+
+        public Builder userAgent(String userAgent) {
+            this.userAgent = userAgent;
+            this.__explicitlySet__.add("userAgent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("consoleSessionId")
+        private String consoleSessionId;
+
+        public Builder consoleSessionId(String consoleSessionId) {
+            this.consoleSessionId = consoleSessionId;
+            this.__explicitlySet__.add("consoleSessionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Identity build() {
+            Identity __instance__ =
+                    new Identity(
+                            principalName,
+                            principalId,
+                            authType,
+                            callerName,
+                            callerId,
+                            tenantId,
+                            ipAddress,
+                            credentials,
+                            userAgent,
+                            consoleSessionId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Identity o) {
+            Builder copiedBuilder =
+                    principalName(o.getPrincipalName())
+                            .principalId(o.getPrincipalId())
+                            .authType(o.getAuthType())
+                            .callerName(o.getCallerName())
+                            .callerId(o.getCallerId())
+                            .tenantId(o.getTenantId())
+                            .ipAddress(o.getIpAddress())
+                            .credentials(o.getCredentials())
+                            .userAgent(o.getUserAgent())
+                            .consoleSessionId(o.getConsoleSessionId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the user or service. This value is the friendly name associated with `principalId`.
+     * <p>
+     * Example: `ExampleName`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("principalName")
+    String principalName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the principal.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("principalId")
+    String principalId;
+
+    /**
+     * The type of authentication used.
+     * <p>
+     * Example: `natv`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("authType")
+    String authType;
+
+    /**
+     * The name of the user or service. This value is the friendly name associated with `callerId`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("callerName")
+    String callerName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the caller. The caller that made a
+     * request on behalf of the prinicpal.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("callerId")
+    String callerId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tenant.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
+    String tenantId;
+
+    /**
+     * The IP address of the source of the request.
+     * <p>
+     * Example: `172.24.80.88`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ipAddress")
+    String ipAddress;
+
+    /**
+     * The credential ID of the user. This value is extracted from the HTTP 'Authorization' request
+     * header. It consists of the tenantId, userId, and user fingerprint, all delimited by a slash (/).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("credentials")
+    String credentials;
+
+    /**
+     * The user agent of the client that made the request.
+     * <p>
+     * Example: `Jersey/2.23 (HttpUrlConnection 1.8.0_212)`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("userAgent")
+    String userAgent;
+
+    /**
+     * This value identifies any Console session associated with this request.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("consoleSessionId")
+    String consoleSessionId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Request.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Request.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.audit.model;
+
+/**
+ * A container object for request attributes.
+ * <p>
+ * Example:
+ * <p>
+ * -----
+ *     {
+ *       \"id\": \"<unique_ID>\",
+ *       \"path\": \"/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\",
+ *       \"action\": \"GET\",
+ *       \"parameters\": {},
+ *       \"headers\": {
+ *         \"opc-principal\": [
+ *           \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+ *         ],
+ *         \"Accept\": [
+ *           \"application/json\"
+ *         ],
+ *         \"X-Oracle-Auth-Client-CN\": [
+ *           \"splat-proxy-se-02302.node.ad2.r2\"
+ *         ],
+ *         \"X-Forwarded-Host\": [
+ *           \"compute-api.svc.ad1.r2\"
+ *         ],
+ *         \"Connection\": [
+ *           \"close\"
+ *         ],
+ *         \"User-Agent\": [
+ *           \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+ *         ],
+ *         \"X-Forwarded-For\": [
+ *           \"172.24.80.88\"
+ *         ],
+ *         \"X-Real-IP\": [
+ *           \"172.24.80.88\"
+ *         ],
+ *         \"oci-original-url\": [
+ *           \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+ *         ],
+ *         \"opc-request-id\": [
+ *           \"<unique_ID>\"
+ *         ],
+ *         \"Date\": [
+ *           \"Wed, 18 Sep 2019 00:10:58 UTC\"
+ *         ]
+ *       }
+ *     }
+ *   -----
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Request.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Request {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("path")
+        private String path;
+
+        public Builder path(String path) {
+            this.path = path;
+            this.__explicitlySet__.add("path");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private String action;
+
+        public Builder action(String action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.Map<String, java.util.List<String>> parameters;
+
+        public Builder parameters(java.util.Map<String, java.util.List<String>> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("headers")
+        private java.util.Map<String, java.util.List<String>> headers;
+
+        public Builder headers(java.util.Map<String, java.util.List<String>> headers) {
+            this.headers = headers;
+            this.__explicitlySet__.add("headers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Request build() {
+            Request __instance__ = new Request(id, path, action, parameters, headers);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Request o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .path(o.getPath())
+                            .action(o.getAction())
+                            .parameters(o.getParameters())
+                            .headers(o.getHeaders());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The opc-request-id of the request.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The full path of the API request.
+     * <p>
+     * Example: `/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    String path;
+
+    /**
+     * The HTTP method of the request.
+     * <p>
+     * Example: `GET`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("action")
+    String action;
+
+    /**
+     * The parameters supplied by the caller during this operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.Map<String, java.util.List<String>> parameters;
+
+    /**
+     * The HTTP header fields and values in the request.
+     * <p>
+     * Example:
+     * <p>
+     * -----
+     *     {
+     *       \"opc-principal\": [
+     *         \"{\\\"tenantId\\\":\\\"ocid1.tenancy.oc1..<unique_ID>\\\",\\\"subjectId\\\":\\\"ocid1.user.oc1..<unique_ID>\\\",\\\"claims\\\":[{\\\"key\\\":\\\"pstype\\\",\\\"value\\\":\\\"natv\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_host\\\",\\\"value\\\":\\\"iaas.r2.oracleiaas.com\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_opc-request-id\\\",\\\"value\\\":\\\"<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"ptype\\\",\\\"value\\\":\\\"user\\\",\\\"issuer\\\":\\\"authService.oracle.com\\\"},{\\\"key\\\":\\\"h_date\\\",\\\"value\\\":\\\"Wed, 18 Sep 2019 00:10:58 UTC\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_accept\\\",\\\"value\\\":\\\"application/json\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"authorization\\\",\\\"value\\\":\\\"Signature headers=\\\\\\\"date (request-target) host accept opc-request-id\\\\\\\",keyId=\\\\\\\"ocid1.tenancy.oc1..<unique_ID>/ocid1.user.oc1..<unique_ID>/8c:b4:5f:18:e7:ec:db:08:b8:fa:d2:2a:7d:11:76:ac\\\\\\\",algorithm=\\\\\\\"rsa-pss-sha256\\\\\\\",signature=\\\\\\\"<unique_ID>\\\\\\\",version=\\\\\\\"1\\\\\\\"\\\",\\\"issuer\\\":\\\"h\\\"},{\\\"key\\\":\\\"h_(request-target)\\\",\\\"value\\\":\\\"get /20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\\\",\\\"issuer\\\":\\\"h\\\"}]}\"
+     *       ],
+     *       \"Accept\": [
+     *         \"application/json\"
+     *       ],
+     *       \"X-Oracle-Auth-Client-CN\": [
+     *         \"splat-proxy-se-02302.node.ad2.r2\"
+     *       ],
+     *       \"X-Forwarded-Host\": [
+     *         \"compute-api.svc.ad1.r2\"
+     *       ],
+     *       \"Connection\": [
+     *         \"close\"
+     *       ],
+     *       \"User-Agent\": [
+     *         \"Jersey/2.23 (HttpUrlConnection 1.8.0_212)\"
+     *       ],
+     *       \"X-Forwarded-For\": [
+     *         \"172.24.80.88\"
+     *       ],
+     *       \"X-Real-IP\": [
+     *         \"172.24.80.88\"
+     *       ],
+     *       \"oci-original-url\": [
+     *         \"https://iaas.r2.oracleiaas.com/20160918/instances/ocid1.instance.oc1.phx.<unique_ID>\"
+     *       ],
+     *       \"opc-request-id\": [
+     *         \"<unique_ID>\"
+     *       ],
+     *       \"Date\": [
+     *         \"Wed, 18 Sep 2019 00:10:58 UTC\"
+     *       ]
+     *     }
+     *   -----
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("headers")
+    java.util.Map<String, java.util.List<String>> headers;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Response.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/Response.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.audit.model;
+
+/**
+ * A container object for response attributes.
+ * <p>
+ * Example:
+ * <p>
+ * -----
+ *     {
+ *       \"status\": \"200\",
+ *       \"responseTime\": \"2019-09-18T00:10:59.278Z\",
+ *       \"headers\": {
+ *         \"ETag\": [
+ *           \"<unique_ID>\"
+ *         ],
+ *         \"Connection\": [
+ *           \"close\"
+ *         ],
+ *         \"Content-Length\": [
+ *           \"1828\"
+ *         ],
+ *         \"opc-request-id\": [
+ *           \"<unique_ID>\"
+ *         ],
+ *         \"Date\": [
+ *           \"Wed, 18 Sep 2019 00:10:59 GMT\"
+ *         ],
+ *         \"Content-Type\": [
+ *           \"application/json\"
+ *         ]
+ *       },
+ *       \"payload\": {
+ *         \"resourceName\": \"my_instance\",
+ *         \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+ *       },
+ *       \"message\": null
+ *     }
+ *   -----
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Response.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Response {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private String status;
+
+        public Builder status(String status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("responseTime")
+        private java.util.Date responseTime;
+
+        public Builder responseTime(java.util.Date responseTime) {
+            this.responseTime = responseTime;
+            this.__explicitlySet__.add("responseTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("headers")
+        private java.util.Map<String, java.util.List<String>> headers;
+
+        public Builder headers(java.util.Map<String, java.util.List<String>> headers) {
+            this.headers = headers;
+            this.__explicitlySet__.add("headers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("payload")
+        private java.util.Map<String, Object> payload;
+
+        public Builder payload(java.util.Map<String, Object> payload) {
+            this.payload = payload;
+            this.__explicitlySet__.add("payload");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Response build() {
+            Response __instance__ = new Response(status, responseTime, headers, payload, message);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Response o) {
+            Builder copiedBuilder =
+                    status(o.getStatus())
+                            .responseTime(o.getResponseTime())
+                            .headers(o.getHeaders())
+                            .payload(o.getPayload())
+                            .message(o.getMessage());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The status code of the response.
+     * <p>
+     * Example: `200`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    String status;
+
+    /**
+     * The time of the response to the audited request, expressed in
+     * [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+     * <p>
+     * Example: `2019-09-18T00:10:59.278Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("responseTime")
+    java.util.Date responseTime;
+
+    /**
+     * The headers of the response.
+     * <p>
+     * Example:
+     * <p>
+     * -----
+     *     {
+     *       \"ETag\": [
+     *         \"<unique_ID>\"
+     *       ],
+     *       \"Connection\": [
+     *         \"close\"
+     *       ],
+     *       \"Content-Length\": [
+     *         \"1828\"
+     *       ],
+     *       \"opc-request-id\": [
+     *         \"<unique_ID>\"
+     *       ],
+     *       \"Date\": [
+     *         \"Wed, 18 Sep 2019 00:10:59 GMT\"
+     *       ],
+     *       \"Content-Type\": [
+     *         \"application/json\"
+     *       ]
+     *     }
+     *   -----
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("headers")
+    java.util.Map<String, java.util.List<String>> headers;
+
+    /**
+     * This value is included for backward compatibility with the Audit version 1 schema, where
+     * it contained metadata of interest from the response payload.
+     * <p>
+     * Example:
+     * <p>
+     * -----
+     *     {
+     *       \"resourceName\": \"my_instance\",
+     *       \"id\": \"ocid1.instance.oc1.phx.<unique_ID>\"
+     *     }
+     *   -----
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("payload")
+    java.util.Map<String, Object> payload;
+
+    /**
+     * A friendly description of what happened during the operation. Use this for troubleshooting.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/StateChange.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/StateChange.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.audit.model;
+
+/**
+ * A container object for state change attributes.
+ * <p>
+ * Example:
+ * <p>
+ * -----
+ *     {
+ *       \"previous\": null,
+ *       \"current\": null
+ *     }
+ *   -----
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = StateChange.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class StateChange {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("previous")
+        private java.util.Map<String, Object> previous;
+
+        public Builder previous(java.util.Map<String, Object> previous) {
+            this.previous = previous;
+            this.__explicitlySet__.add("previous");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("current")
+        private java.util.Map<String, Object> current;
+
+        public Builder current(java.util.Map<String, Object> current) {
+            this.current = current;
+            this.__explicitlySet__.add("current");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public StateChange build() {
+            StateChange __instance__ = new StateChange(previous, current);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(StateChange o) {
+            Builder copiedBuilder = previous(o.getPrevious()).current(o.getCurrent());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Provides the previous state of fields that may have changed during an operation. To determine
+     * how the current operation changed a resource, compare the information in this attribute to
+     * `current`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("previous")
+    java.util.Map<String, Object> previous;
+
+    /**
+     * Provides the current state of fields that may have changed during an operation. To determine
+     * how the current operation changed a resource, compare the information in this attribute to
+     * `previous`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("current")
+    java.util.Map<String, Object> current;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/model/UpdateConfigurationDetails.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/model/UpdateConfigurationDetails.java
@@ -4,6 +4,8 @@
 package com.oracle.bmc.audit.model;
 
 /**
+ * The configuration details for the retention period setting, specified in days. For more
+ * information, see [Setting Audit Log Retention Period](https://docs.cloud.oracle.com/iaas/Content/Audit/Tasks/settingretentionperiod.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -13,7 +15,7 @@ package com.oracle.bmc.audit.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -60,7 +62,10 @@ public class UpdateConfigurationDetails {
     }
 
     /**
-     * The retention period days
+     * The retention period setting, specified in days. The minimum is 90, the maximum 365.
+     * <p>
+     * Example: `90`
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionPeriodDays")
     Integer retentionPeriodDays;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/GetConfigurationRequest.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/GetConfigurationRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.audit.requests;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/ListEventsRequest.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/ListEventsRequest.java
@@ -5,40 +5,51 @@ package com.oracle.bmc.audit.requests;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListEventsRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * The OCID of the compartment.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * Returns events that were processed at or after this start date and time, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
-     * For example, a start value of `2017-01-15T11:30:00Z` will retrieve a list of all events processed since 30 minutes after the 11th hour of January 15, 2017, in Coordinated Universal Time (UTC).
-     * You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
+     * Returns events that were processed at or after this start date and time, expressed in
+     * [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+     * <p>
+     * For example, a start value of `2017-01-15T11:30:00Z` will retrieve a list of all events processed
+     * since 30 minutes after the 11th hour of January 15, 2017, in Coordinated Universal Time (UTC).
+     * You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must
+     * be set to `0`.
      *
      */
     private java.util.Date startTime;
 
     /**
-     * Returns events that were processed before this end date and time, expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format. For example, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-01-02T00:00:00Z` will retrieve a list of all events processed on January 1, 2017.
-     * Similarly, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-02-01T00:00:00Z` will result in a list of all events processed between January 1, 2017 and January 31, 2017.
-     * You can specify a value with granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
+     * Returns events that were processed before this end date and time, expressed in
+     * [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
+     * <p>
+     * For example, a start value of `2017-01-01T00:00:00Z` and an end value of `2017-01-02T00:00:00Z`
+     * will retrieve a list of all events processed on January 1, 2017. Similarly, a start value of
+     * `2017-01-01T00:00:00Z` and an end value of `2017-02-01T00:00:00Z` will result in a list of all
+     * events processed between January 1, 2017 and January 31, 2017. You can specify a value with
+     * granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`.
      *
      */
     private java.util.Date endTime;
 
     /**
-     * The value of the `opc-next-page` response header from the previous list query.
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
      */
     private String page;
 
     /**
-     * Unique Oracle-assigned identifier for the request.
-     * If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/UpdateConfigurationRequest.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/requests/UpdateConfigurationRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.audit.requests;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateConfigurationRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/GetConfigurationResponse.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/GetConfigurationResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.audit.responses;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetConfigurationResponse {

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/ListEventsResponse.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/ListEventsResponse.java
@@ -5,15 +5,16 @@ package com.oracle.bmc.audit.responses;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListEventsResponse {
 
     /**
      * For pagination of a list of audit events. When this header appears in the response,
-     * it means you received a partial list and there are more results.
-     * Include this value as the `page` parameter for the subsequent ListEvents request to get the next batch of events.
+     * it means you received a partial list and there are more results. Include this value as the `page`
+     * parameter for the subsequent ListEvents request to get the next batch of events. For important
+     * details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
      *
      */
     private String opcNextPage;

--- a/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/UpdateConfigurationResponse.java
+++ b/bmc-audit/src/main/java/com/oracle/bmc/audit/responses/UpdateConfigurationResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.audit.responses;
 
 import com.oracle.bmc.audit.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190901")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateConfigurationResponse {

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,181 +19,181 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
         <optional>false</optional>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <optional>false</optional>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
@@ -181,6 +181,15 @@ public interface Blockstorage extends AutoCloseable {
     CreateVolumeBackupResponse createVolumeBackup(CreateVolumeBackupRequest request);
 
     /**
+     * Creates a new backup policy for the caller.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateVolumeBackupPolicyResponse createVolumeBackupPolicy(
+            CreateVolumeBackupPolicyRequest request);
+
+    /**
      * Assigns a policy to the specified asset, such as a volume. Note that a given asset can
      * only have one policy assigned to it; if this method is called for an asset that previously
      * has a different policy assigned, the prior assignment will be silently deleted.
@@ -265,6 +274,15 @@ public interface Blockstorage extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     DeleteVolumeBackupResponse deleteVolumeBackup(DeleteVolumeBackupRequest request);
+
+    /**
+     * Deletes the specified scheduled backup policy.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteVolumeBackupPolicyResponse deleteVolumeBackupPolicy(
+            DeleteVolumeBackupPolicyRequest request);
 
     /**
      * Deletes a volume backup policy assignment (i.e. unassigns the policy from an asset).
@@ -508,6 +526,17 @@ public interface Blockstorage extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     UpdateVolumeBackupResponse updateVolumeBackup(UpdateVolumeBackupRequest request);
+
+    /**
+     * Updates a volume backup policy.
+     * Avoid entering confidential information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateVolumeBackupPolicyResponse updateVolumeBackupPolicy(
+            UpdateVolumeBackupPolicyRequest request);
 
     /**
      * Updates the set of volumes in a volume group along with the display name. Use this operation

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
@@ -267,6 +267,22 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Creates a new backup policy for the caller.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateVolumeBackupPolicyResponse> createVolumeBackupPolicy(
+            CreateVolumeBackupPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateVolumeBackupPolicyRequest, CreateVolumeBackupPolicyResponse>
+                    handler);
+
+    /**
      * Assigns a policy to the specified asset, such as a volume. Note that a given asset can
      * only have one policy assigned to it; if this method is called for an asset that previously
      * has a different policy assigned, the prior assignment will be silently deleted.
@@ -413,6 +429,22 @@ public interface BlockstorageAsync extends AutoCloseable {
             DeleteVolumeBackupRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             DeleteVolumeBackupRequest, DeleteVolumeBackupResponse>
+                    handler);
+
+    /**
+     * Deletes the specified scheduled backup policy.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteVolumeBackupPolicyResponse> deleteVolumeBackupPolicy(
+            DeleteVolumeBackupPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVolumeBackupPolicyRequest, DeleteVolumeBackupPolicyResponse>
                     handler);
 
     /**
@@ -862,6 +894,24 @@ public interface BlockstorageAsync extends AutoCloseable {
             UpdateVolumeBackupRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateVolumeBackupRequest, UpdateVolumeBackupResponse>
+                    handler);
+
+    /**
+     * Updates a volume backup policy.
+     * Avoid entering confidential information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateVolumeBackupPolicyResponse> updateVolumeBackupPolicy(
+            UpdateVolumeBackupPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVolumeBackupPolicyRequest, UpdateVolumeBackupPolicyResponse>
                     handler);
 
     /**

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
@@ -1316,6 +1316,97 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateVolumeBackupPolicyResponse> createVolumeBackupPolicy(
+            final CreateVolumeBackupPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateVolumeBackupPolicyRequest, CreateVolumeBackupPolicyResponse>
+                    handler) {
+        LOG.trace("Called async createVolumeBackupPolicy");
+        final CreateVolumeBackupPolicyRequest interceptedRequest =
+                CreateVolumeBackupPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>
+                transformer = CreateVolumeBackupPolicyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateVolumeBackupPolicyRequest, CreateVolumeBackupPolicyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateVolumeBackupPolicyRequest, CreateVolumeBackupPolicyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateVolumeBackupPolicyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateVolumeBackupPolicyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateVolumeBackupPolicyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateVolumeBackupPolicyAssignmentResponse>
             createVolumeBackupPolicyAssignment(
                     final CreateVolumeBackupPolicyAssignmentRequest request,
@@ -1948,6 +2039,82 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, DeleteVolumeBackupResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteVolumeBackupPolicyResponse> deleteVolumeBackupPolicy(
+            final DeleteVolumeBackupPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVolumeBackupPolicyRequest, DeleteVolumeBackupPolicyResponse>
+                    handler) {
+        LOG.trace("Called async deleteVolumeBackupPolicy");
+        final DeleteVolumeBackupPolicyRequest interceptedRequest =
+                DeleteVolumeBackupPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>
+                transformer = DeleteVolumeBackupPolicyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteVolumeBackupPolicyRequest, DeleteVolumeBackupPolicyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteVolumeBackupPolicyRequest, DeleteVolumeBackupPolicyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -4061,6 +4228,97 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
                             return client.put(
                                     ib,
                                     interceptedRequest.getUpdateVolumeBackupDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateVolumeBackupPolicyResponse> updateVolumeBackupPolicy(
+            final UpdateVolumeBackupPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVolumeBackupPolicyRequest, UpdateVolumeBackupPolicyResponse>
+                    handler) {
+        LOG.trace("Called async updateVolumeBackupPolicy");
+        final UpdateVolumeBackupPolicyRequest interceptedRequest =
+                UpdateVolumeBackupPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>
+                transformer = UpdateVolumeBackupPolicyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateVolumeBackupPolicyRequest, UpdateVolumeBackupPolicyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateVolumeBackupPolicyRequest, UpdateVolumeBackupPolicyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVolumeBackupPolicyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateVolumeBackupPolicyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateVolumeBackupPolicyDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
@@ -749,6 +749,39 @@ public class BlockstorageClient implements Blockstorage {
     }
 
     @Override
+    public CreateVolumeBackupPolicyResponse createVolumeBackupPolicy(
+            CreateVolumeBackupPolicyRequest request) {
+        LOG.trace("Called createVolumeBackupPolicy");
+        final CreateVolumeBackupPolicyRequest interceptedRequest =
+                CreateVolumeBackupPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>
+                transformer = CreateVolumeBackupPolicyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateVolumeBackupPolicyDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateVolumeBackupPolicyAssignmentResponse createVolumeBackupPolicyAssignment(
             CreateVolumeBackupPolicyAssignmentRequest request) {
         LOG.trace("Called createVolumeBackupPolicyAssignment");
@@ -975,6 +1008,36 @@ public class BlockstorageClient implements Blockstorage {
                 DeleteVolumeBackupConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVolumeBackupResponse>
                 transformer = DeleteVolumeBackupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteVolumeBackupPolicyResponse deleteVolumeBackupPolicy(
+            DeleteVolumeBackupPolicyRequest request) {
+        LOG.trace("Called deleteVolumeBackupPolicy");
+        final DeleteVolumeBackupPolicyRequest interceptedRequest =
+                DeleteVolumeBackupPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>
+                transformer = DeleteVolumeBackupPolicyConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1782,6 +1845,39 @@ public class BlockstorageClient implements Blockstorage {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateVolumeBackupDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateVolumeBackupPolicyResponse updateVolumeBackupPolicy(
+            UpdateVolumeBackupPolicyRequest request) {
+        LOG.trace("Called updateVolumeBackupPolicy");
+        final UpdateVolumeBackupPolicyRequest interceptedRequest =
+                UpdateVolumeBackupPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVolumeBackupPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>
+                transformer = UpdateVolumeBackupPolicyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateVolumeBackupPolicyDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateVolumeBackupPolicyConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateVolumeBackupPolicyConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateVolumeBackupPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static CreateVolumeBackupPolicyRequest interceptRequest(
+            CreateVolumeBackupPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            CreateVolumeBackupPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateVolumeBackupPolicyDetails(),
+                "createVolumeBackupPolicyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("volumeBackupPolicies");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, CreateVolumeBackupPolicyResponse>() {
+                            @Override
+                            public CreateVolumeBackupPolicyResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for CreateVolumeBackupPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VolumeBackupPolicy>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VolumeBackupPolicy.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VolumeBackupPolicy>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                CreateVolumeBackupPolicyResponse.Builder builder =
+                                        CreateVolumeBackupPolicyResponse.builder();
+
+                                builder.volumeBackupPolicy(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                CreateVolumeBackupPolicyResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteVolumeBackupPolicyConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteVolumeBackupPolicyConverter.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteVolumeBackupPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static DeleteVolumeBackupPolicyRequest interceptRequest(
+            DeleteVolumeBackupPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            DeleteVolumeBackupPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getPolicyId(), "policyId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("volumeBackupPolicies")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPolicyId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, DeleteVolumeBackupPolicyResponse>() {
+                            @Override
+                            public DeleteVolumeBackupPolicyResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for DeleteVolumeBackupPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                DeleteVolumeBackupPolicyResponse.Builder builder =
+                                        DeleteVolumeBackupPolicyResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                DeleteVolumeBackupPolicyResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVolumeBackupPoliciesConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVolumeBackupPoliciesConverter.java
@@ -46,6 +46,14 @@ public class ListVolumeBackupPoliciesConverter {
                                     request.getPage()));
         }
 
+        if (request.getCompartmentId() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateVolumeBackupPolicyConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateVolumeBackupPolicyConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateVolumeBackupPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static UpdateVolumeBackupPolicyRequest interceptRequest(
+            UpdateVolumeBackupPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            UpdateVolumeBackupPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getPolicyId(), "policyId must not be blank");
+        Validate.notNull(
+                request.getUpdateVolumeBackupPolicyDetails(),
+                "updateVolumeBackupPolicyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("volumeBackupPolicies")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPolicyId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response, UpdateVolumeBackupPolicyResponse>() {
+                            @Override
+                            public UpdateVolumeBackupPolicyResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for UpdateVolumeBackupPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VolumeBackupPolicy>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VolumeBackupPolicy.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VolumeBackupPolicy>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                UpdateVolumeBackupPolicyResponse.Builder builder =
+                                        UpdateVolumeBackupPolicyResponse.builder();
+
+                                builder.volumeBackupPolicy(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                UpdateVolumeBackupPolicyResponse responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeBackupPolicyDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeBackupPolicyDetails.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains properties for a scheduled backup policy.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateVolumeBackupPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateVolumeBackupPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+        private java.util.List<VolumeBackupSchedule> schedules;
+
+        public Builder schedules(java.util.List<VolumeBackupSchedule> schedules) {
+            this.schedules = schedules;
+            this.__explicitlySet__.add("schedules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateVolumeBackupPolicyDetails build() {
+            CreateVolumeBackupPolicyDetails __instance__ =
+                    new CreateVolumeBackupPolicyDetails(
+                            compartmentId, displayName, schedules, definedTags, freeformTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateVolumeBackupPolicyDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .schedules(o.getSchedules())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment that contains the backup policy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The collection of schedules that this policy will apply.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+    java.util.List<VolumeBackupSchedule> schedules;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -135,6 +135,15 @@ public class LaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
+        private LaunchOptions launchOptions;
+
+        public Builder launchOptions(LaunchOptions launchOptions) {
+            this.launchOptions = launchOptions;
+            this.__explicitlySet__.add("launchOptions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("metadata")
         private java.util.Map<String, String> metadata;
 
@@ -207,6 +216,7 @@ public class LaunchInstanceDetails {
                             hostnameLabel,
                             imageId,
                             ipxeScript,
+                            launchOptions,
                             metadata,
                             agentConfig,
                             shape,
@@ -232,6 +242,7 @@ public class LaunchInstanceDetails {
                             .hostnameLabel(o.getHostnameLabel())
                             .imageId(o.getImageId())
                             .ipxeScript(o.getIpxeScript())
+                            .launchOptions(o.getLaunchOptions())
                             .metadata(o.getMetadata())
                             .agentConfig(o.getAgentConfig())
                             .shape(o.getShape())
@@ -386,6 +397,9 @@ public class LaunchInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ipxeScript")
     String ipxeScript;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
+    LaunchOptions launchOptions;
 
     /**
      * Custom metadata key/value pairs that you provide, such as the SSH public key

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeBackupPolicyDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeBackupPolicyDetails.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains properties for updating a scheduled backup policy.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateVolumeBackupPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateVolumeBackupPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+        private java.util.List<VolumeBackupSchedule> schedules;
+
+        public Builder schedules(java.util.List<VolumeBackupSchedule> schedules) {
+            this.schedules = schedules;
+            this.__explicitlySet__.add("schedules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateVolumeBackupPolicyDetails build() {
+            UpdateVolumeBackupPolicyDetails __instance__ =
+                    new UpdateVolumeBackupPolicyDetails(
+                            displayName, schedules, definedTags, freeformTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateVolumeBackupPolicyDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .schedules(o.getSchedules())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The collection of schedules that this policy will apply.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+    java.util.List<VolumeBackupSchedule> schedules;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackupPolicy.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackupPolicy.java
@@ -66,12 +66,47 @@ public class VolumeBackupPolicy {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public VolumeBackupPolicy build() {
             VolumeBackupPolicy __instance__ =
-                    new VolumeBackupPolicy(displayName, id, schedules, timeCreated);
+                    new VolumeBackupPolicy(
+                            displayName,
+                            id,
+                            schedules,
+                            timeCreated,
+                            compartmentId,
+                            definedTags,
+                            freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -82,7 +117,10 @@ public class VolumeBackupPolicy {
                     displayName(o.getDisplayName())
                             .id(o.getId())
                             .schedules(o.getSchedules())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .compartmentId(o.getCompartmentId())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -122,6 +160,32 @@ public class VolumeBackupPolicy {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * The OCID of the compartment that contains the volume backup.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackupSchedule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeBackupSchedule.java
@@ -51,6 +51,51 @@ public class VolumeBackupSchedule {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("offsetType")
+        private OffsetType offsetType;
+
+        public Builder offsetType(OffsetType offsetType) {
+            this.offsetType = offsetType;
+            this.__explicitlySet__.add("offsetType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hourOfDay")
+        private Integer hourOfDay;
+
+        public Builder hourOfDay(Integer hourOfDay) {
+            this.hourOfDay = hourOfDay;
+            this.__explicitlySet__.add("hourOfDay");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dayOfWeek")
+        private DayOfWeek dayOfWeek;
+
+        public Builder dayOfWeek(DayOfWeek dayOfWeek) {
+            this.dayOfWeek = dayOfWeek;
+            this.__explicitlySet__.add("dayOfWeek");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dayOfMonth")
+        private Integer dayOfMonth;
+
+        public Builder dayOfMonth(Integer dayOfMonth) {
+            this.dayOfMonth = dayOfMonth;
+            this.__explicitlySet__.add("dayOfMonth");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("month")
+        private Month month;
+
+        public Builder month(Month month) {
+            this.month = month;
+            this.__explicitlySet__.add("month");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("retentionSeconds")
         private Integer retentionSeconds;
 
@@ -60,12 +105,31 @@ public class VolumeBackupSchedule {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private TimeZone timeZone;
+
+        public Builder timeZone(TimeZone timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public VolumeBackupSchedule build() {
             VolumeBackupSchedule __instance__ =
-                    new VolumeBackupSchedule(backupType, offsetSeconds, period, retentionSeconds);
+                    new VolumeBackupSchedule(
+                            backupType,
+                            offsetSeconds,
+                            period,
+                            offsetType,
+                            hourOfDay,
+                            dayOfWeek,
+                            dayOfMonth,
+                            month,
+                            retentionSeconds,
+                            timeZone);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -76,7 +140,13 @@ public class VolumeBackupSchedule {
                     backupType(o.getBackupType())
                             .offsetSeconds(o.getOffsetSeconds())
                             .period(o.getPeriod())
-                            .retentionSeconds(o.getRetentionSeconds());
+                            .offsetType(o.getOffsetType())
+                            .hourOfDay(o.getHourOfDay())
+                            .dayOfWeek(o.getDayOfWeek())
+                            .dayOfMonth(o.getDayOfMonth())
+                            .month(o.getMonth())
+                            .retentionSeconds(o.getRetentionSeconds())
+                            .timeZone(o.getTimeZone());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -201,12 +271,243 @@ public class VolumeBackupSchedule {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("period")
     Period period;
+    /**
+     * Indicates how offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the respones. `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`. `dayOfWeek` is applicable for period `ONE_WEEK`. `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`. 'month' is applicable for period 'ONE_YEAR'. They will be ignored in the requests for inapplicable periods. If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the respones. For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum OffsetType {
+        Structured("STRUCTURED"),
+        NumericSeconds("NUMERIC_SECONDS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, OffsetType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (OffsetType v : OffsetType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        OffsetType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static OffsetType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'OffsetType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Indicates how offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the respones. `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`. `dayOfWeek` is applicable for period `ONE_WEEK`. `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`. 'month' is applicable for period 'ONE_YEAR'. They will be ignored in the requests for inapplicable periods. If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the respones. For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("offsetType")
+    OffsetType offsetType;
+
+    /**
+     * The hour of the day to schedule the backup
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hourOfDay")
+    Integer hourOfDay;
+    /**
+     * The day of the week to schedule the backup
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DayOfWeek {
+        Monday("MONDAY"),
+        Tuesday("TUESDAY"),
+        Wednesday("WEDNESDAY"),
+        Thursday("THURSDAY"),
+        Friday("FRIDAY"),
+        Saturday("SATURDAY"),
+        Sunday("SUNDAY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DayOfWeek> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DayOfWeek v : DayOfWeek.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DayOfWeek(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DayOfWeek create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DayOfWeek', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The day of the week to schedule the backup
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dayOfWeek")
+    DayOfWeek dayOfWeek;
+
+    /**
+     * The day of the month to schedule the backup
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dayOfMonth")
+    Integer dayOfMonth;
+    /**
+     * The month of the year to schedule the backup
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Month {
+        January("JANUARY"),
+        February("FEBRUARY"),
+        March("MARCH"),
+        April("APRIL"),
+        May("MAY"),
+        June("JUNE"),
+        July("JULY"),
+        August("AUGUST"),
+        September("SEPTEMBER"),
+        October("OCTOBER"),
+        November("NOVEMBER"),
+        December("DECEMBER"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Month> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Month v : Month.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Month(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Month create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Month', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The month of the year to schedule the backup
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("month")
+    Month month;
 
     /**
      * How long, in seconds, backups created by this schedule should be kept until being automatically deleted.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionSeconds")
     Integer retentionSeconds;
+    /**
+     * Specifies what time zone is the schedule in
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TimeZone {
+        Utc("UTC"),
+        RegionalDataCenterTime("REGIONAL_DATA_CENTER_TIME"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TimeZone> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TimeZone v : TimeZone.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TimeZone(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TimeZone create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TimeZone', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies what time zone is the schedule in
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+    TimeZone timeZone;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateVolumeBackupPolicyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateVolumeBackupPolicyRequest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateVolumeBackupPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * Request to create a new scheduled backup policy.
+     */
+    private CreateVolumeBackupPolicyDetails createVolumeBackupPolicyDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVolumeBackupPolicyRequest o) {
+            createVolumeBackupPolicyDetails(o.getCreateVolumeBackupPolicyDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateVolumeBackupPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateVolumeBackupPolicyRequest
+         */
+        public CreateVolumeBackupPolicyRequest build() {
+            CreateVolumeBackupPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVolumeBackupPolicyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVolumeBackupPolicyRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteVolumeBackupPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the volume backup policy.
+     */
+    private String policyId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVolumeBackupPolicyRequest o) {
+            policyId(o.getPolicyId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteVolumeBackupPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteVolumeBackupPolicyRequest
+         */
+        public DeleteVolumeBackupPolicyRequest build() {
+            DeleteVolumeBackupPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVolumeBackupPoliciesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVolumeBackupPoliciesRequest.java
@@ -28,6 +28,13 @@ public class ListVolumeBackupPoliciesRequest extends com.oracle.bmc.requests.Bmc
      */
     private String page;
 
+    /**
+     * The OCID of the compartment to list.
+     * If no compartment is specified, list the predefined (Gold, Silver, Bronze) backup policies.
+     *
+     */
+    private String compartmentId;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -63,6 +70,7 @@ public class ListVolumeBackupPoliciesRequest extends com.oracle.bmc.requests.Bmc
         public Builder copy(ListVolumeBackupPoliciesRequest o) {
             limit(o.getLimit());
             page(o.getPage());
+            compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeBackupPolicyRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeBackupPolicyRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateVolumeBackupPolicyRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * The OCID of the volume backup policy.
+     */
+    private String policyId;
+
+    /**
+     * Update volume backup policy fields
+     */
+    private UpdateVolumeBackupPolicyDetails updateVolumeBackupPolicyDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVolumeBackupPolicyRequest o) {
+            policyId(o.getPolicyId());
+            updateVolumeBackupPolicyDetails(o.getUpdateVolumeBackupPolicyDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateVolumeBackupPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateVolumeBackupPolicyRequest
+         */
+        public UpdateVolumeBackupPolicyRequest build() {
+            UpdateVolumeBackupPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateVolumeBackupPolicyResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateVolumeBackupPolicyResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateVolumeBackupPolicyResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VolumeBackupPolicy instance.
+     */
+    private VolumeBackupPolicy volumeBackupPolicy;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVolumeBackupPolicyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            volumeBackupPolicy(o.getVolumeBackupPolicy());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteVolumeBackupPolicyResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteVolumeBackupPolicyResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteVolumeBackupPolicyResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVolumeBackupPolicyResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateVolumeBackupPolicyResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateVolumeBackupPolicyResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateVolumeBackupPolicyResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VolumeBackupPolicy instance.
+     */
+    private VolumeBackupPolicy volumeBackupPolicy;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVolumeBackupPolicyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            volumeBackupPolicy(o.getVolumeBackupPolicy());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface ShippingVendors extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface ShippingVendorsAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ShippingVendorsAsyncClient implements ShippingVendorsAsync {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ShippingVendorsClient implements ShippingVendors {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferAppliance extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferApplianceAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceAsyncClient implements TransferApplianceAsync {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceClient implements TransferAppliance {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferApplianceEntitlement extends AutoCloseable {
 
     /**
@@ -37,7 +37,7 @@ public interface TransferApplianceEntitlement extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+     * Create the Entitlement to use a Transfer Appliance. It requires some offline process of review and signatures before request is granted.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -53,4 +53,20 @@ public interface TransferApplianceEntitlement extends AutoCloseable {
      */
     GetTransferApplianceEntitlementResponse getTransferApplianceEntitlement(
             GetTransferApplianceEntitlementRequest request);
+
+    /**
+     * Lists Transfer Transfer Appliance Entitlement
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListTransferApplianceEntitlementResponse listTransferApplianceEntitlement(
+            ListTransferApplianceEntitlementRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    TransferApplianceEntitlementWaiters getWaiters();
 }

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferApplianceEntitlementAsync extends AutoCloseable {
 
     /**
@@ -37,7 +37,7 @@ public interface TransferApplianceEntitlementAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Create the Transfer Appliance Entitlement that allows customers to use Transfer Appliance
+     * Create the Entitlement to use a Transfer Appliance. It requires some offline process of review and signatures before request is granted.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -70,5 +70,23 @@ public interface TransferApplianceEntitlementAsync extends AutoCloseable {
                     com.oracle.bmc.responses.AsyncHandler<
                                     GetTransferApplianceEntitlementRequest,
                                     GetTransferApplianceEntitlementResponse>
+                            handler);
+
+    /**
+     * Lists Transfer Transfer Appliance Entitlement
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListTransferApplianceEntitlementResponse>
+            listTransferApplianceEntitlement(
+                    ListTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListTransferApplianceEntitlementRequest,
+                                    ListTransferApplianceEntitlementResponse>
                             handler);
 }

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceEntitlementAsyncClient implements TransferApplianceEntitlementAsync {
     /**
@@ -463,6 +463,86 @@ public class TransferApplianceEntitlementAsyncClient implements TransferApplianc
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetTransferApplianceEntitlementResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListTransferApplianceEntitlementResponse>
+            listTransferApplianceEntitlement(
+                    final ListTransferApplianceEntitlementRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListTransferApplianceEntitlementRequest,
+                                    ListTransferApplianceEntitlementResponse>
+                            handler) {
+        LOG.trace("Called async listTransferApplianceEntitlement");
+        final ListTransferApplianceEntitlementRequest interceptedRequest =
+                ListTransferApplianceEntitlementConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferApplianceEntitlementResponse>
+                transformer = ListTransferApplianceEntitlementConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListTransferApplianceEntitlementRequest,
+                        ListTransferApplianceEntitlementResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListTransferApplianceEntitlementRequest,
+                            ListTransferApplianceEntitlementResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListTransferApplianceEntitlementResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceEntitlementClient implements TransferApplianceEntitlement {
     /**
@@ -22,6 +22,8 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final TransferApplianceEntitlementWaiters waiters;
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
     private final com.oracle.bmc.http.internal.RestClient client;
@@ -172,6 +174,43 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
                     signingStrategyRequestSignerFactories,
             java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
             String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public TransferApplianceEntitlementClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
         this.authenticationDetailsProvider = authenticationDetailsProvider;
         com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
                 com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
@@ -205,6 +244,25 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
         this.client =
                 restClientFactory.create(
                         defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("TransferApplianceEntitlement-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new TransferApplianceEntitlementWaiters(executorService, this);
 
         if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
             com.oracle.bmc.auth.RegionProvider provider =
@@ -240,11 +298,23 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
     public static class Builder
             extends com.oracle.bmc.common.RegionalClientBuilder<
                     Builder, TransferApplianceEntitlementClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
         private Builder(com.oracle.bmc.Service service) {
             super(service);
             requestSignerFactory =
                     new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
                             com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
         }
 
         /**
@@ -263,7 +333,8 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
                     requestSignerFactory,
                     signingStrategyRequestSignerFactories,
                     additionalClientConfigurators,
-                    endpoint);
+                    endpoint,
+                    executorService);
         }
     }
 
@@ -365,5 +436,40 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
                                 return transformer.apply(response);
                             });
                 });
+    }
+
+    @Override
+    public ListTransferApplianceEntitlementResponse listTransferApplianceEntitlement(
+            ListTransferApplianceEntitlementRequest request) {
+        LOG.trace("Called listTransferApplianceEntitlement");
+        final ListTransferApplianceEntitlementRequest interceptedRequest =
+                ListTransferApplianceEntitlementConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListTransferApplianceEntitlementConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferApplianceEntitlementResponse>
+                transformer = ListTransferApplianceEntitlementConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public TransferApplianceEntitlementWaiters getWaiters() {
+        return waiters;
     }
 }

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementWaiters.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts;
+
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of TransferApplianceEntitlement.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
+@lombok.RequiredArgsConstructor
+public class TransferApplianceEntitlementWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final TransferApplianceEntitlement client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetTransferApplianceEntitlementRequest, GetTransferApplianceEntitlementResponse>
+            forTransferApplianceEntitlement(
+                    GetTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forTransferApplianceEntitlement(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetTransferApplianceEntitlementRequest, GetTransferApplianceEntitlementResponse>
+            forTransferApplianceEntitlement(
+                    GetTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState
+                            targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forTransferApplianceEntitlement(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetTransferApplianceEntitlementRequest, GetTransferApplianceEntitlementResponse>
+            forTransferApplianceEntitlement(
+                    GetTransferApplianceEntitlementRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forTransferApplianceEntitlement(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for TransferApplianceEntitlement.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetTransferApplianceEntitlementRequest, GetTransferApplianceEntitlementResponse>
+            forTransferApplianceEntitlement(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetTransferApplianceEntitlementRequest request,
+                    final com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetTransferApplianceEntitlementRequest,
+                                GetTransferApplianceEntitlementResponse>() {
+                            @Override
+                            public GetTransferApplianceEntitlementResponse apply(
+                                    GetTransferApplianceEntitlementRequest request) {
+                                return client.getTransferApplianceEntitlement(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetTransferApplianceEntitlementResponse>() {
+                            @Override
+                            public boolean apply(GetTransferApplianceEntitlementResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getTransferApplianceEntitlement()
+                                                .getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dts.model.TransferApplianceEntitlement.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.RequiredArgsConstructor
 public class TransferApplianceWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferDevice extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferDeviceAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferDeviceAsyncClient implements TransferDeviceAsync {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferDeviceClient implements TransferDevice {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.RequiredArgsConstructor
 public class TransferDeviceWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferJob extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferJobAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferJobAsyncClient implements TransferJobAsync {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferJobClient implements TransferJob {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.RequiredArgsConstructor
 public class TransferJobWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferPackage extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 public interface TransferPackageAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferPackageAsyncClient implements TransferPackageAsync {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class TransferPackageClient implements TransferPackage {
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.RequiredArgsConstructor
 public class TransferPackageWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class AttachDevicesToTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ChangeTransferJobCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceAdminCredentialsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceEntitlementConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class DetachDevicesFromTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceCertificateAuthorityCertificateConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceEncryptionPassphraseConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceEntitlementConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -26,7 +26,7 @@ public class GetTransferApplianceEntitlementConverter {
             com.oracle.bmc.http.internal.RestClient client,
             GetTransferApplianceEntitlementRequest request) {
         Validate.notNull(request, "request instance is required");
-        Validate.notBlank(request.getTenantId(), "tenantId must not be blank");
+        Validate.notBlank(request.getId(), "id must not be blank");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
@@ -34,11 +34,15 @@ public class GetTransferApplianceEntitlementConverter {
                         .path("transferApplianceEntitlement")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
-                                        request.getTenantId()));
+                                        request.getId()));
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
 
         if (request.getOpcRequestId() != null) {
             ib.header("opc-request-id", request.getOpcRequestId());

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ListShippingVendorsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferApplianceEntitlementConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dts.model.*;
+import com.oracle.bmc.dts.requests.*;
+import com.oracle.bmc.dts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
+@lombok.extern.slf4j.Slf4j
+public class ListTransferApplianceEntitlementConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static ListTransferApplianceEntitlementRequest interceptRequest(
+            ListTransferApplianceEntitlementRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            ListTransferApplianceEntitlementRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20171001").path("transferApplianceEntitlement");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, ListTransferApplianceEntitlementResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListTransferApplianceEntitlementResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                ListTransferApplianceEntitlementResponse>() {
+                            @Override
+                            public ListTransferApplianceEntitlementResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for ListTransferApplianceEntitlementResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                TransferApplianceEntitlementSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        TransferApplianceEntitlementSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<TransferApplianceEntitlementSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                ListTransferApplianceEntitlementResponse.Builder builder =
+                                        ListTransferApplianceEntitlementResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                ListTransferApplianceEntitlementResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferAppliancesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferDevicesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferJobsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferPackagesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -30,6 +30,15 @@ public class CreateTransferApplianceEntitlementDetails {
         public Builder compartmentId(String compartmentId) {
             this.compartmentId = compartmentId;
             this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
             return this;
         }
 
@@ -51,13 +60,37 @@ public class CreateTransferApplianceEntitlementDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateTransferApplianceEntitlementDetails build() {
             CreateTransferApplianceEntitlementDetails __instance__ =
                     new CreateTransferApplianceEntitlementDetails(
-                            compartmentId, requestorName, requestorEmail);
+                            compartmentId,
+                            displayName,
+                            requestorName,
+                            requestorEmail,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -66,8 +99,11 @@ public class CreateTransferApplianceEntitlementDetails {
         public Builder copy(CreateTransferApplianceEntitlementDetails o) {
             Builder copiedBuilder =
                     compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
                             .requestorName(o.getRequestorName())
-                            .requestorEmail(o.getRequestorEmail());
+                            .requestorEmail(o.getRequestorEmail())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -84,11 +120,30 @@ public class CreateTransferApplianceEntitlementDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
     @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
     String requestorName;
 
     @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
     String requestorEmail;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingAddress.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingVendors.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -231,6 +231,8 @@ public class TransferAppliance {
         Shipping("SHIPPING"),
         Delivered("DELIVERED"),
         Preparing("PREPARING"),
+        Finalized("FINALIZED"),
+        ReturnDelayed("RETURN_DELAYED"),
         ReturnShipped("RETURN_SHIPPED"),
         ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
         OracleReceived("ORACLE_RECEIVED"),

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -24,12 +24,30 @@ public class TransferApplianceEntitlement {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
-        private String tenantId;
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
 
-        public Builder tenantId(String tenantId) {
-            this.tenantId = tenantId;
-            this.__explicitlySet__.add("tenantId");
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
             return this;
         }
 
@@ -51,12 +69,21 @@ public class TransferApplianceEntitlement {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("status")
-        private Status status;
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
 
-        public Builder status(Status status) {
-            this.status = status;
-            this.__explicitlySet__.add("status");
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleStateDetails")
+        private String lifecycleStateDetails;
+
+        public Builder lifecycleStateDetails(String lifecycleStateDetails) {
+            this.lifecycleStateDetails = lifecycleStateDetails;
+            this.__explicitlySet__.add("lifecycleStateDetails");
             return this;
         }
 
@@ -78,18 +105,42 @@ public class TransferApplianceEntitlement {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public TransferApplianceEntitlement build() {
             TransferApplianceEntitlement __instance__ =
                     new TransferApplianceEntitlement(
-                            tenantId,
+                            id,
+                            compartmentId,
+                            displayName,
                             requestorName,
                             requestorEmail,
-                            status,
+                            lifecycleState,
+                            lifecycleStateDetails,
                             creationTime,
-                            updateTime);
+                            updateTime,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -97,12 +148,17 @@ public class TransferApplianceEntitlement {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TransferApplianceEntitlement o) {
             Builder copiedBuilder =
-                    tenantId(o.getTenantId())
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
                             .requestorName(o.getRequestorName())
                             .requestorEmail(o.getRequestorEmail())
-                            .status(o.getStatus())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleStateDetails(o.getLifecycleStateDetails())
                             .creationTime(o.getCreationTime())
-                            .updateTime(o.getUpdateTime());
+                            .updateTime(o.getUpdateTime())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -116,8 +172,14 @@ public class TransferApplianceEntitlement {
         return new Builder();
     }
 
-    @com.fasterxml.jackson.annotation.JsonProperty("tenantId")
-    String tenantId;
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
 
     @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
     String requestorName;
@@ -127,14 +189,11 @@ public class TransferApplianceEntitlement {
     /**
      **/
     @lombok.extern.slf4j.Slf4j
-    public enum Status {
-        Requested("REQUESTED"),
-        PendingSigning("PENDING_SIGNING"),
-        PendingApproval("PENDING_APPROVAL"),
-        TermsExpired("TERMS_EXPIRED"),
-        Approved("APPROVED"),
-        Rejected("REJECTED"),
-        Cancelled("CANCELLED"),
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Deleted("DELETED"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -143,18 +202,18 @@ public class TransferApplianceEntitlement {
         UnknownEnumValue(null);
 
         private final String value;
-        private static java.util.Map<String, Status> map;
+        private static java.util.Map<String, LifecycleState> map;
 
         static {
             map = new java.util.HashMap<>();
-            for (Status v : Status.values()) {
+            for (LifecycleState v : LifecycleState.values()) {
                 if (v != UnknownEnumValue) {
                     map.put(v.getValue(), v);
                 }
             }
         }
 
-        Status(String value) {
+        LifecycleState(String value) {
             this.value = value;
         }
 
@@ -164,25 +223,47 @@ public class TransferApplianceEntitlement {
         }
 
         @com.fasterxml.jackson.annotation.JsonCreator
-        public static Status create(String key) {
+        public static LifecycleState create(String key) {
             if (map.containsKey(key)) {
                 return map.get(key);
             }
             LOG.warn(
-                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
                     key);
             return UnknownEnumValue;
         }
     };
 
-    @com.fasterxml.jackson.annotation.JsonProperty("status")
-    Status status;
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A property that can contain details on the lifecycle.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleStateDetails")
+    String lifecycleStateDetails;
 
     @com.fasterxml.jackson.annotation.JsonProperty("creationTime")
     java.util.Date creationTime;
 
     @com.fasterxml.jackson.annotation.JsonProperty("updateTime")
     java.util.Date updateTime;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlementSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlementSummary.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TransferApplianceEntitlementSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TransferApplianceEntitlementSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+        private String requestorName;
+
+        public Builder requestorName(String requestorName) {
+            this.requestorName = requestorName;
+            this.__explicitlySet__.add("requestorName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+        private String requestorEmail;
+
+        public Builder requestorEmail(String requestorEmail) {
+            this.requestorEmail = requestorEmail;
+            this.__explicitlySet__.add("requestorEmail");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private TransferApplianceEntitlement.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(TransferApplianceEntitlement.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleStateDetails")
+        private String lifecycleStateDetails;
+
+        public Builder lifecycleStateDetails(String lifecycleStateDetails) {
+            this.lifecycleStateDetails = lifecycleStateDetails;
+            this.__explicitlySet__.add("lifecycleStateDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TransferApplianceEntitlementSummary build() {
+            TransferApplianceEntitlementSummary __instance__ =
+                    new TransferApplianceEntitlementSummary(
+                            id,
+                            compartmentId,
+                            displayName,
+                            requestorName,
+                            requestorEmail,
+                            lifecycleState,
+                            lifecycleStateDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TransferApplianceEntitlementSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .requestorName(o.getRequestorName())
+                            .requestorEmail(o.getRequestorEmail())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleStateDetails(o.getLifecycleStateDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorName")
+    String requestorName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requestorEmail")
+    String requestorEmail;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    TransferApplianceEntitlement.LifecycleState lifecycleState;
+
+    /**
+     * A property that can contain details on the lifecycle.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleStateDetails")
+    String lifecycleStateDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"foo-value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -101,6 +101,8 @@ public class TransferApplianceSummary {
         Shipping("SHIPPING"),
         Delivered("DELIVERED"),
         Preparing("PREPARING"),
+        Finalized("FINALIZED"),
+        ReturnDelayed("RETURN_DELAYED"),
         ReturnShipped("RETURN_SHIPPED"),
         ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
         OracleReceived("ORACLE_RECEIVED"),

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferDevice.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferJob.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferPackage.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -74,6 +74,7 @@ public class UpdateTransferApplianceDetails {
      **/
     public enum LifecycleState {
         Preparing("PREPARING"),
+        Finalized("FINALIZED"),
         Deleted("DELETED"),
         CustomerNeverReceived("CUSTOMER_NEVER_RECEIVED"),
         Cancelled("CANCELLED"),

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class AttachDevicesToTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ChangeTransferJobCompartmentRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceAdminCredentialsRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceEntitlementRequest extends com.oracle.bmc.requests.BmcRequest {
@@ -16,12 +16,19 @@ public class CreateTransferApplianceEntitlementRequest extends com.oracle.bmc.re
     private CreateTransferApplianceEntitlementDetails createTransferApplianceEntitlementDetails;
 
     /**
-     * opc retry token
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
      */
     private String opcRetryToken;
 
     /**
-     * opc request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
      */
     private String opcRequestId;
 

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DetachDevicesFromTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceCertificateAuthorityCertificateRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceEncryptionPassphraseRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
@@ -5,18 +5,30 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceEntitlementRequest extends com.oracle.bmc.requests.BmcRequest {
 
     /**
-     * Tenant Id
+     * Id of the Transfer Appliance Entitlement
      */
-    private String tenantId;
+    private String id;
 
     /**
-     * opc request id
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
      */
     private String opcRequestId;
 
@@ -53,7 +65,8 @@ public class GetTransferApplianceEntitlementRequest extends com.oracle.bmc.reque
          * @return this builder instance
          */
         public Builder copy(GetTransferApplianceEntitlementRequest o) {
-            tenantId(o.getTenantId());
+            id(o.getId());
+            opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListShippingVendorsRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferApplianceEntitlementRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.requests;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListTransferApplianceEntitlementRequest extends com.oracle.bmc.requests.BmcRequest {
+
+    /**
+     * compartment id
+     */
+    private String compartmentId;
+
+    /**
+     * filtering by Transfer Appliance Entitlement id
+     */
+    private String id;
+
+    /**
+     * filtering by displayName
+     */
+    private String displayName;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferApplianceEntitlementRequest o) {
+            compartmentId(o.getCompartmentId());
+            id(o.getId());
+            displayName(o.getDisplayName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListTransferApplianceEntitlementRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListTransferApplianceEntitlementRequest
+         */
+        public ListTransferApplianceEntitlementRequest build() {
+            ListTransferApplianceEntitlementRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferAppliancesRequest extends com.oracle.bmc.requests.BmcRequest {
@@ -29,6 +29,8 @@ public class ListTransferAppliancesRequest extends com.oracle.bmc.requests.BmcRe
         Shipping("SHIPPING"),
         Delivered("DELIVERED"),
         Preparing("PREPARING"),
+        Finalized("FINALIZED"),
+        ReturnDelayed("RETURN_DELAYED"),
         ReturnShipped("RETURN_SHIPPED"),
         ReturnShippedCancelled("RETURN_SHIPPED_CANCELLED"),
         OracleReceived("ORACLE_RECEIVED"),

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferDevicesRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferJobsRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferPackagesRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferApplianceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferJobRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class AttachDevicesToTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ChangeTransferJobCompartmentResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceAdminCredentialsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceEntitlementResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DetachDevicesFromTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceCertificateAuthorityCertificateResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceEncryptionPassphraseResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceEntitlementResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListShippingVendorsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferApplianceEntitlementResponse.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+package com.oracle.bmc.dts.responses;
+
+import com.oracle.bmc.dts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListTransferApplianceEntitlementResponse {
+
+    /**
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of TransferApplianceEntitlementSummary instances.
+     */
+    private java.util.List<TransferApplianceEntitlementSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListTransferApplianceEntitlementResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferAppliancesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferDevicesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferJobsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferPackagesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
@@ -5,7 +5,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.009")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.011")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferPackageResponse {

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ChangeHttpMonitorCompartmentConverter.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ChangeHttpMonitorCompartmentConverter.java
@@ -98,15 +98,6 @@ public class ChangeHttpMonitorCompartmentConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 ChangeHttpMonitorCompartmentResponse responseWrapper =
                                         builder.build();
 

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ChangePingMonitorCompartmentConverter.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ChangePingMonitorCompartmentConverter.java
@@ -98,15 +98,6 @@ public class ChangePingMonitorCompartmentConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
-                                }
-
                                 ChangePingMonitorCompartmentResponse responseWrapper =
                                         builder.build();
 

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ListHttpMonitorsConverter.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ListHttpMonitorsConverter.java
@@ -75,6 +75,14 @@ public class ListHttpMonitorsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getHomeRegion() != null) {
+            target =
+                    target.queryParam(
+                            "homeRegion",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getHomeRegion()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ListPingMonitorsConverter.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/internal/http/ListPingMonitorsConverter.java
@@ -75,6 +75,14 @@ public class ListPingMonitorsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getHomeRegion() != null) {
+            target =
+                    target.queryParam(
+                            "homeRegion",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getHomeRegion()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpMonitor.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpMonitor.java
@@ -41,6 +41,24 @@ public class HttpMonitor {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -176,6 +194,8 @@ public class HttpMonitor {
                     new HttpMonitor(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             targets,
                             vantagePointNames,
@@ -199,6 +219,8 @@ public class HttpMonitor {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .targets(o.getTargets())
                             .vantagePointNames(o.getVantagePointNames())
@@ -237,6 +259,20 @@ public class HttpMonitor {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpMonitorSummary.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpMonitorSummary.java
@@ -43,6 +43,24 @@ public class HttpMonitorSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -115,6 +133,8 @@ public class HttpMonitorSummary {
                     new HttpMonitorSummary(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             displayName,
                             intervalInSeconds,
@@ -131,6 +151,8 @@ public class HttpMonitorSummary {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .intervalInSeconds(o.getIntervalInSeconds())
@@ -162,6 +184,20 @@ public class HttpMonitorSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpProbe.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/HttpProbe.java
@@ -41,6 +41,24 @@ public class HttpProbe {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -130,6 +148,8 @@ public class HttpProbe {
                     new HttpProbe(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             targets,
                             vantagePointNames,
@@ -148,6 +168,8 @@ public class HttpProbe {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .targets(o.getTargets())
                             .vantagePointNames(o.getVantagePointNames())
@@ -181,6 +203,20 @@ public class HttpProbe {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingMonitor.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingMonitor.java
@@ -41,6 +41,24 @@ public class PingMonitor {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -149,6 +167,8 @@ public class PingMonitor {
                     new PingMonitor(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             targets,
                             vantagePointNames,
@@ -169,6 +189,8 @@ public class PingMonitor {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .targets(o.getTargets())
                             .vantagePointNames(o.getVantagePointNames())
@@ -204,6 +226,20 @@ public class PingMonitor {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingMonitorSummary.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingMonitorSummary.java
@@ -43,6 +43,24 @@ public class PingMonitorSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -115,6 +133,8 @@ public class PingMonitorSummary {
                     new PingMonitorSummary(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             displayName,
                             intervalInSeconds,
@@ -131,6 +151,8 @@ public class PingMonitorSummary {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .intervalInSeconds(o.getIntervalInSeconds())
@@ -162,6 +184,20 @@ public class PingMonitorSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingProbe.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/model/PingProbe.java
@@ -41,6 +41,24 @@ public class PingProbe {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+        private String homeRegion;
+
+        public Builder homeRegion(String homeRegion) {
+            this.homeRegion = homeRegion;
+            this.__explicitlySet__.add("homeRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -103,6 +121,8 @@ public class PingProbe {
                     new PingProbe(
                             id,
                             resultsUrl,
+                            homeRegion,
+                            timeCreated,
                             compartmentId,
                             targets,
                             vantagePointNames,
@@ -118,6 +138,8 @@ public class PingProbe {
             Builder copiedBuilder =
                     id(o.getId())
                             .resultsUrl(o.getResultsUrl())
+                            .homeRegion(o.getHomeRegion())
+                            .timeCreated(o.getTimeCreated())
                             .compartmentId(o.getCompartmentId())
                             .targets(o.getTargets())
                             .vantagePointNames(o.getVantagePointNames())
@@ -148,6 +170,20 @@ public class PingProbe {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resultsUrl")
     String resultsUrl;
+
+    /**
+     * The region where updates must be made and where results must be fetched from.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("homeRegion")
+    String homeRegion;
+
+    /**
+     * The RFC 3339-formatted creation date and time of the probe.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
 
     /**
      * The OCID of the compartment.

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/requests/ListHttpMonitorsRequest.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/requests/ListHttpMonitorsRequest.java
@@ -46,6 +46,7 @@ public class ListHttpMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
     public enum SortBy {
         Id("id"),
         DisplayName("displayName"),
+        TimeCreated("timeCreated"),
         ;
 
         private final String value;
@@ -122,6 +123,11 @@ public class ListHttpMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
      */
     private String displayName;
 
+    /**
+     * Filters results that match the `homeRegion`.
+     */
+    private String homeRegion;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -162,6 +168,7 @@ public class ListHttpMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             displayName(o.getDisplayName());
+            homeRegion(o.getHomeRegion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/requests/ListPingMonitorsRequest.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/requests/ListPingMonitorsRequest.java
@@ -46,6 +46,7 @@ public class ListPingMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
     public enum SortBy {
         Id("id"),
         DisplayName("displayName"),
+        TimeCreated("timeCreated"),
         ;
 
         private final String value;
@@ -122,6 +123,11 @@ public class ListPingMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
      */
     private String displayName;
 
+    /**
+     * Filters results that match the `homeRegion`.
+     */
+    private String homeRegion;
+
     public static class Builder {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
@@ -162,6 +168,7 @@ public class ListPingMonitorsRequest extends com.oracle.bmc.requests.BmcRequest 
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             displayName(o.getDisplayName());
+            homeRegion(o.getHomeRegion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/responses/ChangeHttpMonitorCompartmentResponse.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/responses/ChangeHttpMonitorCompartmentResponse.java
@@ -18,11 +18,6 @@ public class ChangeHttpMonitorCompartmentResponse {
      */
     private String opcRequestId;
 
-    /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
     public static class Builder {
         /**
          * Copy method to populate the builder with values from the given instance.
@@ -30,7 +25,6 @@ public class ChangeHttpMonitorCompartmentResponse {
          */
         public Builder copy(ChangeHttpMonitorCompartmentResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
 
             return this;
         }

--- a/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/responses/ChangePingMonitorCompartmentResponse.java
+++ b/bmc-healthchecks/src/main/java/com/oracle/bmc/healthchecks/responses/ChangePingMonitorCompartmentResponse.java
@@ -18,11 +18,6 @@ public class ChangePingMonitorCompartmentResponse {
      */
     private String opcRequestId;
 
-    /**
-     * For optimistic concurrency control. See `if-match`.
-     */
-    private String etag;
-
     public static class Builder {
         /**
          * Copy method to populate the builder with values from the given instance.
@@ -30,7 +25,6 @@ public class ChangePingMonitorCompartmentResponse {
          */
         public Builder copy(ChangePingMonitorCompartmentResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
 
             return this;
         }

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/src/main/java/com/oracle/bmc/ons/internal/http/UpdateTopicConverter.java
+++ b/bmc-ons/src/main/java/com/oracle/bmc/ons/internal/http/UpdateTopicConverter.java
@@ -25,6 +25,7 @@ public class UpdateTopicConverter {
             com.oracle.bmc.http.internal.RestClient client, UpdateTopicRequest request) {
         Validate.notNull(request, "request instance is required");
         Validate.notBlank(request.getTopicId(), "topicId must not be blank");
+        Validate.notNull(request.getTopicAttributesDetails(), "topicAttributesDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()

--- a/bmc-ons/src/main/java/com/oracle/bmc/ons/model/CreateSubscriptionDetails.java
+++ b/bmc-ons/src/main/java/com/oracle/bmc/ons/model/CreateSubscriptionDetails.java
@@ -146,6 +146,13 @@ public class CreateSubscriptionDetails {
     /**
      * The protocol used for the subscription.
      * <p>
+     * Allowed values:
+     *   * `CUSTOM_HTTPS`
+     *   * `EMAIL`
+     *   * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+     *   * `PAGERDUTY`
+     *   * `SLACK`
+     * <p>
      * For information about subscription protocols, see
      * [To create a subscription](https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
      *

--- a/bmc-ons/src/main/java/com/oracle/bmc/ons/requests/GetConfirmSubscriptionRequest.java
+++ b/bmc-ons/src/main/java/com/oracle/bmc/ons/requests/GetConfirmSubscriptionRequest.java
@@ -24,6 +24,13 @@ public class GetConfirmSubscriptionRequest extends com.oracle.bmc.requests.BmcRe
     /**
      * The protocol used for the subscription.
      * <p>
+     * Allowed values:
+     *   * `CUSTOM_HTTPS`
+     *   * `EMAIL`
+     *   * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+     *   * `PAGERDUTY`
+     *   * `SLACK`
+     * <p>
      * For information about subscription protocols, see
      * [To create a subscription](https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
      *

--- a/bmc-ons/src/main/java/com/oracle/bmc/ons/requests/GetUnsubscriptionRequest.java
+++ b/bmc-ons/src/main/java/com/oracle/bmc/ons/requests/GetUnsubscriptionRequest.java
@@ -24,6 +24,13 @@ public class GetUnsubscriptionRequest extends com.oracle.bmc.requests.BmcRequest
     /**
      * The protocol used for the subscription.
      * <p>
+     * Allowed values:
+     *   * `CUSTOM_HTTPS`
+     *   * `EMAIL`
+     *   * `HTTPS` (deprecated; for PagerDuty endpoints, use `PAGERDUTY`)
+     *   * `PAGERDUTY`
+     *   * `SLACK`
+     * <p>
      * For information about subscription protocols, see
      * [To create a subscription](https://docs.cloud.oracle.com/iaas/Content/Notification/Tasks/managingtopicsandsubscriptions.htm#createSub).
      *

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.8.2</version>
+    <version>1.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.8.2</version>
+      <version>1.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.8.2</version>
+  <version>1.9.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for the new schema for events in the Audit service

- Support for entitlements in the Data Transfer service

- Support for custom scheduled backup policies on volumes in the Block Storage service

- Support for specifying the network type when launching virtual machine instances in the Compute service

- Support for Monitoring service integration in the Health Checks service



### Breaking changes

- For `com.oracle.bmc.dts.model.TransferApplianceEntitlement`:

	- The `Status` enum has been removed and replaced with `LifecycleState`

	- The `tenantId` parameter has been renamed as `id`

- The `eTag` parameter has been removed from `com.oracle.bmc.healthchecks.responses.ChangeHttpMonitorCompartmentResponse`

- The Audit service version to support the new schema was increased to 20190901.  Older versions of the SDK (< 1.9.0) will continue to function to support Audit service version 20160918
