### PR TITLE
Releasing version 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.18.0 - 2020-06-09
+### Added
+- Support for returning the database version of backups in the Database service
+- Support for patching on Exadata Cloud at Customer resources in the Database service
+- Support for new lifecycle substates on instances in the Digital Assistant service
+- Support for file servers in the Integration service
+- Support for deleting non-empty tag namespaces and bulk deleting tags in the Identity service
+- Support for bulk move and bulk delete of resources by compartment in the Identity service
+
+
+### Breaking Changes
+- Data type for paramater `dataStorageSizeInTBs` changed from `Integer` to `Double` in the Database service
+- Enum `LifecycleState` has removed the state `Offline` and added `Disconnected` in the Database service
+
 ## 1.17.5 - 2020-06-02
 ### Added
 - Support for optionally supplying a signature when deleting an agreement in the Marketplace service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,300 +19,300 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
@@ -97,6 +97,7 @@ public class RegionTest {
                         .property(ClientProperties.CONNECT_TIMEOUT, 10000)
                         .property(ClientProperties.READ_TIMEOUT, 60000));
         Region.hasUsedInstanceMetadataService = false;
+        Region.enableInstanceMetadataService();
     }
 
     @Test

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -240,7 +240,7 @@ public interface Database extends AutoCloseable {
             CreateDataGuardAssociationRequest request);
 
     /**
-     * Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies only to Exadata DB systems.
+     * Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata DB systems and Exadata Cloud at Customer.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -249,7 +249,7 @@ public interface Database extends AutoCloseable {
     CreateDatabaseResponse createDatabase(CreateDatabaseRequest request);
 
     /**
-     * Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies only to bare metal and Exadata DB systems.
+     * Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -373,11 +373,9 @@ public interface Database extends AutoCloseable {
     DeleteDatabaseResponse deleteDatabase(DeleteDatabaseRequest request);
 
     /**
-     * Deletes a Database Home. Applies only to bare metal and Exadata DB systems.
+     * Deletes a Database Home. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
      * <p>
-     * The Database Home and its database data are local to the DB system, and on a bare metal DB system, both are lost when you delete the Database Home. Oracle recommends that you back up any data on the DB system before you delete it. You can use the `performFinalBackup` parameter with this operation on bare metal DB systems.
-     * <p>
-     * On an Exadata DB system, the delete request is rejected if the Database Home is not empty. You must terminate all databases in the Database Home before you delete the home. The `performFinalBackup` parameter is not used with this operation on Exadata DB systems.
+     * Oracle recommends that you use the `performFinalBackup` parameter to back up any data on a bare metal DB system before you delete a Database Home. On an Exadata Cloud at Customer system or an Exadata DB system, you can delete a Database Home only when there are no databases in it and therefore you cannot use the `performFinalBackup` parameter to back up data.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -732,6 +730,25 @@ public interface Database extends AutoCloseable {
     GetVmClusterNetworkResponse getVmClusterNetwork(GetVmClusterNetworkRequest request);
 
     /**
+     * Gets information about a specified patch package.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetVmClusterPatchResponse getVmClusterPatch(GetVmClusterPatchRequest request);
+
+    /**
+     * Gets the patch history details for the specified patchHistoryEntryId.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetVmClusterPatchHistoryEntryResponse getVmClusterPatchHistoryEntry(
+            GetVmClusterPatchHistoryEntryRequest request);
+
+    /**
      * Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
      *
      * @param request The request object containing the details to send
@@ -1009,6 +1026,25 @@ public interface Database extends AutoCloseable {
     ListVmClusterNetworksResponse listVmClusterNetworks(ListVmClusterNetworksRequest request);
 
     /**
+     * Gets the history of the patch actions performed on the specified Vm cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListVmClusterPatchHistoryEntriesResponse listVmClusterPatchHistoryEntries(
+            ListVmClusterPatchHistoryEntriesRequest request);
+
+    /**
+     * Lists the patches applicable to the requested Vm cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListVmClusterPatchesResponse listVmClusterPatches(ListVmClusterPatchesRequest request);
+
+    /**
      * Gets a list of the VM clusters in the specified compartment.
      *
      * @param request The request object containing the details to send
@@ -1048,7 +1084,7 @@ public interface Database extends AutoCloseable {
             RestartAutonomousContainerDatabaseRequest request);
 
     /**
-     * Restarts the specified Autonomous Database. Restart supported only for databases using dedicated Exadata infrastructure.
+     * Restarts the specified Autonomous Database.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -385,7 +385,7 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies only to Exadata DB systems.
+     * Creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata DB systems and Exadata Cloud at Customer.
      *
      *
      * @param request The request object containing the details to send
@@ -401,7 +401,7 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies only to bare metal and Exadata DB systems.
+     * Creates a new Database Home in the specified DB system based on the request parameters you provide. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
      *
      *
      * @param request The request object containing the details to send
@@ -615,11 +615,9 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes a Database Home. Applies only to bare metal and Exadata DB systems.
+     * Deletes a Database Home. Applies to bare metal DB systems, Exadata DB systems, and Exadata Cloud at Customer systems.
      * <p>
-     * The Database Home and its database data are local to the DB system, and on a bare metal DB system, both are lost when you delete the Database Home. Oracle recommends that you back up any data on the DB system before you delete it. You can use the `performFinalBackup` parameter with this operation on bare metal DB systems.
-     * <p>
-     * On an Exadata DB system, the delete request is rejected if the Database Home is not empty. You must terminate all databases in the Database Home before you delete the home. The `performFinalBackup` parameter is not used with this operation on Exadata DB systems.
+     * Oracle recommends that you use the `performFinalBackup` parameter to back up any data on a bare metal DB system before you delete a Database Home. On an Exadata Cloud at Customer system or an Exadata DB system, you can delete a Database Home only when there are no databases in it and therefore you cannot use the `performFinalBackup` parameter to back up data.
      *
      *
      * @param request The request object containing the details to send
@@ -1268,6 +1266,42 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets information about a specified patch package.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVmClusterPatchResponse> getVmClusterPatch(
+            GetVmClusterPatchRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetVmClusterPatchRequest, GetVmClusterPatchResponse>
+                    handler);
+
+    /**
+     * Gets the patch history details for the specified patchHistoryEntryId.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVmClusterPatchHistoryEntryResponse>
+            getVmClusterPatchHistoryEntry(
+                    GetVmClusterPatchHistoryEntryRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetVmClusterPatchHistoryEntryRequest,
+                                    GetVmClusterPatchHistoryEntryResponse>
+                            handler);
+
+    /**
      * Launches a new Autonomous Exadata Infrastructure in the specified compartment and availability domain.
      *
      *
@@ -1772,6 +1806,42 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets the history of the patch actions performed on the specified Vm cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVmClusterPatchHistoryEntriesResponse>
+            listVmClusterPatchHistoryEntries(
+                    ListVmClusterPatchHistoryEntriesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListVmClusterPatchHistoryEntriesRequest,
+                                    ListVmClusterPatchHistoryEntriesResponse>
+                            handler);
+
+    /**
+     * Lists the patches applicable to the requested Vm cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVmClusterPatchesResponse> listVmClusterPatches(
+            ListVmClusterPatchesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>
+                    handler);
+
+    /**
      * Gets a list of the VM clusters in the specified compartment.
      *
      *
@@ -1845,7 +1915,7 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Restarts the specified Autonomous Database. Restart supported only for databases using dedicated Exadata infrastructure.
+     * Restarts the specified Autonomous Database.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -6051,6 +6051,159 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetVmClusterPatchResponse> getVmClusterPatch(
+            final GetVmClusterPatchRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetVmClusterPatchRequest, GetVmClusterPatchResponse>
+                    handler) {
+        LOG.trace("Called async getVmClusterPatch");
+        final GetVmClusterPatchRequest interceptedRequest =
+                GetVmClusterPatchConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterPatchConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterPatchResponse>
+                transformer = GetVmClusterPatchConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetVmClusterPatchRequest, GetVmClusterPatchResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetVmClusterPatchRequest, GetVmClusterPatchResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetVmClusterPatchResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetVmClusterPatchHistoryEntryResponse>
+            getVmClusterPatchHistoryEntry(
+                    final GetVmClusterPatchHistoryEntryRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetVmClusterPatchHistoryEntryRequest,
+                                    GetVmClusterPatchHistoryEntryResponse>
+                            handler) {
+        LOG.trace("Called async getVmClusterPatchHistoryEntry");
+        final GetVmClusterPatchHistoryEntryRequest interceptedRequest =
+                GetVmClusterPatchHistoryEntryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterPatchHistoryEntryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVmClusterPatchHistoryEntryResponse>
+                transformer = GetVmClusterPatchHistoryEntryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetVmClusterPatchHistoryEntryRequest, GetVmClusterPatchHistoryEntryResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetVmClusterPatchHistoryEntryRequest,
+                            GetVmClusterPatchHistoryEntryResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetVmClusterPatchHistoryEntryResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<LaunchAutonomousExadataInfrastructureResponse>
             launchAutonomousExadataInfrastructure(
                     final LaunchAutonomousExadataInfrastructureRequest request,
@@ -8287,6 +8440,162 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, ListVmClusterNetworksResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVmClusterPatchHistoryEntriesResponse>
+            listVmClusterPatchHistoryEntries(
+                    final ListVmClusterPatchHistoryEntriesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListVmClusterPatchHistoryEntriesRequest,
+                                    ListVmClusterPatchHistoryEntriesResponse>
+                            handler) {
+        LOG.trace("Called async listVmClusterPatchHistoryEntries");
+        final ListVmClusterPatchHistoryEntriesRequest interceptedRequest =
+                ListVmClusterPatchHistoryEntriesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterPatchHistoryEntriesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVmClusterPatchHistoryEntriesResponse>
+                transformer = ListVmClusterPatchHistoryEntriesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListVmClusterPatchHistoryEntriesRequest,
+                        ListVmClusterPatchHistoryEntriesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListVmClusterPatchHistoryEntriesRequest,
+                            ListVmClusterPatchHistoryEntriesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListVmClusterPatchHistoryEntriesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVmClusterPatchesResponse> listVmClusterPatches(
+            final ListVmClusterPatchesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>
+                    handler) {
+        LOG.trace("Called async listVmClusterPatches");
+        final ListVmClusterPatchesRequest interceptedRequest =
+                ListVmClusterPatchesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterPatchesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVmClusterPatchesResponse>
+                transformer = ListVmClusterPatchesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListVmClusterPatchesResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -2588,6 +2588,64 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public GetVmClusterPatchResponse getVmClusterPatch(GetVmClusterPatchRequest request) {
+        LOG.trace("Called getVmClusterPatch");
+        final GetVmClusterPatchRequest interceptedRequest =
+                GetVmClusterPatchConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterPatchConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetVmClusterPatchResponse>
+                transformer = GetVmClusterPatchConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetVmClusterPatchHistoryEntryResponse getVmClusterPatchHistoryEntry(
+            GetVmClusterPatchHistoryEntryRequest request) {
+        LOG.trace("Called getVmClusterPatchHistoryEntry");
+        final GetVmClusterPatchHistoryEntryRequest interceptedRequest =
+                GetVmClusterPatchHistoryEntryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVmClusterPatchHistoryEntryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVmClusterPatchHistoryEntryResponse>
+                transformer = GetVmClusterPatchHistoryEntryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public LaunchAutonomousExadataInfrastructureResponse launchAutonomousExadataInfrastructure(
             LaunchAutonomousExadataInfrastructureRequest request) {
         LOG.trace("Called launchAutonomousExadataInfrastructure");
@@ -3423,6 +3481,64 @@ public class DatabaseClient implements Database {
                 ListVmClusterNetworksConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClusterNetworksResponse>
                 transformer = ListVmClusterNetworksConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVmClusterPatchHistoryEntriesResponse listVmClusterPatchHistoryEntries(
+            ListVmClusterPatchHistoryEntriesRequest request) {
+        LOG.trace("Called listVmClusterPatchHistoryEntries");
+        final ListVmClusterPatchHistoryEntriesRequest interceptedRequest =
+                ListVmClusterPatchHistoryEntriesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterPatchHistoryEntriesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVmClusterPatchHistoryEntriesResponse>
+                transformer = ListVmClusterPatchHistoryEntriesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVmClusterPatchesResponse listVmClusterPatches(ListVmClusterPatchesRequest request) {
+        LOG.trace("Called listVmClusterPatches");
+        final ListVmClusterPatchesRequest interceptedRequest =
+                ListVmClusterPatchesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVmClusterPatchesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListVmClusterPatchesResponse>
+                transformer = ListVmClusterPatchesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
@@ -3108,6 +3108,243 @@ public class DatabasePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listVmClusterPatchHistoryEntries operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVmClusterPatchHistoryEntriesResponse>
+            listVmClusterPatchHistoryEntriesResponseIterator(
+                    final ListVmClusterPatchHistoryEntriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVmClusterPatchHistoryEntriesRequest.Builder,
+                ListVmClusterPatchHistoryEntriesRequest, ListVmClusterPatchHistoryEntriesResponse>(
+                new com.google.common.base.Supplier<
+                        ListVmClusterPatchHistoryEntriesRequest.Builder>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesRequest.Builder get() {
+                        return ListVmClusterPatchHistoryEntriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchHistoryEntriesResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterPatchHistoryEntriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterPatchHistoryEntriesRequest.Builder>,
+                        ListVmClusterPatchHistoryEntriesRequest>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterPatchHistoryEntriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchHistoryEntriesRequest,
+                        ListVmClusterPatchHistoryEntriesResponse>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesResponse apply(
+                            ListVmClusterPatchHistoryEntriesRequest request) {
+                        return client.listVmClusterPatchHistoryEntries(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.PatchHistoryEntrySummary} objects
+     * contained in responses from the listVmClusterPatchHistoryEntries operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.PatchHistoryEntrySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.PatchHistoryEntrySummary>
+            listVmClusterPatchHistoryEntriesRecordIterator(
+                    final ListVmClusterPatchHistoryEntriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVmClusterPatchHistoryEntriesRequest.Builder,
+                ListVmClusterPatchHistoryEntriesRequest, ListVmClusterPatchHistoryEntriesResponse,
+                com.oracle.bmc.database.model.PatchHistoryEntrySummary>(
+                new com.google.common.base.Supplier<
+                        ListVmClusterPatchHistoryEntriesRequest.Builder>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesRequest.Builder get() {
+                        return ListVmClusterPatchHistoryEntriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchHistoryEntriesResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterPatchHistoryEntriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterPatchHistoryEntriesRequest.Builder>,
+                        ListVmClusterPatchHistoryEntriesRequest>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterPatchHistoryEntriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchHistoryEntriesRequest,
+                        ListVmClusterPatchHistoryEntriesResponse>() {
+                    @Override
+                    public ListVmClusterPatchHistoryEntriesResponse apply(
+                            ListVmClusterPatchHistoryEntriesRequest request) {
+                        return client.listVmClusterPatchHistoryEntries(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchHistoryEntriesResponse,
+                        java.util.List<com.oracle.bmc.database.model.PatchHistoryEntrySummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.PatchHistoryEntrySummary>
+                            apply(ListVmClusterPatchHistoryEntriesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listVmClusterPatches operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVmClusterPatchesResponse> listVmClusterPatchesResponseIterator(
+            final ListVmClusterPatchesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVmClusterPatchesRequest.Builder, ListVmClusterPatchesRequest,
+                ListVmClusterPatchesResponse>(
+                new com.google.common.base.Supplier<ListVmClusterPatchesRequest.Builder>() {
+                    @Override
+                    public ListVmClusterPatchesRequest.Builder get() {
+                        return ListVmClusterPatchesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClusterPatchesResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterPatchesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterPatchesRequest.Builder>,
+                        ListVmClusterPatchesRequest>() {
+                    @Override
+                    public ListVmClusterPatchesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterPatchesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>() {
+                    @Override
+                    public ListVmClusterPatchesResponse apply(ListVmClusterPatchesRequest request) {
+                        return client.listVmClusterPatches(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.PatchSummary} objects
+     * contained in responses from the listVmClusterPatches operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.PatchSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.PatchSummary> listVmClusterPatchesRecordIterator(
+            final ListVmClusterPatchesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVmClusterPatchesRequest.Builder, ListVmClusterPatchesRequest,
+                ListVmClusterPatchesResponse, com.oracle.bmc.database.model.PatchSummary>(
+                new com.google.common.base.Supplier<ListVmClusterPatchesRequest.Builder>() {
+                    @Override
+                    public ListVmClusterPatchesRequest.Builder get() {
+                        return ListVmClusterPatchesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVmClusterPatchesResponse, String>() {
+                    @Override
+                    public String apply(ListVmClusterPatchesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVmClusterPatchesRequest.Builder>,
+                        ListVmClusterPatchesRequest>() {
+                    @Override
+                    public ListVmClusterPatchesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVmClusterPatchesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchesRequest, ListVmClusterPatchesResponse>() {
+                    @Override
+                    public ListVmClusterPatchesResponse apply(ListVmClusterPatchesRequest request) {
+                        return client.listVmClusterPatches(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVmClusterPatchesResponse,
+                        java.util.List<com.oracle.bmc.database.model.PatchSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.PatchSummary> apply(
+                            ListVmClusterPatchesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listVmClusters operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterPatchConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterPatchConverter.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVmClusterPatchConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.GetVmClusterPatchRequest interceptRequest(
+            com.oracle.bmc.database.requests.GetVmClusterPatchRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.GetVmClusterPatchRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+        Validate.notBlank(request.getPatchId(), "patchId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("patches")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatchId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.GetVmClusterPatchResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.GetVmClusterPatchResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses.GetVmClusterPatchResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses.GetVmClusterPatchResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetVmClusterPatchResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Patch>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Patch.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Patch> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.GetVmClusterPatchResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetVmClusterPatchResponse.builder();
+
+                                builder.patch(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.GetVmClusterPatchResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterPatchHistoryEntryConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetVmClusterPatchHistoryEntryConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVmClusterPatchHistoryEntryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.GetVmClusterPatchHistoryEntryRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.GetVmClusterPatchHistoryEntryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.GetVmClusterPatchHistoryEntryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+        Validate.notBlank(
+                request.getPatchHistoryEntryId(), "patchHistoryEntryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("patchHistoryEntries")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatchHistoryEntryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.GetVmClusterPatchHistoryEntryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.GetVmClusterPatchHistoryEntryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .GetVmClusterPatchHistoryEntryResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .GetVmClusterPatchHistoryEntryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetVmClusterPatchHistoryEntryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PatchHistoryEntry>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PatchHistoryEntry.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PatchHistoryEntry>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .GetVmClusterPatchHistoryEntryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetVmClusterPatchHistoryEntryResponse
+                                                        .builder();
+
+                                builder.patchHistoryEntry(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .GetVmClusterPatchHistoryEntryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterPatchHistoryEntriesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterPatchHistoryEntriesConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListVmClusterPatchHistoryEntriesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListVmClusterPatchHistoryEntriesRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.ListVmClusterPatchHistoryEntriesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListVmClusterPatchHistoryEntriesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("patchHistoryEntries");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListVmClusterPatchHistoryEntriesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListVmClusterPatchHistoryEntriesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListVmClusterPatchHistoryEntriesResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListVmClusterPatchHistoryEntriesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListVmClusterPatchHistoryEntriesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<PatchHistoryEntrySummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        PatchHistoryEntrySummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<PatchHistoryEntrySummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListVmClusterPatchHistoryEntriesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListVmClusterPatchHistoryEntriesResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListVmClusterPatchHistoryEntriesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterPatchesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListVmClusterPatchesConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListVmClusterPatchesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListVmClusterPatchesRequest interceptRequest(
+            com.oracle.bmc.database.requests.ListVmClusterPatchesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListVmClusterPatchesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("patches");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListVmClusterPatchesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListVmClusterPatchesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses.ListVmClusterPatchesResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses.ListVmClusterPatchesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListVmClusterPatchesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<PatchSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<PatchSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<PatchSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.ListVmClusterPatchesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListVmClusterPatchesResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.ListVmClusterPatchesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Backup.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Backup.java
@@ -140,6 +140,15 @@ public class Backup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class Backup {
                             lifecycleState,
                             databaseEdition,
                             databaseSizeInGBs,
-                            shape);
+                            shape,
+                            version);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -178,7 +188,8 @@ public class Backup {
                             .lifecycleState(o.getLifecycleState())
                             .databaseEdition(o.getDatabaseEdition())
                             .databaseSizeInGBs(o.getDatabaseSizeInGBs())
-                            .shape(o.getShape());
+                            .shape(o.getShape())
+                            .version(o.getVersion());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -413,6 +424,12 @@ public class Backup {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shape")
     String shape;
+
+    /**
+     * Version of the backup's source database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupSummary.java
@@ -144,6 +144,15 @@ public class BackupSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -162,7 +171,8 @@ public class BackupSummary {
                             lifecycleState,
                             databaseEdition,
                             databaseSizeInGBs,
-                            shape);
+                            shape,
+                            version);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -182,7 +192,8 @@ public class BackupSummary {
                             .lifecycleState(o.getLifecycleState())
                             .databaseEdition(o.getDatabaseEdition())
                             .databaseSizeInGBs(o.getDatabaseSizeInGBs())
-                            .shape(o.getShape());
+                            .shape(o.getShape())
+                            .version(o.getVersion());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -417,6 +428,12 @@ public class BackupSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shape")
     String shape;
+
+    /**
+     * Version of the backup's source database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
@@ -62,6 +62,33 @@ public class CreateVmClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
         private java.util.List<String> sshPublicKeys;
 
@@ -154,6 +181,9 @@ public class CreateVmClusterDetails {
                             displayName,
                             exadataInfrastructureId,
                             cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            dataStorageSizeInTBs,
                             sshPublicKeys,
                             vmClusterNetworkId,
                             licenseModel,
@@ -174,6 +204,9 @@ public class CreateVmClusterDetails {
                             .displayName(o.getDisplayName())
                             .exadataInfrastructureId(o.getExadataInfrastructureId())
                             .cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .vmClusterNetworkId(o.getVmClusterNetworkId())
                             .licenseModel(o.getLicenseModel())
@@ -219,6 +252,24 @@ public class CreateVmClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
     Integer cpuCoreCount;
+
+    /**
+     * The memory to be allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The local node storage to be allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The data disk group size to be allocated in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Double dataStorageSizeInTBs;
 
     /**
      * The public key portion of one or more key pairs used for SSH access to the VM cluster.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
@@ -299,7 +299,7 @@ public class DbNode {
     @com.fasterxml.jackson.annotation.JsonProperty("softwareStorageSizeInGB")
     Integer softwareStorageSizeInGB;
     /**
-     * The type of maintenance of dbNode.
+     * The type of database node maintenance.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum MaintenanceType {
@@ -344,7 +344,7 @@ public class DbNode {
         }
     };
     /**
-     * The type of maintenance of dbNode.
+     * The type of database node maintenance.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceType")
     MaintenanceType maintenanceType;
@@ -362,7 +362,7 @@ public class DbNode {
     java.util.Date timeMaintenanceWindowEnd;
 
     /**
-     * Additional information like a message to customer about the maintenance.
+     * Additional information about the planned maintenance.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
     String additionalDetails;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
@@ -304,7 +304,7 @@ public class DbNodeSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("softwareStorageSizeInGB")
     Integer softwareStorageSizeInGB;
     /**
-     * The type of maintenance of dbNode.
+     * The type of database node maintenance.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum MaintenanceType {
@@ -349,7 +349,7 @@ public class DbNodeSummary {
         }
     };
     /**
-     * The type of maintenance of dbNode.
+     * The type of database node maintenance.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceType")
     MaintenanceType maintenanceType;
@@ -367,7 +367,7 @@ public class DbNodeSummary {
     java.util.Date timeMaintenanceWindowEnd;
 
     /**
-     * Additional information like a message to customer about the maintenance.
+     * Additional information about the planned maintenance.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
     String additionalDetails;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemShapeSummary.java
@@ -84,6 +84,69 @@ public class DbSystemShapeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("minCoreCountPerNode")
+        private Integer minCoreCountPerNode;
+
+        public Builder minCoreCountPerNode(Integer minCoreCountPerNode) {
+            this.minCoreCountPerNode = minCoreCountPerNode;
+            this.__explicitlySet__.add("minCoreCountPerNode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableMemoryInGBs")
+        private Integer availableMemoryInGBs;
+
+        public Builder availableMemoryInGBs(Integer availableMemoryInGBs) {
+            this.availableMemoryInGBs = availableMemoryInGBs;
+            this.__explicitlySet__.add("availableMemoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minMemoryPerNodeInGBs")
+        private Integer minMemoryPerNodeInGBs;
+
+        public Builder minMemoryPerNodeInGBs(Integer minMemoryPerNodeInGBs) {
+            this.minMemoryPerNodeInGBs = minMemoryPerNodeInGBs;
+            this.__explicitlySet__.add("minMemoryPerNodeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableDbNodeStorageInGBs")
+        private Integer availableDbNodeStorageInGBs;
+
+        public Builder availableDbNodeStorageInGBs(Integer availableDbNodeStorageInGBs) {
+            this.availableDbNodeStorageInGBs = availableDbNodeStorageInGBs;
+            this.__explicitlySet__.add("availableDbNodeStorageInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minDbNodeStoragePerNodeInGBs")
+        private Integer minDbNodeStoragePerNodeInGBs;
+
+        public Builder minDbNodeStoragePerNodeInGBs(Integer minDbNodeStoragePerNodeInGBs) {
+            this.minDbNodeStoragePerNodeInGBs = minDbNodeStoragePerNodeInGBs;
+            this.__explicitlySet__.add("minDbNodeStoragePerNodeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableDataStorageInTBs")
+        private Integer availableDataStorageInTBs;
+
+        public Builder availableDataStorageInTBs(Integer availableDataStorageInTBs) {
+            this.availableDataStorageInTBs = availableDataStorageInTBs;
+            this.__explicitlySet__.add("availableDataStorageInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minDataStorageInTBs")
+        private Integer minDataStorageInTBs;
+
+        public Builder minDataStorageInTBs(Integer minDataStorageInTBs) {
+            this.minDataStorageInTBs = minDataStorageInTBs;
+            this.__explicitlySet__.add("minDataStorageInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("minimumNodeCount")
         private Integer minimumNodeCount;
 
@@ -114,6 +177,13 @@ public class DbSystemShapeSummary {
                             availableCoreCount,
                             minimumCoreCount,
                             coreCountIncrement,
+                            minCoreCountPerNode,
+                            availableMemoryInGBs,
+                            minMemoryPerNodeInGBs,
+                            availableDbNodeStorageInGBs,
+                            minDbNodeStoragePerNodeInGBs,
+                            availableDataStorageInTBs,
+                            minDataStorageInTBs,
                             minimumNodeCount,
                             maximumNodeCount);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -129,6 +199,13 @@ public class DbSystemShapeSummary {
                             .availableCoreCount(o.getAvailableCoreCount())
                             .minimumCoreCount(o.getMinimumCoreCount())
                             .coreCountIncrement(o.getCoreCountIncrement())
+                            .minCoreCountPerNode(o.getMinCoreCountPerNode())
+                            .availableMemoryInGBs(o.getAvailableMemoryInGBs())
+                            .minMemoryPerNodeInGBs(o.getMinMemoryPerNodeInGBs())
+                            .availableDbNodeStorageInGBs(o.getAvailableDbNodeStorageInGBs())
+                            .minDbNodeStoragePerNodeInGBs(o.getMinDbNodeStoragePerNodeInGBs())
+                            .availableDataStorageInTBs(o.getAvailableDataStorageInTBs())
+                            .minDataStorageInTBs(o.getMinDataStorageInTBs())
                             .minimumNodeCount(o.getMinimumNodeCount())
                             .maximumNodeCount(o.getMaximumNodeCount());
 
@@ -179,6 +256,48 @@ public class DbSystemShapeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("coreCountIncrement")
     Integer coreCountIncrement;
+
+    /**
+     * The minimum number of CPU cores that can be enabled per node for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minCoreCountPerNode")
+    Integer minCoreCountPerNode;
+
+    /**
+     * The maximum memory that can be enabled for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableMemoryInGBs")
+    Integer availableMemoryInGBs;
+
+    /**
+     * The minimum memory that need be allocated per node for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minMemoryPerNodeInGBs")
+    Integer minMemoryPerNodeInGBs;
+
+    /**
+     * The maximum Db Node storage that can be enabled for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableDbNodeStorageInGBs")
+    Integer availableDbNodeStorageInGBs;
+
+    /**
+     * The minimum Db Node storage that need be allocated per node for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minDbNodeStoragePerNodeInGBs")
+    Integer minDbNodeStoragePerNodeInGBs;
+
+    /**
+     * The maximum DATA storage that can be enabled for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableDataStorageInTBs")
+    Integer availableDataStorageInTBs;
+
+    /**
+     * The minimum data storage that need be allocated for this shape.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minDataStorageInTBs")
+    Integer minDataStorageInTBs;
 
     /**
      * The minimum number of database nodes available for this shape.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
@@ -88,12 +88,66 @@ public class ExadataInfrastructure {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-        private Integer dataStorageSizeInTBs;
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+        private Integer maxCpuCount;
 
-        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+        public Builder maxCpuCount(Integer maxCpuCount) {
+            this.maxCpuCount = maxCpuCount;
+            this.__explicitlySet__.add("maxCpuCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+        private Integer maxMemoryInGBs;
+
+        public Builder maxMemoryInGBs(Integer maxMemoryInGBs) {
+            this.maxMemoryInGBs = maxMemoryInGBs;
+            this.__explicitlySet__.add("maxMemoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+        private Integer maxDbNodeStorageInGBs;
+
+        public Builder maxDbNodeStorageInGBs(Integer maxDbNodeStorageInGBs) {
+            this.maxDbNodeStorageInGBs = maxDbNodeStorageInGBs;
+            this.__explicitlySet__.add("maxDbNodeStorageInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
             this.dataStorageSizeInTBs = dataStorageSizeInTBs;
             this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDataStorageInTBs")
+        private Double maxDataStorageInTBs;
+
+        public Builder maxDataStorageInTBs(Double maxDataStorageInTBs) {
+            this.maxDataStorageInTBs = maxDataStorageInTBs;
+            this.__explicitlySet__.add("maxDataStorageInTBs");
             return this;
         }
 
@@ -228,7 +282,13 @@ public class ExadataInfrastructure {
                             shape,
                             timeZone,
                             cpusEnabled,
+                            maxCpuCount,
+                            memorySizeInGBs,
+                            maxMemoryInGBs,
+                            dbNodeStorageSizeInGBs,
+                            maxDbNodeStorageInGBs,
                             dataStorageSizeInTBs,
+                            maxDataStorageInTBs,
                             cloudControlPlaneServer1,
                             cloudControlPlaneServer2,
                             netmask,
@@ -256,7 +316,13 @@ public class ExadataInfrastructure {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .cpusEnabled(o.getCpusEnabled())
+                            .maxCpuCount(o.getMaxCpuCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .maxMemoryInGBs(o.getMaxMemoryInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .maxDataStorageInTBs(o.getMaxDataStorageInTBs())
                             .cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
                             .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
                             .netmask(o.getNetmask())
@@ -308,7 +374,7 @@ public class ExadataInfrastructure {
         Updating("UPDATING"),
         Deleting("DELETING"),
         Deleted("DELETED"),
-        Offline("OFFLINE"),
+        Disconnected("DISCONNECTED"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -380,11 +446,47 @@ public class ExadataInfrastructure {
     Integer cpusEnabled;
 
     /**
+     * The total number of CPU cores available.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+    Integer maxCpuCount;
+
+    /**
+     * The memory allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The total memory available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+    Integer maxMemoryInGBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The total local node storage available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+    Integer maxDbNodeStorageInGBs;
+
+    /**
      * Size, in terabytes, of the DATA disk group.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-    Integer dataStorageSizeInTBs;
+    Double dataStorageSizeInTBs;
+
+    /**
+     * The total available DATA disk group size.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDataStorageInTBs")
+    Double maxDataStorageInTBs;
 
     /**
      * The IP address for the first control plane server.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
@@ -88,12 +88,66 @@ public class ExadataInfrastructureSummary {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-        private Integer dataStorageSizeInTBs;
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+        private Integer maxCpuCount;
 
-        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+        public Builder maxCpuCount(Integer maxCpuCount) {
+            this.maxCpuCount = maxCpuCount;
+            this.__explicitlySet__.add("maxCpuCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+        private Integer maxMemoryInGBs;
+
+        public Builder maxMemoryInGBs(Integer maxMemoryInGBs) {
+            this.maxMemoryInGBs = maxMemoryInGBs;
+            this.__explicitlySet__.add("maxMemoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+        private Integer maxDbNodeStorageInGBs;
+
+        public Builder maxDbNodeStorageInGBs(Integer maxDbNodeStorageInGBs) {
+            this.maxDbNodeStorageInGBs = maxDbNodeStorageInGBs;
+            this.__explicitlySet__.add("maxDbNodeStorageInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
             this.dataStorageSizeInTBs = dataStorageSizeInTBs;
             this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDataStorageInTBs")
+        private Double maxDataStorageInTBs;
+
+        public Builder maxDataStorageInTBs(Double maxDataStorageInTBs) {
+            this.maxDataStorageInTBs = maxDataStorageInTBs;
+            this.__explicitlySet__.add("maxDataStorageInTBs");
             return this;
         }
 
@@ -228,7 +282,13 @@ public class ExadataInfrastructureSummary {
                             shape,
                             timeZone,
                             cpusEnabled,
+                            maxCpuCount,
+                            memorySizeInGBs,
+                            maxMemoryInGBs,
+                            dbNodeStorageSizeInGBs,
+                            maxDbNodeStorageInGBs,
                             dataStorageSizeInTBs,
+                            maxDataStorageInTBs,
                             cloudControlPlaneServer1,
                             cloudControlPlaneServer2,
                             netmask,
@@ -256,7 +316,13 @@ public class ExadataInfrastructureSummary {
                             .shape(o.getShape())
                             .timeZone(o.getTimeZone())
                             .cpusEnabled(o.getCpusEnabled())
+                            .maxCpuCount(o.getMaxCpuCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .maxMemoryInGBs(o.getMaxMemoryInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
+                            .maxDataStorageInTBs(o.getMaxDataStorageInTBs())
                             .cloudControlPlaneServer1(o.getCloudControlPlaneServer1())
                             .cloudControlPlaneServer2(o.getCloudControlPlaneServer2())
                             .netmask(o.getNetmask())
@@ -308,7 +374,7 @@ public class ExadataInfrastructureSummary {
         Updating("UPDATING"),
         Deleting("DELETING"),
         Deleted("DELETED"),
-        Offline("OFFLINE"),
+        Disconnected("DISCONNECTED"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -380,11 +446,47 @@ public class ExadataInfrastructureSummary {
     Integer cpusEnabled;
 
     /**
+     * The total number of CPU cores available.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+    Integer maxCpuCount;
+
+    /**
+     * The memory allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The total memory available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+    Integer maxMemoryInGBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The total local node storage available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+    Integer maxDbNodeStorageInGBs;
+
+    /**
      * Size, in terabytes, of the DATA disk group.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-    Integer dataStorageSizeInTBs;
+    Double dataStorageSizeInTBs;
+
+    /**
+     * The total available DATA disk group size.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDataStorageInTBs")
+    Double maxDataStorageInTBs;
 
     /**
      * The IP address for the first control plane server.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -101,15 +101,6 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
-        private java.util.List<String> nsgIds;
-
-        public Builder nsgIds(java.util.List<String> nsgIds) {
-            this.nsgIds = nsgIds;
-            this.__explicitlySet__.add("nsgIds");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
         private LicenseModel licenseModel;
 
@@ -146,6 +137,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -160,11 +160,11 @@ public class UpdateAutonomousDatabaseDetails {
                             dbName,
                             freeformTags,
                             definedTags,
-                            nsgIds,
                             licenseModel,
                             whitelistedIps,
                             isAutoScalingEnabled,
-                            dbVersion);
+                            dbVersion,
+                            nsgIds);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -180,11 +180,11 @@ public class UpdateAutonomousDatabaseDetails {
                             .dbName(o.getDbName())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .nsgIds(o.getNsgIds())
                             .licenseModel(o.getLicenseModel())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
-                            .dbVersion(o.getDbVersion());
+                            .dbVersion(o.getDbVersion())
+                            .nsgIds(o.getNsgIds());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -212,7 +212,9 @@ public class UpdateAutonomousDatabaseDetails {
     Integer dataStorageSizeInTBs;
 
     /**
-     * The user-friendly name for the Autonomous Database. The name does not have to be unique.
+     * The user-friendly name for the Autonomous Database. The name does not have to be unique. Can only be updated for Autonomous Databases
+     * using dedicated Exadata infrastructure.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -256,15 +258,6 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
-
-    /**
-     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
-     * **NsgIds restrictions:**
-     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
-    java.util.List<String> nsgIds;
     /**
      * The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on [dedicated Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
      * Autonomous Exadata Infrastructure level. When using [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.
@@ -332,6 +325,15 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
     String dbVersion;
+
+    /**
+     * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).
+     * **NsgIds restrictions:**
+     * - Autonomous Databases with private access require at least 1 Network Security Group (NSG). The nsgIds array cannot be empty.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateBackupDestinationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateBackupDestinationDetails.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.database.model;
 
 /**
  * For a RECOVERY_APPLIANCE backup destination, used to update the connection string and/or the list of VPC users.
- * For an NFS backup destination, used to update the NFS location.
+ * For an NFS backup destination, there are 2 mount types - Self mount used for non-autonomous ExaCC and automated mount used for autonomous on ExaCC.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateVmClusterDetails.java
@@ -34,6 +34,33 @@ public class UpdateVmClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
+            this.dataStorageSizeInTBs = dataStorageSizeInTBs;
+            this.__explicitlySet__.add("dataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
         private LicenseModel licenseModel;
 
@@ -49,6 +76,15 @@ public class UpdateVmClusterDetails {
         public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
             this.sshPublicKeys = sshPublicKeys;
             this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private PatchDetails version;
+
+        public Builder version(PatchDetails version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
             return this;
         }
 
@@ -77,7 +113,15 @@ public class UpdateVmClusterDetails {
         public UpdateVmClusterDetails build() {
             UpdateVmClusterDetails __instance__ =
                     new UpdateVmClusterDetails(
-                            cpuCoreCount, licenseModel, sshPublicKeys, freeformTags, definedTags);
+                            cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            dataStorageSizeInTBs,
+                            licenseModel,
+                            sshPublicKeys,
+                            version,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -86,8 +130,12 @@ public class UpdateVmClusterDetails {
         public Builder copy(UpdateVmClusterDetails o) {
             Builder copiedBuilder =
                     cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .licenseModel(o.getLicenseModel())
                             .sshPublicKeys(o.getSshPublicKeys())
+                            .version(o.getVersion())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -108,6 +156,24 @@ public class UpdateVmClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
     Integer cpuCoreCount;
+
+    /**
+     * The memory to be allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The local node storage to be allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The data disk group size to be allocated in TBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+    Double dataStorageSizeInTBs;
     /**
      * The Oracle license model that applies to the VM cluster. The default is BRING_YOUR_OWN_LICENSE.
      *
@@ -156,6 +222,9 @@ public class UpdateVmClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
     java.util.List<String> sshPublicKeys;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    PatchDetails version;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
@@ -42,6 +42,15 @@ public class VmCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lastPatchHistoryEntryId")
+        private String lastPatchHistoryEntryId;
+
+        public Builder lastPatchHistoryEntryId(String lastPatchHistoryEntryId) {
+            this.lastPatchHistoryEntryId = lastPatchHistoryEntryId;
+            this.__explicitlySet__.add("lastPatchHistoryEntryId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -132,10 +141,28 @@ public class VmCluster {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-        private Integer dataStorageSizeInTBs;
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
 
-        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
             this.dataStorageSizeInTBs = dataStorageSizeInTBs;
             this.__explicitlySet__.add("dataStorageSizeInTBs");
             return this;
@@ -204,6 +231,7 @@ public class VmCluster {
                     new VmCluster(
                             id,
                             compartmentId,
+                            lastPatchHistoryEntryId,
                             lifecycleState,
                             displayName,
                             timeCreated,
@@ -214,6 +242,8 @@ public class VmCluster {
                             isSparseDiskgroupEnabled,
                             vmClusterNetworkId,
                             cpusEnabled,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
                             dataStorageSizeInTBs,
                             shape,
                             giVersion,
@@ -230,6 +260,7 @@ public class VmCluster {
             Builder copiedBuilder =
                     id(o.getId())
                             .compartmentId(o.getCompartmentId())
+                            .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
                             .lifecycleState(o.getLifecycleState())
                             .displayName(o.getDisplayName())
                             .timeCreated(o.getTimeCreated())
@@ -240,6 +271,8 @@ public class VmCluster {
                             .isSparseDiskgroupEnabled(o.getIsSparseDiskgroupEnabled())
                             .vmClusterNetworkId(o.getVmClusterNetworkId())
                             .cpusEnabled(o.getCpusEnabled())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .shape(o.getShape())
                             .giVersion(o.getGiVersion())
@@ -271,6 +304,12 @@ public class VmCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the last patch history. This value is updated as soon as a patch operation starts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastPatchHistoryEntryId")
+    String lastPatchHistoryEntryId;
     /**
      * The current state of the VM cluster.
      **/
