### PR TITLE
Runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For details on compatibility, advanced configurations, and add-ons, see [Configu
 Examples can be found [here](/bmc-examples/src/main/java/).
 
 You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties,
-for example: `ObjectStorageGetBucketExample` class dwwhich requires 3 argumentsxi which are OCID of the compartment, name of bucket, name of object. This example class can be run as follows:
+for example: `ObjectStorageGetBucketExample` class requires 3 arguments which are OCID of the compartment, name of bucket, name of object. This example class can be executed as follows:
 
 ```
 mvn -am -pl bmc-examples exec:java -Dexec.mainClass=ObjectStorageGetBucketExample \

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ For details on compatibility, advanced configurations, and add-ons, see [Configu
 
 Examples can be found [here](/bmc-examples/src/main/java/).
 
-You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties, for example
+You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties, such as it's the case 
+for the `ObjectStorageGetBucketExample` class that requires 3 arguments: OCID of the compartment, name of bucket, name of object.
 
 ```
 mvn -am -pl bmc-examples exec:java -Dexec.mainClass=ObjectStorageGetBucketExample \
-  -Dexec.arguments=ocid1.compartment.oc1..aaaaabaaoht5722yrrthjpjdpvrfkng2rgzfbh32rbwa5hlanhqlafpl3tsa,test,sample
+  -Dexec.arguments=compartment_ocid,bucket_name,object_name
 ```
+
+Where `compartment_id`, `bucket_name`, and `object_name` should be substituted with appropriate values according to your setup.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For details on compatibility, advanced configurations, and add-ons, see [Configu
 Examples can be found [here](/bmc-examples/src/main/java/).
 
 You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties,
-for exiample in the `ObjectStorageGetBucketExample` class which requires 3 arguments: OCID of the compartment, name of bucket, name of object.
+for example: `ObjectStorageGetBucketExample` class dwwhich requires 3 argumentsxi which are OCID of the compartment, name of bucket, name of object. This example class can be run as follows:
 
 ```
 mvn -am -pl bmc-examples exec:java -Dexec.mainClass=ObjectStorageGetBucketExample \

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For details on compatibility, advanced configurations, and add-ons, see [Configu
 
 Examples can be found [here](/bmc-examples/src/main/java/).
 
-You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties, such as it's the case 
-for the `ObjectStorageGetBucketExample` class that requires 3 arguments: OCID of the compartment, name of bucket, name of object.
+You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties,
+for exiample in the `ObjectStorageGetBucketExample` class which requires 3 arguments: OCID of the compartment, name of bucket, name of object.
 
 ```
 mvn -am -pl bmc-examples exec:java -Dexec.mainClass=ObjectStorageGetBucketExample \

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ For details on compatibility, advanced configurations, and add-ons, see [Configu
 
 Examples can be found [here](/bmc-examples/src/main/java/).
 
+You may run any example by invoking the `exec:java` goal and passing appropriate values for `exec.mainClass` and `.exec.arguments` properties, for example
+
+```
+mvn -am -pl bmc-examples exec:java -Dexec.mainClass=ObjectStorageGetBucketExample \
+  -Dexec.arguments=ocid1.compartment.oc1..aaaaabaaoht5722yrrthjpjdpvrfkng2rgzfbh32rbwa5hlanhqlafpl3tsa,test,sample
+```
+
 ## Documentation
 
 Full documentation, including prerequisites, installation, and configuration instructions, is available [here](https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/javasdk.htm).

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -272,4 +272,16 @@
       <artifactId>oci-java-sdk-managementagent</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <configuration>
+            <skip>false</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
     <powermock.version>1.7.4</powermock.version>
     <excluded.testcases>**/*IntegrationAutoTest.java</excluded.testcases>
     <dev.profile.skip.javadoc>true</dev.profile.skip.javadoc>
+    <exec.skip>true</exec.skip>
+    <exec.mainClass>com.acme.Undefined</exec.mainClass>
   </properties>
   <profiles>
     <profile>
@@ -457,6 +459,12 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.6.0</version>
+          <inherited>true</inherited>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -477,6 +485,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Allow examples to be executed from the command line by configuring the `exec-maven-plugin`.