@@ -384,11 +423,23 @@ public class VmCluster {
     Integer cpusEnabled;
 
     /**
+     * The memory allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
      * Size, in terabytes, of the DATA disk group.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-    Integer dataStorageSizeInTBs;
+    Double dataStorageSizeInTBs;
 
     /**
      * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
@@ -42,6 +42,15 @@ public class VmClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lastPatchHistoryEntryId")
+        private String lastPatchHistoryEntryId;
+
+        public Builder lastPatchHistoryEntryId(String lastPatchHistoryEntryId) {
+            this.lastPatchHistoryEntryId = lastPatchHistoryEntryId;
+            this.__explicitlySet__.add("lastPatchHistoryEntryId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -132,10 +141,28 @@ public class VmClusterSummary {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-        private Integer dataStorageSizeInTBs;
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
 
-        public Builder dataStorageSizeInTBs(Integer dataStorageSizeInTBs) {
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
+        private Double dataStorageSizeInTBs;
+
+        public Builder dataStorageSizeInTBs(Double dataStorageSizeInTBs) {
             this.dataStorageSizeInTBs = dataStorageSizeInTBs;
             this.__explicitlySet__.add("dataStorageSizeInTBs");
             return this;
@@ -204,6 +231,7 @@ public class VmClusterSummary {
                     new VmClusterSummary(
                             id,
                             compartmentId,
+                            lastPatchHistoryEntryId,
                             lifecycleState,
                             displayName,
                             timeCreated,
@@ -214,6 +242,8 @@ public class VmClusterSummary {
                             isSparseDiskgroupEnabled,
                             vmClusterNetworkId,
                             cpusEnabled,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
                             dataStorageSizeInTBs,
                             shape,
                             giVersion,
@@ -230,6 +260,7 @@ public class VmClusterSummary {
             Builder copiedBuilder =
                     id(o.getId())
                             .compartmentId(o.getCompartmentId())
+                            .lastPatchHistoryEntryId(o.getLastPatchHistoryEntryId())
                             .lifecycleState(o.getLifecycleState())
                             .displayName(o.getDisplayName())
                             .timeCreated(o.getTimeCreated())
@@ -240,6 +271,8 @@ public class VmClusterSummary {
                             .isSparseDiskgroupEnabled(o.getIsSparseDiskgroupEnabled())
                             .vmClusterNetworkId(o.getVmClusterNetworkId())
                             .cpusEnabled(o.getCpusEnabled())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
                             .dataStorageSizeInTBs(o.getDataStorageSizeInTBs())
                             .shape(o.getShape())
                             .giVersion(o.getGiVersion())
@@ -271,6 +304,12 @@ public class VmClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the last patch history. This value is updated as soon as a patch operation starts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastPatchHistoryEntryId")
+    String lastPatchHistoryEntryId;
     /**
      * The current state of the VM cluster.
      **/
@@ -384,11 +423,23 @@ public class VmClusterSummary {
     Integer cpusEnabled;
 
     /**
+     * The memory allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The local node storage allocated in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
      * Size, in terabytes, of the DATA disk group.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInTBs")
-    Integer dataStorageSizeInTBs;
+    Double dataStorageSizeInTBs;
 
     /**
      * The shape of the Exadata infrastructure. The shape determines the amount of CPU, storage, and memory resources allocated to the instance.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterPatchHistoryEntryRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterPatchHistoryEntryRequest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetVmClusterPatchHistoryEntryRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the patch history entry.
+     */
+    private String patchHistoryEntryId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetVmClusterPatchHistoryEntryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterPatchHistoryEntryRequest o) {
+            vmClusterId(o.getVmClusterId());
+            patchHistoryEntryId(o.getPatchHistoryEntryId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVmClusterPatchHistoryEntryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVmClusterPatchHistoryEntryRequest
+         */
+        public GetVmClusterPatchHistoryEntryRequest build() {
+            GetVmClusterPatchHistoryEntryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterPatchRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetVmClusterPatchRequest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetVmClusterPatchRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the patch.
+     */
+    private String patchId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetVmClusterPatchRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterPatchRequest o) {
+            vmClusterId(o.getVmClusterId());
+            patchId(o.getPatchId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVmClusterPatchRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVmClusterPatchRequest
+         */
+        public GetVmClusterPatchRequest build() {
+            GetVmClusterPatchRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterPatchHistoryEntriesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterPatchHistoryEntriesRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListVmClusterPatchHistoryEntriesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListVmClusterPatchHistoryEntriesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterPatchHistoryEntriesRequest o) {
+            vmClusterId(o.getVmClusterId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVmClusterPatchHistoryEntriesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVmClusterPatchHistoryEntriesRequest
+         */
+        public ListVmClusterPatchHistoryEntriesRequest build() {
+            ListVmClusterPatchHistoryEntriesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterPatchesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListVmClusterPatchesRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListVmClusterPatchesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListVmClusterPatchesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterPatchesRequest o) {
+            vmClusterId(o.getVmClusterId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVmClusterPatchesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVmClusterPatchesRequest
+         */
+        public ListVmClusterPatchesRequest build() {
+            ListVmClusterPatchesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterPatchHistoryEntryResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterPatchHistoryEntryResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetVmClusterPatchHistoryEntryResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned PatchHistoryEntry instance.
+     */
+    private PatchHistoryEntry patchHistoryEntry;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterPatchHistoryEntryResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            patchHistoryEntry(o.getPatchHistoryEntry());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterPatchResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetVmClusterPatchResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetVmClusterPatchResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Patch instance.
+     */
+    private Patch patch;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVmClusterPatchResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            patch(o.getPatch());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterPatchHistoryEntriesResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterPatchHistoryEntriesResponse.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListVmClusterPatchHistoryEntriesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of PatchHistoryEntrySummary instances.
+     */
+    private java.util.List<PatchHistoryEntrySummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterPatchHistoryEntriesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterPatchesResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListVmClusterPatchesResponse.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListVmClusterPatchesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of PatchSummary instances.
+     */
+    private java.util.List<PatchSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVmClusterPatchesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/CircuitBreakerExample.java
+++ b/bmc-examples/src/main/java/CircuitBreakerExample.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.circuitbreaker.CircuitBreakerConfiguration;
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.requests.ListRegionsRequest;
+import com.oracle.bmc.identity.responses.ListRegionsResponse;
+import com.oracle.bmc.retrier.RetryConfiguration;
+
+import java.time.Duration;
+
+/**
+ * A sample to demonstrate how to configure a client using circuit breaker configuration.
+ */
+public class CircuitBreakerExample {
+
+    public static void main(String[] args) throws Exception {
+
+        String configurationFilePath = "~/.oci/config";
+        String profile = "DEFAULT";
+
+        AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configurationFilePath, profile);
+
+        // Setup CircuitBreakerConfiguration with custom values
+        ClientConfiguration configuration =
+                ClientConfiguration.builder()
+                        .retryConfiguration(RetryConfiguration.builder().build())
+                        .circuitBreakerConfiguration(
+                                CircuitBreakerConfiguration.builder()
+                                        .failureRateThreshold(50)
+                                        .slowCallRateThreshold(90)
+                                        .slowCallDurationThreshold(Duration.ofSeconds(6))
+                                        .permittedNumberOfCallsInHalfOpenState(2)
+                                        .slidingWindowSize(10)
+                                        .minimumNumberOfCalls(4)
+                                        .waitDurationInOpenState(Duration.ofSeconds(2))
+                                        .recordHttpStatuses(
+                                                ImmutableSet.of(
+                                                        CircuitBreakerConfiguration
+                                                                .TOO_MANY_REQUESTS,
+                                                        CircuitBreakerConfiguration
+                                                                .SERVICE_UNAVAILABLE))
+                                        .recordExceptions(
+                                                ImmutableList.of(
+                                                        CircuitBreakerConfiguration
+                                                                .SERVICE_UNAVAILABLE_EXCEPTION_CLASS))
+                                        .build())
+                        .build();
+
+        // Create Client using above ClientConfiguration
+        IdentityClient identityClient = new IdentityClient(provider, configuration);
+        System.out.println("Querying for list of regions");
+        final ListRegionsResponse response =
+                identityClient.listRegions(ListRegionsRequest.builder().build());
+        System.out.println("List of regions: " + response.getItems());
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
@@ -71,6 +71,83 @@ public interface Identity extends AutoCloseable {
     AssembleEffectiveTagSetResponse assembleEffectiveTagSet(AssembleEffectiveTagSetRequest request);
 
     /**
+     * Bulk delete resources in the compartment. All resources must be in the same compartment.
+     * This API can only be invoked from tenancy's home region.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    BulkDeleteResourcesResponse bulkDeleteResources(BulkDeleteResourcesRequest request);
+
+    /**
+     * Deletes the specified tag key definitions. This operation triggers a process that removes the
+     * tags from all resources in your tenancy.
+     * <p>
+     * The following actions happen immediately:
+     * \u00A0
+     *   * If the tag is a cost-tracking tag, the tag no longer counts against your
+     *   10 cost-tracking tags limit, even if you do not disable the tag before running this operation.
+     *   * If the tag is used with dynamic groups, the rules that contain the tag are no longer
+     *   evaluated against the tag.
+     * <p>
+     * After you start this operation, the state of the tag changes to DELETING, and tag removal
+     * from resources begins. This process can take up to 48 hours depending on the number of resources that
+     * are tagged and the regions in which those resources reside.
+     * <p>
+     * When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. After the tag state
+     * changes to DELETED, you can use the same tag name again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #deleteTag(DeleteTagRequest) deleteTag} or the {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest) cascadeDeleteTagNamespace} operation until this process completes.
+     * <p>
+     * In order to delete tags, you must first retire the tags. Use {@link #updateTag(UpdateTagRequest) updateTag}
+     * to retire a tag.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    BulkDeleteTagsResponse bulkDeleteTags(BulkDeleteTagsRequest request);
+
+    /**
+     * Bulk move resources in the compartment. All resources must be in the same compartment.
+     * This API can only be invoked from tenancy's home region.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    BulkMoveResourcesResponse bulkMoveResources(BulkMoveResourcesRequest request);
+
+    /**
+     * Deletes the specified tag namespace. This operation triggers a process that removes all of the tags
+     * defined in the specified tag namespace from all resources in your tenancy and then deletes the tag namespace.
+     * <p>
+     * After you start the delete operation:
+     * <p>
+     * New tag key definitions cannot be created under the namespace.
+     *   * The state of the tag namespace changes to DELETING.
+     *   * Tag removal from the resources begins.
+     * <p>
+     * This process can take up to 48 hours depending on the number of tag definitions in the namespace, the number of resources
+     * that are tagged, and the locations of the regions in which those resources reside.
+     * <p>
+     * After all tags are removed, the state changes to DELETED. You cannot restore a deleted tag namespace. After the deleted tag namespace
+     * changes its state to DELETED, you can use the name of the deleted tag namespace again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #deleteTag(DeleteTagRequest) deleteTag} or the {@link #bulkDeleteTags(BulkDeleteTagsRequest) bulkDeleteTags} operation until this process completes.
+     * <p>
+     * To delete a tag namespace, you must first retire it. Use {@link #updateTagNamespace(UpdateTagNamespaceRequest) updateTagNamespace}
+     * to retire a tag namespace.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CascadeDeleteTagNamespaceResponse cascadeDeleteTagNamespace(
+            CascadeDeleteTagNamespaceRequest request);
+
+    /**
      * Moves the specified tag namespace to the specified compartment within the same tenancy.
      * <p>
      * To move the tag namespace, you must have the manage tag-namespaces permission on both compartments.
@@ -268,6 +345,9 @@ public interface Identity extends AutoCloseable {
      * <p>
      * After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
      * object, first make sure its `lifecycleState` has changed to ACTIVE.
+     * <p>
+     * After your network resource is created, you can use it in policy to restrict access to only requests made from an allowed
+     * IP address specified in your network source. For more information, see [Managing Network Sources](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -626,11 +706,14 @@ public interface Identity extends AutoCloseable {
      *   * If the tag was used with dynamic groups, none of the rules that contain the tag will
      *   be evaluated against the tag.
      * <p>
-     * Once you start the delete operation, the state of the tag changes to DELETING and tag removal
+     * When you start the delete operation, the state of the tag changes to DELETING and tag removal
      * from resources begins. This can take up to 48 hours depending on the number of resources that
-     * were tagged as well as the regions in which those resources reside. When all tags have been
-     * removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
+     * were tagged as well as the regions in which those resources reside.
+     * <p>
+     * When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
      * changes its state to DELETED, you can use the same tag name again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #bulkDeleteTags(BulkDeleteTagsRequest) bulkDeleteTags} or the {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest) cascadeDeleteTagNamespace} operation until this process completes.
      * <p>
      * To delete a tag, you must first retire it. Use {@link #updateTag(UpdateTagRequest) updateTag}
      * to retire a tag.
@@ -651,8 +734,11 @@ public interface Identity extends AutoCloseable {
     DeleteTagDefaultResponse deleteTagDefault(DeleteTagDefaultRequest request);
 
     /**
-     * Deletes the specified tag namespace. Only an empty tag namespace can be deleted. To delete
-     * a tag namespace, first delete all its tag definitions.
+     * Deletes the specified tag namespace. Only an empty tag namespace can be deleted with this operation. To use this operation
+     * to delete a tag namespace that contains tag definitions, first delete all of its tag definitions.
+     * <p>
+     * Use {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest) cascadeDeleteTagNamespace} to delete a tag namespace along with all of
+     * the tag definitions contained within that namespace.
      * <p>
      * Use {@link #deleteTag(DeleteTagRequest) deleteTag} to delete a tag definition.
      *
@@ -884,6 +970,16 @@ public interface Identity extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ListAvailabilityDomainsResponse listAvailabilityDomains(ListAvailabilityDomainsRequest request);
+
+    /**
+     * Lists the resource types supported by compartment bulk actions.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListBulkActionResourceTypesResponse listBulkActionResourceTypes(
+            ListBulkActionResourceTypesRequest request);
 
     /**
      * Lists the compartments in a specified compartment. The members of the list

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
@@ -94,6 +94,113 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Bulk delete resources in the compartment. All resources must be in the same compartment.
+     * This API can only be invoked from tenancy's home region.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<BulkDeleteResourcesResponse> bulkDeleteResources(
+            BulkDeleteResourcesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            BulkDeleteResourcesRequest, BulkDeleteResourcesResponse>
+                    handler);
+
+    /**
+     * Deletes the specified tag key definitions. This operation triggers a process that removes the
+     * tags from all resources in your tenancy.
+     * <p>
+     * The following actions happen immediately:
+     * \u00A0
+     *   * If the tag is a cost-tracking tag, the tag no longer counts against your
+     *   10 cost-tracking tags limit, even if you do not disable the tag before running this operation.
+     *   * If the tag is used with dynamic groups, the rules that contain the tag are no longer
+     *   evaluated against the tag.
+     * <p>
+     * After you start this operation, the state of the tag changes to DELETING, and tag removal
+     * from resources begins. This process can take up to 48 hours depending on the number of resources that
+     * are tagged and the regions in which those resources reside.
+     * <p>
+     * When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. After the tag state
+     * changes to DELETED, you can use the same tag name again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #deleteTag(DeleteTagRequest, Consumer, Consumer) deleteTag} or the {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest, Consumer, Consumer) cascadeDeleteTagNamespace} operation until this process completes.
+     * <p>
+     * In order to delete tags, you must first retire the tags. Use {@link #updateTag(UpdateTagRequest, Consumer, Consumer) updateTag}
+     * to retire a tag.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<BulkDeleteTagsResponse> bulkDeleteTags(
+            BulkDeleteTagsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<BulkDeleteTagsRequest, BulkDeleteTagsResponse>
+                    handler);
+
+    /**
+     * Bulk move resources in the compartment. All resources must be in the same compartment.
+     * This API can only be invoked from tenancy's home region.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<BulkMoveResourcesResponse> bulkMoveResources(
+            BulkMoveResourcesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            BulkMoveResourcesRequest, BulkMoveResourcesResponse>
+                    handler);
+
+    /**
+     * Deletes the specified tag namespace. This operation triggers a process that removes all of the tags
+     * defined in the specified tag namespace from all resources in your tenancy and then deletes the tag namespace.
+     * <p>
+     * After you start the delete operation:
+     * <p>
+     * New tag key definitions cannot be created under the namespace.
+     *   * The state of the tag namespace changes to DELETING.
+     *   * Tag removal from the resources begins.
+     * <p>
+     * This process can take up to 48 hours depending on the number of tag definitions in the namespace, the number of resources
+     * that are tagged, and the locations of the regions in which those resources reside.
+     * <p>
+     * After all tags are removed, the state changes to DELETED. You cannot restore a deleted tag namespace. After the deleted tag namespace
+     * changes its state to DELETED, you can use the name of the deleted tag namespace again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #deleteTag(DeleteTagRequest, Consumer, Consumer) deleteTag} or the {@link #bulkDeleteTags(BulkDeleteTagsRequest, Consumer, Consumer) bulkDeleteTags} operation until this process completes.
+     * <p>
+     * To delete a tag namespace, you must first retire it. Use {@link #updateTagNamespace(UpdateTagNamespaceRequest, Consumer, Consumer) updateTagNamespace}
+     * to retire a tag namespace.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CascadeDeleteTagNamespaceResponse> cascadeDeleteTagNamespace(
+            CascadeDeleteTagNamespaceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CascadeDeleteTagNamespaceRequest, CascadeDeleteTagNamespaceResponse>
+                    handler);
+
+    /**
      * Moves the specified tag namespace to the specified compartment within the same tenancy.
      * <p>
      * To move the tag namespace, you must have the manage tag-namespaces permission on both compartments.
@@ -361,6 +468,9 @@ public interface IdentityAsync extends AutoCloseable {
      * <p>
      * After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
      * object, first make sure its `lifecycleState` has changed to ACTIVE.
+     * <p>
+     * After your network resource is created, you can use it in policy to restrict access to only requests made from an allowed
+     * IP address specified in your network source. For more information, see [Managing Network Sources](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -905,11 +1015,14 @@ public interface IdentityAsync extends AutoCloseable {
      *   * If the tag was used with dynamic groups, none of the rules that contain the tag will
      *   be evaluated against the tag.
      * <p>
-     * Once you start the delete operation, the state of the tag changes to DELETING and tag removal
+     * When you start the delete operation, the state of the tag changes to DELETING and tag removal
      * from resources begins. This can take up to 48 hours depending on the number of resources that
-     * were tagged as well as the regions in which those resources reside. When all tags have been
-     * removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
+     * were tagged as well as the regions in which those resources reside.
+     * <p>
+     * When all tags have been removed, the state changes to DELETED. You cannot restore a deleted tag. Once the deleted tag
      * changes its state to DELETED, you can use the same tag name again.
+     * <p>
+     * After you start this operation, you cannot start either the {@link #bulkDeleteTags(BulkDeleteTagsRequest, Consumer, Consumer) bulkDeleteTags} or the {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest, Consumer, Consumer) cascadeDeleteTagNamespace} operation until this process completes.
      * <p>
      * To delete a tag, you must first retire it. Use {@link #updateTag(UpdateTagRequest, Consumer, Consumer) updateTag}
      * to retire a tag.
@@ -943,8 +1056,11 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes the specified tag namespace. Only an empty tag namespace can be deleted. To delete
-     * a tag namespace, first delete all its tag definitions.
+     * Deletes the specified tag namespace. Only an empty tag namespace can be deleted with this operation. To use this operation
+     * to delete a tag namespace that contains tag definitions, first delete all of its tag definitions.
+     * <p>
+     * Use {@link #cascadeDeleteTagNamespace(CascadeDeleteTagNamespaceRequest, Consumer, Consumer) cascadeDeleteTagNamespace} to delete a tag namespace along with all of
+     * the tag definitions contained within that namespace.
      * <p>
      * Use {@link #deleteTag(DeleteTagRequest, Consumer, Consumer) deleteTag} to delete a tag definition.
      *
@@ -1344,6 +1460,23 @@ public interface IdentityAsync extends AutoCloseable {
             ListAvailabilityDomainsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListAvailabilityDomainsRequest, ListAvailabilityDomainsResponse>
+                    handler);
+
+    /**
+     * Lists the resource types supported by compartment bulk actions.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBulkActionResourceTypesResponse> listBulkActionResourceTypes(
+            ListBulkActionResourceTypesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListBulkActionResourceTypesRequest, ListBulkActionResourceTypesResponse>
                     handler);
 
     /**

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsyncClient.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsyncClient.java
@@ -559,6 +559,351 @@ public class IdentityAsyncClient implements IdentityAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<BulkDeleteResourcesResponse> bulkDeleteResources(
+            final BulkDeleteResourcesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            BulkDeleteResourcesRequest, BulkDeleteResourcesResponse>
+                    handler) {
+        LOG.trace("Called async bulkDeleteResources");
+        final BulkDeleteResourcesRequest interceptedRequest =
+                BulkDeleteResourcesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkDeleteResourcesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, BulkDeleteResourcesResponse>
+                transformer = BulkDeleteResourcesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        BulkDeleteResourcesRequest, BulkDeleteResourcesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            BulkDeleteResourcesRequest, BulkDeleteResourcesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getBulkDeleteResourcesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getBulkDeleteResourcesDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, BulkDeleteResourcesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getBulkDeleteResourcesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<BulkDeleteTagsResponse> bulkDeleteTags(
+            final BulkDeleteTagsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            BulkDeleteTagsRequest, BulkDeleteTagsResponse>
+                    handler) {
+        LOG.trace("Called async bulkDeleteTags");
+        final BulkDeleteTagsRequest interceptedRequest =
+                BulkDeleteTagsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkDeleteTagsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, BulkDeleteTagsResponse>
+                transformer = BulkDeleteTagsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<BulkDeleteTagsRequest, BulkDeleteTagsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            BulkDeleteTagsRequest, BulkDeleteTagsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getBulkDeleteTagsDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getBulkDeleteTagsDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, BulkDeleteTagsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getBulkDeleteTagsDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<BulkMoveResourcesResponse> bulkMoveResources(
+            final BulkMoveResourcesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            BulkMoveResourcesRequest, BulkMoveResourcesResponse>
+                    handler) {
+        LOG.trace("Called async bulkMoveResources");
+        final BulkMoveResourcesRequest interceptedRequest =
+                BulkMoveResourcesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkMoveResourcesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, BulkMoveResourcesResponse>
+                transformer = BulkMoveResourcesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<BulkMoveResourcesRequest, BulkMoveResourcesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            BulkMoveResourcesRequest, BulkMoveResourcesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getBulkMoveResourcesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getBulkMoveResourcesDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, BulkMoveResourcesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getBulkMoveResourcesDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CascadeDeleteTagNamespaceResponse> cascadeDeleteTagNamespace(
+            final CascadeDeleteTagNamespaceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CascadeDeleteTagNamespaceRequest, CascadeDeleteTagNamespaceResponse>
+                    handler) {
+        LOG.trace("Called async cascadeDeleteTagNamespace");
+        final CascadeDeleteTagNamespaceRequest interceptedRequest =
+                CascadeDeleteTagNamespaceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CascadeDeleteTagNamespaceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CascadeDeleteTagNamespaceResponse>
+                transformer = CascadeDeleteTagNamespaceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CascadeDeleteTagNamespaceRequest, CascadeDeleteTagNamespaceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CascadeDeleteTagNamespaceRequest, CascadeDeleteTagNamespaceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CascadeDeleteTagNamespaceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeTagNamespaceCompartmentResponse>
             changeTagNamespaceCompartment(
                     final ChangeTagNamespaceCompartmentRequest request,
@@ -5285,6 +5630,85 @@ public class IdentityAsyncClient implements IdentityAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, ListAvailabilityDomainsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListBulkActionResourceTypesResponse>
+            listBulkActionResourceTypes(
+                    final ListBulkActionResourceTypesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListBulkActionResourceTypesRequest,
+                                    ListBulkActionResourceTypesResponse>
+                            handler) {
+        LOG.trace("Called async listBulkActionResourceTypes");
+        final ListBulkActionResourceTypesRequest interceptedRequest =
+                ListBulkActionResourceTypesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBulkActionResourceTypesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBulkActionResourceTypesResponse>
+                transformer = ListBulkActionResourceTypesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListBulkActionResourceTypesRequest, ListBulkActionResourceTypesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListBulkActionResourceTypesRequest,
+                            ListBulkActionResourceTypesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListBulkActionResourceTypesResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityClient.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityClient.java
@@ -513,6 +513,133 @@ public class IdentityClient implements Identity {
     }
 
     @Override
+    public BulkDeleteResourcesResponse bulkDeleteResources(BulkDeleteResourcesRequest request) {
+        LOG.trace("Called bulkDeleteResources");
+        final BulkDeleteResourcesRequest interceptedRequest =
+                BulkDeleteResourcesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkDeleteResourcesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, BulkDeleteResourcesResponse>
+                transformer = BulkDeleteResourcesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getBulkDeleteResourcesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public BulkDeleteTagsResponse bulkDeleteTags(BulkDeleteTagsRequest request) {
+        LOG.trace("Called bulkDeleteTags");
+        final BulkDeleteTagsRequest interceptedRequest =
+                BulkDeleteTagsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkDeleteTagsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, BulkDeleteTagsResponse>
+                transformer = BulkDeleteTagsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getBulkDeleteTagsDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public BulkMoveResourcesResponse bulkMoveResources(BulkMoveResourcesRequest request) {
+        LOG.trace("Called bulkMoveResources");
+        final BulkMoveResourcesRequest interceptedRequest =
+                BulkMoveResourcesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                BulkMoveResourcesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, BulkMoveResourcesResponse>
+                transformer = BulkMoveResourcesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getBulkMoveResourcesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CascadeDeleteTagNamespaceResponse cascadeDeleteTagNamespace(
+            CascadeDeleteTagNamespaceRequest request) {
+        LOG.trace("Called cascadeDeleteTagNamespace");
+        final CascadeDeleteTagNamespaceRequest interceptedRequest =
+                CascadeDeleteTagNamespaceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CascadeDeleteTagNamespaceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CascadeDeleteTagNamespaceResponse>
+                transformer = CascadeDeleteTagNamespaceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeTagNamespaceCompartmentResponse changeTagNamespaceCompartment(
             ChangeTagNamespaceCompartmentRequest request) {
         LOG.trace("Called changeTagNamespaceCompartment");
@@ -2279,6 +2406,36 @@ public class IdentityClient implements Identity {
                 ListAvailabilityDomainsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListAvailabilityDomainsResponse>
                 transformer = ListAvailabilityDomainsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListBulkActionResourceTypesResponse listBulkActionResourceTypes(
+            ListBulkActionResourceTypesRequest request) {
+        LOG.trace("Called listBulkActionResourceTypes");
+        final ListBulkActionResourceTypesRequest interceptedRequest =
+                ListBulkActionResourceTypesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBulkActionResourceTypesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListBulkActionResourceTypesResponse>
+                transformer = ListBulkActionResourceTypesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityPaginators.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityPaginators.java
@@ -31,6 +31,124 @@ public class IdentityPaginators {
     private final Identity client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listBulkActionResourceTypes operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListBulkActionResourceTypesResponse>
+            listBulkActionResourceTypesResponseIterator(
+                    final ListBulkActionResourceTypesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListBulkActionResourceTypesRequest.Builder, ListBulkActionResourceTypesRequest,
+                ListBulkActionResourceTypesResponse>(
+                new com.google.common.base.Supplier<ListBulkActionResourceTypesRequest.Builder>() {
+                    @Override
+                    public ListBulkActionResourceTypesRequest.Builder get() {
+                        return ListBulkActionResourceTypesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBulkActionResourceTypesResponse, String>() {
+                    @Override
+                    public String apply(ListBulkActionResourceTypesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBulkActionResourceTypesRequest.Builder>,
+                        ListBulkActionResourceTypesRequest>() {
+                    @Override
+                    public ListBulkActionResourceTypesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBulkActionResourceTypesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBulkActionResourceTypesRequest, ListBulkActionResourceTypesResponse>() {
+                    @Override
+                    public ListBulkActionResourceTypesResponse apply(
+                            ListBulkActionResourceTypesRequest request) {
+                        return client.listBulkActionResourceTypes(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.identity.model.BulkActionResourceType} objects
+     * contained in responses from the listBulkActionResourceTypes operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.identity.model.BulkActionResourceType} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.identity.model.BulkActionResourceType>
+            listBulkActionResourceTypesRecordIterator(
+                    final ListBulkActionResourceTypesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListBulkActionResourceTypesRequest.Builder, ListBulkActionResourceTypesRequest,
+                ListBulkActionResourceTypesResponse,
+                com.oracle.bmc.identity.model.BulkActionResourceType>(
+                new com.google.common.base.Supplier<ListBulkActionResourceTypesRequest.Builder>() {
+                    @Override
+                    public ListBulkActionResourceTypesRequest.Builder get() {
+                        return ListBulkActionResourceTypesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBulkActionResourceTypesResponse, String>() {
+                    @Override
+                    public String apply(ListBulkActionResourceTypesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBulkActionResourceTypesRequest.Builder>,
+                        ListBulkActionResourceTypesRequest>() {
+                    @Override
+                    public ListBulkActionResourceTypesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBulkActionResourceTypesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBulkActionResourceTypesRequest, ListBulkActionResourceTypesResponse>() {
+                    @Override
+                    public ListBulkActionResourceTypesResponse apply(
+                            ListBulkActionResourceTypesRequest request) {
+                        return client.listBulkActionResourceTypes(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBulkActionResourceTypesResponse,
+                        java.util.List<com.oracle.bmc.identity.model.BulkActionResourceType>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.identity.model.BulkActionResourceType>
+                            apply(ListBulkActionResourceTypesResponse response) {
+                        return response.getBulkActionResourceTypeCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listCompartments operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkDeleteResourcesConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkDeleteResourcesConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.identity.model.*;
+import com.oracle.bmc.identity.requests.*;
+import com.oracle.bmc.identity.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class BulkDeleteResourcesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.identity.requests.BulkDeleteResourcesRequest interceptRequest(
+            com.oracle.bmc.identity.requests.BulkDeleteResourcesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.identity.requests.BulkDeleteResourcesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCompartmentId(), "compartmentId must not be blank");
+        Validate.notNull(
+                request.getBulkDeleteResourcesDetails(), "bulkDeleteResourcesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("compartments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCompartmentId()))
+                        .path("actions")
+                        .path("bulkDeleteResources");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse>() {
+                            @Override
+                            public com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.identity.responses
+                                                        .BulkDeleteResourcesResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.identity.responses.BulkDeleteResourcesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkDeleteTagsConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkDeleteTagsConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.identity.model.*;
+import com.oracle.bmc.identity.requests.*;
+import com.oracle.bmc.identity.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class BulkDeleteTagsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.identity.requests.BulkDeleteTagsRequest interceptRequest(
+            com.oracle.bmc.identity.requests.BulkDeleteTagsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.identity.requests.BulkDeleteTagsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getBulkDeleteTagsDetails(), "bulkDeleteTagsDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("tags")
+                        .path("actions")
+                        .path("bulkDelete");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.identity.responses.BulkDeleteTagsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.identity.responses.BulkDeleteTagsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.identity.responses.BulkDeleteTagsResponse>() {
+                            @Override
+                            public com.oracle.bmc.identity.responses.BulkDeleteTagsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.identity.responses.BulkDeleteTagsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.identity.responses.BulkDeleteTagsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.identity.responses
+                                                        .BulkDeleteTagsResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.identity.responses.BulkDeleteTagsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkMoveResourcesConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/BulkMoveResourcesConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.identity.model.*;
+import com.oracle.bmc.identity.requests.*;
+import com.oracle.bmc.identity.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class BulkMoveResourcesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.identity.requests.BulkMoveResourcesRequest interceptRequest(
+            com.oracle.bmc.identity.requests.BulkMoveResourcesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.identity.requests.BulkMoveResourcesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCompartmentId(), "compartmentId must not be blank");
+        Validate.notNull(
+                request.getBulkMoveResourcesDetails(), "bulkMoveResourcesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("compartments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCompartmentId()))
+                        .path("actions")
+                        .path("bulkMoveResources");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.identity.responses.BulkMoveResourcesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.identity.responses.BulkMoveResourcesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.identity.responses.BulkMoveResourcesResponse>() {
+                            @Override
+                            public com.oracle.bmc.identity.responses.BulkMoveResourcesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.identity.responses.BulkMoveResourcesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.identity.responses.BulkMoveResourcesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.identity.responses
+                                                        .BulkMoveResourcesResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.identity.responses.BulkMoveResourcesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/CascadeDeleteTagNamespaceConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/CascadeDeleteTagNamespaceConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.identity.model.*;
+import com.oracle.bmc.identity.requests.*;
+import com.oracle.bmc.identity.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CascadeDeleteTagNamespaceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.identity.requests.CascadeDeleteTagNamespaceRequest
+            interceptRequest(
+                    com.oracle.bmc.identity.requests.CascadeDeleteTagNamespaceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.identity.requests.CascadeDeleteTagNamespaceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getTagNamespaceId(), "tagNamespaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("tagNamespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTagNamespaceId()))
+                        .path("actions")
+                        .path("cascadeDelete");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.identity.responses.CascadeDeleteTagNamespaceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.identity.responses.CascadeDeleteTagNamespaceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.identity.responses
+                                        .CascadeDeleteTagNamespaceResponse>() {
+                            @Override
+                            public com.oracle.bmc.identity.responses
+                                            .CascadeDeleteTagNamespaceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.identity.responses.CascadeDeleteTagNamespaceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.identity.responses.CascadeDeleteTagNamespaceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.identity.responses
+                                                        .CascadeDeleteTagNamespaceResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.identity.responses.CascadeDeleteTagNamespaceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListBulkActionResourceTypesConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListBulkActionResourceTypesConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.identity.model.*;
+import com.oracle.bmc.identity.requests.*;
+import com.oracle.bmc.identity.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListBulkActionResourceTypesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.identity.requests.ListBulkActionResourceTypesRequest
+            interceptRequest(
+                    com.oracle.bmc.identity.requests.ListBulkActionResourceTypesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.identity.requests.ListBulkActionResourceTypesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getBulkActionType(), "bulkActionType is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("compartments")
+                        .path("bulkActionResourceTypes");
+
+        target =
+                target.queryParam(
+                        "bulkActionType",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getBulkActionType().getValue()));
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.identity.responses.ListBulkActionResourceTypesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.identity.responses.ListBulkActionResourceTypesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.identity.responses
+                                        .ListBulkActionResourceTypesResponse>() {
+                            @Override
+                            public com.oracle.bmc.identity.responses
+                                            .ListBulkActionResourceTypesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.identity.responses.ListBulkActionResourceTypesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        BulkActionResourceTypeCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        BulkActionResourceTypeCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                BulkActionResourceTypeCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.identity.responses
+                                                .ListBulkActionResourceTypesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.identity.responses
+                                                        .ListBulkActionResourceTypesResponse
+                                                        .builder();
+
+                                builder.bulkActionResourceTypeCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.identity.responses
+                                                .ListBulkActionResourceTypesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResource.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResource.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ * The bulk action resource entity.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkActionResource.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkActionResource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+        private String entityType;
+
+        public Builder entityType(String entityType) {
+            this.entityType = entityType;
+            this.__explicitlySet__.add("entityType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private java.util.Map<String, String> metadata;
+
+        public Builder metadata(java.util.Map<String, String> metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkActionResource build() {
+            BulkActionResource __instance__ =
+                    new BulkActionResource(identifier, entityType, metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkActionResource o) {
+            Builder copiedBuilder =
+                    identifier(o.getIdentifier())
+                            .entityType(o.getEntityType())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The resource identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * The resource type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+    String entityType;
+
+    /**
+     * Additional information that helps to identity the resource for bulk action.
+     * <p>
+     * DELETE and UPDATE APIs for most resource types only require the resource identifier(ocid).
+     * But additional metadata is required for some resource types.
+     * <p>
+     * This information is provided in the resource's public API document. It is also
+     * available through the ListBulkActionResourceTypes API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    java.util.Map<String, String> metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceType.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceType.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkActionResourceType.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkActionResourceType {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadataKeys")
+        private java.util.List<String> metadataKeys;
+
+        public Builder metadataKeys(java.util.List<String> metadataKeys) {
+            this.metadataKeys = metadataKeys;
+            this.__explicitlySet__.add("metadataKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkActionResourceType build() {
+            BulkActionResourceType __instance__ = new BulkActionResourceType(name, metadataKeys);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkActionResourceType o) {
+            Builder copiedBuilder = name(o.getName()).metadataKeys(o.getMetadataKeys());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique name of the resource type.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * List of metadata keys required to identify the resource.
+     * E.g. for bucket, metadataKeys will be [\"namespaceName\", \"bucketName\"].
+     * This informatino will match the public API document:
+     * https://docs.cloud.oracle.com/en-us/iaas/api/#/en/objectstorage/20160918/Bucket/GetBucket
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metadataKeys")
+    java.util.List<String> metadataKeys;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceTypeCollection.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceTypeCollection.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ * Collection of resource types supported by bulk action.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkActionResourceTypeCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkActionResourceTypeCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<BulkActionResourceType> items;
+
+        public Builder items(java.util.List<BulkActionResourceType> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkActionResourceTypeCollection build() {
+            BulkActionResourceTypeCollection __instance__ =
+                    new BulkActionResourceTypeCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkActionResourceTypeCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Collection of resource types supported by bulk action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<BulkActionResourceType> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkDeleteResourcesDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkDeleteResourcesDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkDeleteResourcesDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkDeleteResourcesDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<BulkActionResource> resources;
+
+        public Builder resources(java.util.List<BulkActionResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkDeleteResourcesDetails build() {
+            BulkDeleteResourcesDetails __instance__ = new BulkDeleteResourcesDetails(resources);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkDeleteResourcesDetails o) {
+            Builder copiedBuilder = resources(o.getResources());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The resources to be deleted.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<BulkActionResource> resources;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkDeleteTagsDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkDeleteTagsDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ * Properties for deleting tags in bulk
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkDeleteTagsDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkDeleteTagsDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("tagDefinitionIds")
+        private java.util.List<String> tagDefinitionIds;
+
+        public Builder tagDefinitionIds(java.util.List<String> tagDefinitionIds) {
+            this.tagDefinitionIds = tagDefinitionIds;
+            this.__explicitlySet__.add("tagDefinitionIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkDeleteTagsDetails build() {
+            BulkDeleteTagsDetails __instance__ = new BulkDeleteTagsDetails(tagDefinitionIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkDeleteTagsDetails o) {
+            Builder copiedBuilder = tagDefinitionIds(o.getTagDefinitionIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCIDs of the tag definitions to delete
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tagDefinitionIds")
+    java.util.List<String> tagDefinitionIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkMoveResourcesDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkMoveResourcesDetails.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkMoveResourcesDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class BulkMoveResourcesDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<BulkActionResource> resources;
+
+        public Builder resources(java.util.List<BulkActionResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetCompartmentId")
+        private String targetCompartmentId;
+
+        public Builder targetCompartmentId(String targetCompartmentId) {
+            this.targetCompartmentId = targetCompartmentId;
+            this.__explicitlySet__.add("targetCompartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkMoveResourcesDetails build() {
+            BulkMoveResourcesDetails __instance__ =
+                    new BulkMoveResourcesDetails(resources, targetCompartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkMoveResourcesDetails o) {
+            Builder copiedBuilder =
+                    resources(o.getResources()).targetCompartmentId(o.getTargetCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The resources to be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<BulkActionResource> resources;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the destination compartment
+     * into which to move the resources.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetCompartmentId")
+    String targetCompartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateNetworkSourceDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateNetworkSourceDetails.java
@@ -142,7 +142,7 @@ public class CreateNetworkSourceDetails {
     }
 
     /**
-     * The OCID of the tenancy containing the network source object.
+     * The OCID of the tenancy (root compartment) containing the network source object.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -156,22 +156,24 @@ public class CreateNetworkSourceDetails {
     String name;
 
     /**
-     * A list of allowed public IPs and CIDR ranges
+     * A list of allowed public IP addresses and CIDR ranges.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicSourceList")
     java.util.List<String> publicSourceList;
 
     /**
-     * A list of allowed VCN ocid/IP range pairs
+     * A list of allowed VCN OCID and IP range pairs.
+     * Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("virtualSourceList")
     java.util.List<NetworkSources_virtualSourceList> virtualSourceList;
 
     /**
-     * A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-     * At this time only the values of all or none are supported.
+     * A list of services allowed to make on-behalf-of requests. These requests can have different source IP addresses
+     * than those listed in the network source.
+     * Currently, only `all` and `none` are supported. The default is `all`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateRegionSubscriptionDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/CreateRegionSubscriptionDetails.java
@@ -61,16 +61,8 @@ public class CreateRegionSubscriptionDetails {
     }
 
     /**
-     * The regions's key.
-     * <p>
-     * Allowed values are:
-     * - `PHX`
-     * - `IAD`
-     * - `FRA`
-     * - `LHR`
-     * - `YYZ`
-     * - `NRT`
-     * - `ICN`
+     * The regions's key. See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm) for
+     * the full list of supported 3-letter region codes.
      * <p>
      * Example: `PHX`
      *

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkSources.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkSources.java
@@ -5,8 +5,9 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * A network source defines a list of source IPs that are allowed to make auth requests
- * More info needed here
+ * A network source specifies a list of source IP addresses that are allowed to make authorization requests.
+ * Use the network source in policy statements to restrict access to only requests that come from the specified IPs.
+ * For more information, see [Managing Network Sources](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -192,7 +193,7 @@ public class NetworkSources {
     String id;
 
     /**
-     * The OCID of the tenancy containing the network source.
+     * The OCID of the tenancy containing the network source. The tenancy is the root compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -212,22 +213,24 @@ public class NetworkSources {
     String description;
 
     /**
-     * A list of allowed public IPs and CIDR ranges
+     * A list of allowed public IPs and CIDR ranges.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicSourceList")
     java.util.List<String> publicSourceList;
 
     /**
-     * A list of allowed VCN ocid/IP range pairs
+     * A list of allowed VCN OCID and IP range pairs.
+     * Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("virtualSourceList")
     java.util.List<NetworkSources_virtualSourceList> virtualSourceList;
 
     /**
-     * A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-     * At this time only the values of all or none are supported.
+     * A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+     * those specified in the network source.
+     * Currently, only `all` and `none` are supported. The default is `all`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkSourcesSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/NetworkSourcesSummary.java
@@ -5,8 +5,9 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * A network source defines a list of source IPs that are allowed to make auth requests
- * More info needed here
+ * A network source specifies a list of source IP addresses that are allowed to make authorization requests.
+ * Use the network source in policy statements to restrict access to only requests that come from the specified IPs.
+ * For more information, see [Managing Network Sources](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingnetworksources.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -149,7 +150,7 @@ public class NetworkSourcesSummary {
     String id;
 
     /**
-     * The OCID of the tenancy containing the network source.
+     * The OCID of the tenancy (root compartment) containing the network source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -169,22 +170,23 @@ public class NetworkSourcesSummary {
     String description;
 
     /**
-     * A list of allowed public IPs and CIDR ranges
+     * A list of allowed public IP addresses and CIDR ranges.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicSourceList")
     java.util.List<String> publicSourceList;
 
     /**
-     * A list of allowed VCN ocid/IP range pairs
+     * A list of allowed VCN OCID and IP range pairs.
+     * Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("virtualSourceList")
     java.util.List<NetworkSources_virtualSourceList> virtualSourceList;
 
     /**
-     * A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-     * At this time only the values of all or none are supported.
+     * A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+     * those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Region.java
@@ -74,32 +74,20 @@ public class Region {
     }
 
     /**
-     * The key of the region.
+     * The key of the region. See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm) for
+     * the full list of supported 3-letter region codes.
      * <p>
-     * Allowed values are:
-     * - `PHX`
-     * - `IAD`
-     * - `FRA`
-     * - `LHR`
-     * - `YYZ`
-     * - `NRT`
-     * - `ICN`
+     * Example: `PHX`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("key")
     String key;
 
     /**
-     * The name of the region.
+     * The name of the region. See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm)
+     * for the full list of supported region names.
      * <p>
-     * Allowed values are:
-     * - `ap-seoul-1`
-     * - `ap-tokyo-1`
-     * - `ca-toronto-1`
-     * - `eu-frankurt-1`
-     * - `uk-london-1`
-     * - `us-ashburn-1`
-     * - `us-phoenix-1`
+     * Example: `us-phoenix-1`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/RegionSubscription.java
@@ -98,32 +98,20 @@ public class RegionSubscription {
     }
 
     /**
-     * The region's key.
+     * The region's key. See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm)
+     * for the full list of supported 3-letter region codes.
      * <p>
-     * Allowed values are:
-     * - `PHX`
-     * - `IAD`
-     * - `FRA`
-     * - `LHR`
-     * - `YYZ`
-     * - `NRT`
-     * - `ICN`
+     * Example: `PHX`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("regionKey")
     String regionKey;
 
     /**
-     * The region's name.
+     * The region's name. See [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm)
+     * for the full list of supported region names.
      * <p>
-     * Allowed values are:
-     * - `ap-seoul-1`
-     * - `ap-tokyo-1`
-     * - `ca-toronto-1`
-     * - `eu-frankurt-1`
-     * - `uk-london-1`
-     * - `us-ashburn-1`
-     * - `us-phoenix-1`
+     * Example: `us-phoenix-1`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("regionName")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/Tenancy.java
@@ -155,17 +155,10 @@ public class Tenancy {
     String description;
 
     /**
-     * The region key for the tenancy's home region. For more information about regions, see
+     * The region key for the tenancy's home region. For the full list of supported regions, see
      * [Regions and Availability Domains](https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm).
      * <p>
-     * Allowed values are:
-     * - `IAD`
-     * - `PHX`
-     * - `FRA`
-     * - `LHR`
-     * - `ICN`
-     * - `YYZ`
-     * - `NRT`
+     * Example: `PHX`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("homeRegionKey")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateNetworkSourceDetails.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/UpdateNetworkSourceDetails.java
@@ -126,22 +126,23 @@ public class UpdateNetworkSourceDetails {
     String description;
 
     /**
-     * A list of allowed public IPs and CIDR ranges
+     * A list of allowed public IP addresses and CIDR ranges.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicSourceList")
     java.util.List<String> publicSourceList;
 
     /**
-     * A list of allowed VCN ocid/IP range pairs
+     * A list of allowed VCN OCID and IP range pairs.
+     * Example:`\"vcnId\": \"ocid1.vcn.oc1.iad.aaaaaaaaexampleuniqueID\", \"ipRanges\": [ \"129.213.39.0/24\" ]`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("virtualSourceList")
     java.util.List<NetworkSources_virtualSourceList> virtualSourceList;
 
     /**
-     * A list of OCIservices allowed to make on behalf of requests which may have different source ips.
-     * At this time only the values of all or none are supported.
+     * A list of services allowed to make on-behalf-of requests. These requests can have different source IPs than
+     * those specified in the network source. Currently, only `all` and `none` are supported. The default is `all`.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("services")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
@@ -10,7 +10,7 @@ package com.oracle.bmc.identity.model;
  * have one or more IAM Service credentials ({@link ApiKey},
  * {@link UIPassword}, {@link SwiftPassword} and
  * {@link AuthToken}).
- * For more information, see [User Credentials](https://docs.cloud.oracle.com/Content/API/Concepts/usercredentials.htm)). End users of your
+ * For more information, see [User Credentials](https://docs.cloud.oracle.com/Content/Identity/Concepts/usercredentials.htm)). End users of your
  * application are not typically IAM Service users. For conceptual information about users and other IAM Service
  * components, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
  * <p>

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkDeleteResourcesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkDeleteResourcesRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.requests;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class BulkDeleteResourcesRequest
+        extends com.oracle.bmc.requests.BmcRequest<BulkDeleteResourcesDetails> {
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Request object for bulk delete resources in a compartment.
+     */
+    private BulkDeleteResourcesDetails bulkDeleteResourcesDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public BulkDeleteResourcesDetails getBody$() {
+        return bulkDeleteResourcesDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    BulkDeleteResourcesRequest, BulkDeleteResourcesDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkDeleteResourcesRequest o) {
+            compartmentId(o.getCompartmentId());
+            bulkDeleteResourcesDetails(o.getBulkDeleteResourcesDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of BulkDeleteResourcesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of BulkDeleteResourcesRequest
+         */
+        public BulkDeleteResourcesRequest build() {
+            BulkDeleteResourcesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(BulkDeleteResourcesDetails body) {
+            bulkDeleteResourcesDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkDeleteTagsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkDeleteTagsRequest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.requests;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class BulkDeleteTagsRequest
+        extends com.oracle.bmc.requests.BmcRequest<BulkDeleteTagsDetails> {
+
+    /**
+     * Request object for deleting tags in bulk.
+     */
+    private BulkDeleteTagsDetails bulkDeleteTagsDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public BulkDeleteTagsDetails getBody$() {
+        return bulkDeleteTagsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    BulkDeleteTagsRequest, BulkDeleteTagsDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkDeleteTagsRequest o) {
+            bulkDeleteTagsDetails(o.getBulkDeleteTagsDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of BulkDeleteTagsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of BulkDeleteTagsRequest
+         */
+        public BulkDeleteTagsRequest build() {
+            BulkDeleteTagsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(BulkDeleteTagsDetails body) {
+            bulkDeleteTagsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkMoveResourcesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/BulkMoveResourcesRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.requests;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class BulkMoveResourcesRequest
+        extends com.oracle.bmc.requests.BmcRequest<BulkMoveResourcesDetails> {
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Request object for bulk move resources in the compartment.
+     */
+    private BulkMoveResourcesDetails bulkMoveResourcesDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public BulkMoveResourcesDetails getBody$() {
+        return bulkMoveResourcesDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    BulkMoveResourcesRequest, BulkMoveResourcesDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkMoveResourcesRequest o) {
+            compartmentId(o.getCompartmentId());
+            bulkMoveResourcesDetails(o.getBulkMoveResourcesDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of BulkMoveResourcesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of BulkMoveResourcesRequest
+         */
+        public BulkMoveResourcesRequest build() {
+            BulkMoveResourcesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(BulkMoveResourcesDetails body) {
+            bulkMoveResourcesDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/CascadeDeleteTagNamespaceRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/CascadeDeleteTagNamespaceRequest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.requests;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CascadeDeleteTagNamespaceRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the tag namespace.
+     *
+     */
+    private String tagNamespaceId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CascadeDeleteTagNamespaceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CascadeDeleteTagNamespaceRequest o) {
+            tagNamespaceId(o.getTagNamespaceId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CascadeDeleteTagNamespaceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CascadeDeleteTagNamespaceRequest
+         */
+        public CascadeDeleteTagNamespaceRequest build() {
+            CascadeDeleteTagNamespaceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListBulkActionResourceTypesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListBulkActionResourceTypesRequest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.requests;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListBulkActionResourceTypesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The type of the bulk action.
+     *
+     */
+    private BulkActionType bulkActionType;
+
+    /**
+     * The type of the bulk action.
+     *
+     **/
+    public enum BulkActionType {
+        BulkMoveResources("BULK_MOVE_RESOURCES"),
+        BulkDeleteResources("BULK_DELETE_RESOURCES"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, BulkActionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BulkActionType v : BulkActionType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        BulkActionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BulkActionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid BulkActionType: " + key);
+        }
+    };
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return in a paginated \"List\" call.
+     *
+     */
+    private Integer limit;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListBulkActionResourceTypesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBulkActionResourceTypesRequest o) {
+            bulkActionType(o.getBulkActionType());
+            page(o.getPage());
+            limit(o.getLimit());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBulkActionResourceTypesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBulkActionResourceTypesRequest
+         */
+        public ListBulkActionResourceTypesRequest build() {
+            ListBulkActionResourceTypesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkDeleteResourcesResponse.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkDeleteResourcesResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.responses;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class BulkDeleteResourcesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkDeleteResourcesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkDeleteTagsResponse.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkDeleteTagsResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.responses;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class BulkDeleteTagsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkDeleteTagsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkMoveResourcesResponse.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/BulkMoveResourcesResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.responses;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class BulkMoveResourcesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(BulkMoveResourcesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/CascadeDeleteTagNamespaceResponse.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/CascadeDeleteTagNamespaceResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.responses;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CascadeDeleteTagNamespaceResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CascadeDeleteTagNamespaceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/ListBulkActionResourceTypesResponse.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/responses/ListBulkActionResourceTypesResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.identity.responses;
+
+import com.oracle.bmc.identity.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListBulkActionResourceTypesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned BulkActionResourceTypeCollection instance.
+     */
+    private BulkActionResourceTypeCollection bulkActionResourceTypeCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBulkActionResourceTypesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            bulkActionResourceTypeCollection(o.getBulkActionResourceTypeCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/CreateIntegrationInstanceDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/CreateIntegrationInstanceDetails.java
@@ -98,6 +98,15 @@ public class CreateIntegrationInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+        private Boolean isFileServerEnabled;
+
+        public Builder isFileServerEnabled(Boolean isFileServerEnabled) {
+            this.isFileServerEnabled = isFileServerEnabled;
+            this.__explicitlySet__.add("isFileServerEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -111,7 +120,8 @@ public class CreateIntegrationInstanceDetails {
                             definedTags,
                             isByol,
                             idcsAt,
-                            messagePacks);
+                            messagePacks,
+                            isFileServerEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -126,7 +136,8 @@ public class CreateIntegrationInstanceDetails {
                             .definedTags(o.getDefinedTags())
                             .isByol(o.getIsByol())
                             .idcsAt(o.getIdcsAt())
-                            .messagePacks(o.getMessagePacks());
+                            .messagePacks(o.getMessagePacks())
+                            .isFileServerEnabled(o.getIsFileServerEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -227,6 +238,12 @@ public class CreateIntegrationInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("messagePacks")
     Integer messagePacks;
+
+    /**
+     * The file server is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+    Boolean isFileServerEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstance.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstance.java
@@ -143,6 +143,15 @@ public class IntegrationInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+        private Boolean isFileServerEnabled;
+
+        public Builder isFileServerEnabled(Boolean isFileServerEnabled) {
+            this.isFileServerEnabled = isFileServerEnabled;
+            this.__explicitlySet__.add("isFileServerEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -161,7 +170,8 @@ public class IntegrationInstance {
                             definedTags,
                             isByol,
                             instanceUrl,
-                            messagePacks);
+                            messagePacks,
+                            isFileServerEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -181,7 +191,8 @@ public class IntegrationInstance {
                             .definedTags(o.getDefinedTags())
                             .isByol(o.getIsByol())
                             .instanceUrl(o.getInstanceUrl())
-                            .messagePacks(o.getMessagePacks());
+                            .messagePacks(o.getMessagePacks())
+                            .isFileServerEnabled(o.getIsFileServerEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -373,6 +384,12 @@ public class IntegrationInstance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("messagePacks")
     Integer messagePacks;
+
+    /**
+     * The file server is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+    Boolean isFileServerEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstanceSummary.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstanceSummary.java
@@ -124,6 +124,15 @@ public class IntegrationInstanceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+        private Boolean isFileServerEnabled;
+
+        public Builder isFileServerEnabled(Boolean isFileServerEnabled) {
+            this.isFileServerEnabled = isFileServerEnabled;
+            this.__explicitlySet__.add("isFileServerEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -140,7 +149,8 @@ public class IntegrationInstanceSummary {
                             stateMessage,
                             isByol,
                             instanceUrl,
-                            messagePacks);
+                            messagePacks,
+                            isFileServerEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -158,7 +168,8 @@ public class IntegrationInstanceSummary {
                             .stateMessage(o.getStateMessage())
                             .isByol(o.getIsByol())
                             .instanceUrl(o.getInstanceUrl())
-                            .messagePacks(o.getMessagePacks());
+                            .messagePacks(o.getMessagePacks())
+                            .isFileServerEnabled(o.getIsFileServerEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -332,6 +343,12 @@ public class IntegrationInstanceSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("messagePacks")
     Integer messagePacks;
+
+    /**
+     * The file server is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+    Boolean isFileServerEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/UpdateIntegrationInstanceDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/UpdateIntegrationInstanceDetails.java
@@ -80,6 +80,15 @@ public class UpdateIntegrationInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+        private Boolean isFileServerEnabled;
+
+        public Builder isFileServerEnabled(Boolean isFileServerEnabled) {
+            this.isFileServerEnabled = isFileServerEnabled;
+            this.__explicitlySet__.add("isFileServerEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -91,7 +100,8 @@ public class UpdateIntegrationInstanceDetails {
                             freeformTags,
                             definedTags,
                             isByol,
-                            messagePacks);
+                            messagePacks,
+                            isFileServerEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -104,7 +114,8 @@ public class UpdateIntegrationInstanceDetails {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .isByol(o.getIsByol())
-                            .messagePacks(o.getMessagePacks());
+                            .messagePacks(o.getMessagePacks())
+                            .isFileServerEnabled(o.getIsFileServerEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -193,6 +204,12 @@ public class UpdateIntegrationInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("messagePacks")
     Integer messagePacks;
+
+    /**
+     * The file server is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
+    Boolean isFileServerEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/src/main/java/com/oracle/bmc/oda/model/OdaInstance.java
+++ b/bmc-oda/src/main/java/com/oracle/bmc/oda/model/OdaInstance.java
@@ -365,7 +365,13 @@ public class OdaInstance {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LifecycleSubState {
+        Creating("CREATING"),
+        Starting("STARTING"),
+        Stopping("STOPPING"),
+        ChangingCompartment("CHANGING_COMPARTMENT"),
+        Deleting("DELETING"),
         DeletePending("DELETE_PENDING"),
+        Recovering("RECOVERING"),
         Purging("PURGING"),
         Queued("QUEUED"),
 

--- a/bmc-oda/src/main/java/com/oracle/bmc/oda/model/OdaInstanceSummary.java
+++ b/bmc-oda/src/main/java/com/oracle/bmc/oda/model/OdaInstanceSummary.java
@@ -331,7 +331,13 @@ public class OdaInstanceSummary {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LifecycleSubState {
+        Creating("CREATING"),
+        Starting("STARTING"),
+        Stopping("STOPPING"),
+        ChangingCompartment("CHANGING_COMPARTMENT"),
+        Deleting("DELETING"),
         DeletePending("DELETE_PENDING"),
+        Recovering("RECOVERING"),
         Purging("PURGING"),
         Queued("QUEUED"),
 

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.17.5</version>
+    <version>1.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.17.5</version>
+      <version>1.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.17.5</version>
+  <version>1.18.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for returning the database version of backups in the Database service

- Support for patching on Exadata Cloud at Customer resources in the Database service

- Support for new lifecycle substates on instances in the Digital Assistant service

- Support for file servers in the Integration service

- Support for deleting non-empty tag namespaces and bulk deleting tags in the Identity service

- Support for bulk move and bulk delete of resources by compartment in the Identity service





### Breaking Changes

- Data type for paramater `dataStorageSizeInTBs` changed from `Integer` to `Double` in the Database service

- Enum `LifecycleState` has removed the state `Offline` and added `Disconnected` in the Database service