### PR TITLE
Releasing version 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.18.1 - 2020-06-16
+### Added
+- Support for creating a new database from an existing database based on a given timestamp in the Database service
+- Support for enabling archive log backups of databases in the Database service
+- Support for returning the database version on autonomous container databases in the Database service
+- Support for the new DNS format of the Data Transfer service
+- Support for scheduled autoscaling, which allows for scaling actions triggered at particular times based on CRON expressions, in the Compute Autoscaling service
+- Support for filtering of list APIs for groups, identity providers, identity provider groups, compartments, dynamic groups, network sources, policies, and users by name or lifecycle state in the Identity Service
+
 ## 1.18.0 - 2020-06-09
 ### Added
 - Support for returning the database version of backups in the Database service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfiguration.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingConfiguration.java
@@ -118,6 +118,24 @@ public class AutoScalingConfiguration {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("maxResourceCount")
+        private Integer maxResourceCount;
+
+        public Builder maxResourceCount(Integer maxResourceCount) {
+            this.maxResourceCount = maxResourceCount;
+            this.__explicitlySet__.add("maxResourceCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minResourceCount")
+        private Integer minResourceCount;
+
+        public Builder minResourceCount(Integer minResourceCount) {
+            this.minResourceCount = minResourceCount;
+            this.__explicitlySet__.add("minResourceCount");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -133,7 +151,9 @@ public class AutoScalingConfiguration {
                             isEnabled,
                             resource,
                             policies,
-                            timeCreated);
+                            timeCreated,
+                            maxResourceCount,
+                            minResourceCount);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -150,7 +170,9 @@ public class AutoScalingConfiguration {
                             .isEnabled(o.getIsEnabled())
                             .resource(o.getResource())
                             .policies(o.getPolicies())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .maxResourceCount(o.getMaxResourceCount())
+                            .minResourceCount(o.getMinResourceCount());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -239,6 +261,18 @@ public class AutoScalingConfiguration {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * The maximum number of resources to scale out to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxResourceCount")
+    Integer maxResourceCount;
+
+    /**
+     * The minimum number of resources to scale in to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minResourceCount")
+    Integer minResourceCount;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicy.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicy.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.autoscaling.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ScheduledPolicy.class,
+        name = "scheduled"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ThresholdPolicy.class,
         name = "threshold"
     )
@@ -67,4 +71,10 @@ public class AutoScalingPolicy {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * Boolean field indicating whether this policy is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 }

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicySummary.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/AutoScalingPolicySummary.java
@@ -53,12 +53,21 @@ public class AutoScalingPolicySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AutoScalingPolicySummary build() {
             AutoScalingPolicySummary __instance__ =
-                    new AutoScalingPolicySummary(id, displayName, policyType);
+                    new AutoScalingPolicySummary(id, displayName, policyType, isEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -66,7 +75,10 @@ public class AutoScalingPolicySummary {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AutoScalingPolicySummary o) {
             Builder copiedBuilder =
-                    id(o.getId()).displayName(o.getDisplayName()).policyType(o.getPolicyType());
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .policyType(o.getPolicyType())
+                            .isEnabled(o.getIsEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -98,6 +110,12 @@ public class AutoScalingPolicySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("policyType")
     String policyType;
+
+    /**
+     * Boolean field indicated whether this policy is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateAutoScalingPolicyDetails.java
@@ -35,6 +35,10 @@ package com.oracle.bmc.autoscaling.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateScheduledPolicyDetails.class,
+        name = "scheduled"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateThresholdPolicyDetails.class,
         name = "threshold"
     )
@@ -54,4 +58,10 @@ public class CreateAutoScalingPolicyDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Boolean field indicating whether this policy is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 }

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateScheduledPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateScheduledPolicyDetails.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ * Creation details for a schedule-based autoscaling policy.
+ * <p>
+ * In a schedule-based autoscaling policy, an autoscaling action is triggered when execution time is current.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateScheduledPolicyDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "policyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateScheduledPolicyDetails extends CreateAutoScalingPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("capacity")
+        private Capacity capacity;
+
+        public Builder capacity(Capacity capacity) {
+            this.capacity = capacity;
+            this.__explicitlySet__.add("capacity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+        private ExecutionSchedule executionSchedule;
+
+        public Builder executionSchedule(ExecutionSchedule executionSchedule) {
+            this.executionSchedule = executionSchedule;
+            this.__explicitlySet__.add("executionSchedule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateScheduledPolicyDetails build() {
+            CreateScheduledPolicyDetails __instance__ =
+                    new CreateScheduledPolicyDetails(
+                            capacity, displayName, isEnabled, executionSchedule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateScheduledPolicyDetails o) {
+            Builder copiedBuilder =
+                    capacity(o.getCapacity())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .executionSchedule(o.getExecutionSchedule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateScheduledPolicyDetails(
+            Capacity capacity,
+            String displayName,
+            Boolean isEnabled,
+            ExecutionSchedule executionSchedule) {
+        super(capacity, displayName, isEnabled);
+        this.executionSchedule = executionSchedule;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+    ExecutionSchedule executionSchedule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateThresholdPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CreateThresholdPolicyDetails.java
@@ -53,6 +53,15 @@ public class CreateThresholdPolicyDetails extends CreateAutoScalingPolicyDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("rules")
         private java.util.List<CreateConditionDetails> rules;
 
@@ -67,7 +76,7 @@ public class CreateThresholdPolicyDetails extends CreateAutoScalingPolicyDetails
 
         public CreateThresholdPolicyDetails build() {
             CreateThresholdPolicyDetails __instance__ =
-                    new CreateThresholdPolicyDetails(capacity, displayName, rules);
+                    new CreateThresholdPolicyDetails(capacity, displayName, isEnabled, rules);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -75,7 +84,10 @@ public class CreateThresholdPolicyDetails extends CreateAutoScalingPolicyDetails
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateThresholdPolicyDetails o) {
             Builder copiedBuilder =
-                    capacity(o.getCapacity()).displayName(o.getDisplayName()).rules(o.getRules());
+                    capacity(o.getCapacity())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .rules(o.getRules());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -91,8 +103,11 @@ public class CreateThresholdPolicyDetails extends CreateAutoScalingPolicyDetails
 
     @Deprecated
     public CreateThresholdPolicyDetails(
-            Capacity capacity, String displayName, java.util.List<CreateConditionDetails> rules) {
-        super(capacity, displayName);
+            Capacity capacity,
+            String displayName,
+            Boolean isEnabled,
+            java.util.List<CreateConditionDetails> rules) {
+        super(capacity, displayName, isEnabled);
         this.rules = rules;
     }
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CronExecutionSchedule.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/CronExecutionSchedule.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ * Specifies the execution schedule of CRON type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CronExecutionSchedule.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CronExecutionSchedule extends ExecutionSchedule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+        private Timezone timezone;
+
+        public Builder timezone(Timezone timezone) {
+            this.timezone = timezone;
+            this.__explicitlySet__.add("timezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CronExecutionSchedule build() {
+            CronExecutionSchedule __instance__ = new CronExecutionSchedule(timezone, expression);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CronExecutionSchedule o) {
+            Builder copiedBuilder = timezone(o.getTimezone()).expression(o.getExpression());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CronExecutionSchedule(Timezone timezone, String expression) {
+        super(timezone);
+        this.expression = expression;
+    }
+
+    /**
+     * The value representing the execution schedule, as defined by cron format.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ExecutionSchedule.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ExecutionSchedule.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ * Specifies the execution schedule for a policy.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    defaultImpl = ExecutionSchedule.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CronExecutionSchedule.class,
+        name = "cron"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ExecutionSchedule {
+
+    /**
+     * Specifies the time zone the schedule is in.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Timezone {
+        Utc("UTC"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Timezone> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Timezone v : Timezone.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Timezone(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Timezone create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Timezone', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Specifies the time zone the schedule is in.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+    Timezone timezone;
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ScheduledPolicy.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ScheduledPolicy.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ * An autoscaling policy that defines execution schedules for an autoscaling configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ScheduledPolicy.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "policyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ScheduledPolicy extends AutoScalingPolicy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("capacity")
+        private Capacity capacity;
+
+        public Builder capacity(Capacity capacity) {
+            this.capacity = capacity;
+            this.__explicitlySet__.add("capacity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+        private ExecutionSchedule executionSchedule;
+
+        public Builder executionSchedule(ExecutionSchedule executionSchedule) {
+            this.executionSchedule = executionSchedule;
+            this.__explicitlySet__.add("executionSchedule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ScheduledPolicy build() {
+            ScheduledPolicy __instance__ =
+                    new ScheduledPolicy(
+                            capacity, id, displayName, timeCreated, isEnabled, executionSchedule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ScheduledPolicy o) {
+            Builder copiedBuilder =
+                    capacity(o.getCapacity())
+                            .id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .isEnabled(o.getIsEnabled())
+                            .executionSchedule(o.getExecutionSchedule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ScheduledPolicy(
+            Capacity capacity,
+            String id,
+            String displayName,
+            java.util.Date timeCreated,
+            Boolean isEnabled,
+            ExecutionSchedule executionSchedule) {
+        super(capacity, id, displayName, timeCreated, isEnabled);
+        this.executionSchedule = executionSchedule;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+    ExecutionSchedule executionSchedule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ThresholdPolicy.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/ThresholdPolicy.java
@@ -65,6 +65,15 @@ public class ThresholdPolicy extends AutoScalingPolicy {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("rules")
         private java.util.List<Condition> rules;
 
@@ -79,7 +88,7 @@ public class ThresholdPolicy extends AutoScalingPolicy {
 
         public ThresholdPolicy build() {
             ThresholdPolicy __instance__ =
-                    new ThresholdPolicy(capacity, id, displayName, timeCreated, rules);
+                    new ThresholdPolicy(capacity, id, displayName, timeCreated, isEnabled, rules);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -91,6 +100,7 @@ public class ThresholdPolicy extends AutoScalingPolicy {
                             .id(o.getId())
                             .displayName(o.getDisplayName())
                             .timeCreated(o.getTimeCreated())
+                            .isEnabled(o.getIsEnabled())
                             .rules(o.getRules());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -111,8 +121,9 @@ public class ThresholdPolicy extends AutoScalingPolicy {
             String id,
             String displayName,
             java.util.Date timeCreated,
+            Boolean isEnabled,
             java.util.List<Condition> rules) {
-        super(capacity, id, displayName, timeCreated);
+        super(capacity, id, displayName, timeCreated, isEnabled);
         this.rules = rules;
     }
 

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateAutoScalingPolicyDetails.java
@@ -31,6 +31,10 @@ package com.oracle.bmc.autoscaling.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateThresholdPolicyDetails.class,
         name = "threshold"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateScheduledPolicyDetails.class,
+        name = "scheduled"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -48,4 +52,10 @@ public class UpdateAutoScalingPolicyDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("capacity")
     Capacity capacity;
+
+    /**
+     * Boolean field indicating whether this policy is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 }

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateScheduledPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateScheduledPolicyDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.autoscaling.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateScheduledPolicyDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "policyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateScheduledPolicyDetails extends UpdateAutoScalingPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("capacity")
+        private Capacity capacity;
+
+        public Builder capacity(Capacity capacity) {
+            this.capacity = capacity;
+            this.__explicitlySet__.add("capacity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+        private ExecutionSchedule executionSchedule;
+
+        public Builder executionSchedule(ExecutionSchedule executionSchedule) {
+            this.executionSchedule = executionSchedule;
+            this.__explicitlySet__.add("executionSchedule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateScheduledPolicyDetails build() {
+            UpdateScheduledPolicyDetails __instance__ =
+                    new UpdateScheduledPolicyDetails(
+                            displayName, capacity, isEnabled, executionSchedule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateScheduledPolicyDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .capacity(o.getCapacity())
+                            .isEnabled(o.getIsEnabled())
+                            .executionSchedule(o.getExecutionSchedule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateScheduledPolicyDetails(
+            String displayName,
+            Capacity capacity,
+            Boolean isEnabled,
+            ExecutionSchedule executionSchedule) {
+        super(displayName, capacity, isEnabled);
+        this.executionSchedule = executionSchedule;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("executionSchedule")
+    ExecutionSchedule executionSchedule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateThresholdPolicyDetails.java
+++ b/bmc-autoscaling/src/main/java/com/oracle/bmc/autoscaling/model/UpdateThresholdPolicyDetails.java
@@ -49,6 +49,15 @@ public class UpdateThresholdPolicyDetails extends UpdateAutoScalingPolicyDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("rules")
         private java.util.List<UpdateConditionDetails> rules;
 
@@ -63,7 +72,7 @@ public class UpdateThresholdPolicyDetails extends UpdateAutoScalingPolicyDetails
 
         public UpdateThresholdPolicyDetails build() {
             UpdateThresholdPolicyDetails __instance__ =
-                    new UpdateThresholdPolicyDetails(displayName, capacity, rules);
+                    new UpdateThresholdPolicyDetails(displayName, capacity, isEnabled, rules);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -71,7 +80,10 @@ public class UpdateThresholdPolicyDetails extends UpdateAutoScalingPolicyDetails
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateThresholdPolicyDetails o) {
             Builder copiedBuilder =
-                    displayName(o.getDisplayName()).capacity(o.getCapacity()).rules(o.getRules());
+                    displayName(o.getDisplayName())
+                            .capacity(o.getCapacity())
+                            .isEnabled(o.getIsEnabled())
+                            .rules(o.getRules());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -87,8 +99,11 @@ public class UpdateThresholdPolicyDetails extends UpdateAutoScalingPolicyDetails
 
     @Deprecated
     public UpdateThresholdPolicyDetails(
-            String displayName, Capacity capacity, java.util.List<UpdateConditionDetails> rules) {
-        super(displayName, capacity);
+            String displayName,
+            Capacity capacity,
+            Boolean isEnabled,
+            java.util.List<UpdateConditionDetails> rules) {
+        super(displayName, capacity, isEnabled);
         this.rules = rules;
     }
 

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,300 +19,300 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
@@ -162,6 +162,15 @@ public class AutonomousContainerDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("backupConfig")
         private AutonomousContainerDatabaseBackupConfig backupConfig;
 
@@ -192,6 +201,7 @@ public class AutonomousContainerDatabase {
                             freeformTags,
                             definedTags,
                             availabilityDomain,
+                            dbVersion,
                             backupConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -216,6 +226,7 @@ public class AutonomousContainerDatabase {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .availabilityDomain(o.getAvailabilityDomain())
+                            .dbVersion(o.getDbVersion())
                             .backupConfig(o.getBackupConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -466,6 +477,12 @@ public class AutonomousContainerDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
     String availabilityDomain;
+
+    /**
+     * Oracle Database version of the Autonomous Container Database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+    String dbVersion;
 
     @com.fasterxml.jackson.annotation.JsonProperty("backupConfig")
     AutonomousContainerDatabaseBackupConfig backupConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
@@ -163,6 +163,15 @@ public class AutonomousContainerDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("backupConfig")
         private AutonomousContainerDatabaseBackupConfig backupConfig;
 
@@ -193,6 +202,7 @@ public class AutonomousContainerDatabaseSummary {
                             freeformTags,
                             definedTags,
                             availabilityDomain,
+                            dbVersion,
                             backupConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -217,6 +227,7 @@ public class AutonomousContainerDatabaseSummary {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .availabilityDomain(o.getAvailabilityDomain())
+                            .dbVersion(o.getDbVersion())
                             .backupConfig(o.getBackupConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -467,6 +478,12 @@ public class AutonomousContainerDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
     String availabilityDomain;
+
+    /**
+     * Oracle Database version of the Autonomous Container Database
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+    String dbVersion;
 
     @com.fasterxml.jackson.annotation.JsonProperty("backupConfig")
     AutonomousContainerDatabaseBackupConfig backupConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromAnotherDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromAnotherDatabaseDetails.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDatabaseFromAnotherDatabaseDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDatabaseFromAnotherDatabaseDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+        private String databaseId;
+
+        public Builder databaseId(String databaseId) {
+            this.databaseId = databaseId;
+            this.__explicitlySet__.add("databaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupTDEPassword")
+        private String backupTDEPassword;
+
+        public Builder backupTDEPassword(String backupTDEPassword) {
+            this.backupTDEPassword = backupTDEPassword;
+            this.__explicitlySet__.add("backupTDEPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+        private String adminPassword;
+
+        public Builder adminPassword(String adminPassword) {
+            this.adminPassword = adminPassword;
+            this.__explicitlySet__.add("adminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+        private String dbUniqueName;
+
+        public Builder dbUniqueName(String dbUniqueName) {
+            this.dbUniqueName = dbUniqueName;
+            this.__explicitlySet__.add("dbUniqueName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+        private String dbName;
+
+        public Builder dbName(String dbName) {
+            this.dbName = dbName;
+            this.__explicitlySet__.add("dbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStampForPointInTimeRecovery")
+        private java.util.Date timeStampForPointInTimeRecovery;
+
+        public Builder timeStampForPointInTimeRecovery(
+                java.util.Date timeStampForPointInTimeRecovery) {
+            this.timeStampForPointInTimeRecovery = timeStampForPointInTimeRecovery;
+            this.__explicitlySet__.add("timeStampForPointInTimeRecovery");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDatabaseFromAnotherDatabaseDetails build() {
+            CreateDatabaseFromAnotherDatabaseDetails __instance__ =
+                    new CreateDatabaseFromAnotherDatabaseDetails(
+                            databaseId,
+                            backupTDEPassword,
+                            adminPassword,
+                            dbUniqueName,
+                            dbName,
+                            timeStampForPointInTimeRecovery);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDatabaseFromAnotherDatabaseDetails o) {
+            Builder copiedBuilder =
+                    databaseId(o.getDatabaseId())
+                            .backupTDEPassword(o.getBackupTDEPassword())
+                            .adminPassword(o.getAdminPassword())
+                            .dbUniqueName(o.getDbUniqueName())
+                            .dbName(o.getDbName())
+                            .timeStampForPointInTimeRecovery(
+                                    o.getTimeStampForPointInTimeRecovery());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
+    String databaseId;
+
+    /**
+     * The password to open the TDE wallet.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupTDEPassword")
+    String backupTDEPassword;
+
+    /**
+     * A strong password for SYS, SYSTEM, PDB Admin and TDE Wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+    String adminPassword;
+
+    /**
+     * The `DB_UNIQUE_NAME` of the Oracle Database being backed up.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbUniqueName")
+    String dbUniqueName;
+
+    /**
+     * The display name of the database to be created from the backup. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+    String dbName;
+
+    /**
+     * The point in time of the original database from which the new database is created. If not specifed, the latest backup is used to create the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStampForPointInTimeRecovery")
+    java.util.Date timeStampForPointInTimeRecovery;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeBase.java
@@ -32,6 +32,10 @@ package com.oracle.bmc.database.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbHomeWithDbSystemIdFromDatabaseDetails.class,
+        name = "DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateDbHomeWithDbSystemIdFromBackupDetails.class,
         name = "DB_BACKUP"
     ),
@@ -60,6 +64,7 @@ public class CreateDbHomeBase {
     public enum Source {
         None("NONE"),
         DbBackup("DB_BACKUP"),
+        Database("DATABASE"),
         VmClusterNew("VM_CLUSTER_NEW"),
         ;
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeFromDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeFromDatabaseDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for creating a Database Home if you are creating a database by restoring from a database backup.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbHomeFromDatabaseDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeFromDatabaseDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseFromAnotherDatabaseDetails database;
+
+        public Builder database(CreateDatabaseFromAnotherDatabaseDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbHomeFromDatabaseDetails build() {
+            CreateDbHomeFromDatabaseDetails __instance__ =
+                    new CreateDbHomeFromDatabaseDetails(displayName, database);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbHomeFromDatabaseDetails o) {
+            Builder copiedBuilder = displayName(o.getDisplayName()).database(o.getDatabase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The user-provided name of the Database Home.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("database")
+    CreateDatabaseFromAnotherDatabaseDetails database;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeWithDbSystemIdFromDatabaseDetails.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Note that a valid `dbSystemId` value must be supplied for the `CreateDbHomeWithDbSystemIdFromDatabase` API operation to successfully complete.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbHomeWithDbSystemIdFromDatabaseDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateDbHomeWithDbSystemIdFromDatabaseDetails extends CreateDbHomeBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("database")
+        private CreateDatabaseFromAnotherDatabaseDetails database;
+
+        public Builder database(CreateDatabaseFromAnotherDatabaseDetails database) {
+            this.database = database;
+            this.__explicitlySet__.add("database");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbHomeWithDbSystemIdFromDatabaseDetails build() {
+            CreateDbHomeWithDbSystemIdFromDatabaseDetails __instance__ =
+                    new CreateDbHomeWithDbSystemIdFromDatabaseDetails(
+                            displayName, dbSystemId, database);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbHomeWithDbSystemIdFromDatabaseDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .dbSystemId(o.getDbSystemId())
+                            .database(o.getDatabase());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDbHomeWithDbSystemIdFromDatabaseDetails(
+            String displayName,
+            String dbSystemId,
+            CreateDatabaseFromAnotherDatabaseDetails database) {
+        super(displayName);
+        this.dbSystemId = dbSystemId;
+        this.database = database;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB system.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("database")
+    CreateDatabaseFromAnotherDatabaseDetails database;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
@@ -149,6 +149,15 @@ public class Database {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lastBackupTimestamp")
+        private java.util.Date lastBackupTimestamp;
+
+        public Builder lastBackupTimestamp(java.util.Date lastBackupTimestamp) {
+            this.lastBackupTimestamp = lastBackupTimestamp;
+            this.__explicitlySet__.add("lastBackupTimestamp");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbBackupConfig")
         private DbBackupConfig dbBackupConfig;
 
@@ -206,6 +215,7 @@ public class Database {
                             lifecycleDetails,
                             lifecycleState,
                             timeCreated,
+                            lastBackupTimestamp,
                             dbBackupConfig,
                             freeformTags,
                             definedTags,
@@ -231,6 +241,7 @@ public class Database {
                             .lifecycleDetails(o.getLifecycleDetails())
                             .lifecycleState(o.getLifecycleState())
                             .timeCreated(o.getTimeCreated())
+                            .lastBackupTimestamp(o.getLastBackupTimestamp())
                             .dbBackupConfig(o.getDbBackupConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -383,6 +394,12 @@ public class Database {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * The date and time when the latest database backup was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastBackupTimestamp")
+    java.util.Date lastBackupTimestamp;
 
     @com.fasterxml.jackson.annotation.JsonProperty("dbBackupConfig")
     DbBackupConfig dbBackupConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
@@ -154,6 +154,15 @@ public class DatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lastBackupTimestamp")
+        private java.util.Date lastBackupTimestamp;
+
+        public Builder lastBackupTimestamp(java.util.Date lastBackupTimestamp) {
+            this.lastBackupTimestamp = lastBackupTimestamp;
+            this.__explicitlySet__.add("lastBackupTimestamp");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbBackupConfig")
         private DbBackupConfig dbBackupConfig;
 
@@ -211,6 +220,7 @@ public class DatabaseSummary {
                             lifecycleDetails,
                             lifecycleState,
                             timeCreated,
+                            lastBackupTimestamp,
                             dbBackupConfig,
                             freeformTags,
                             definedTags,
@@ -236,6 +246,7 @@ public class DatabaseSummary {
                             .lifecycleDetails(o.getLifecycleDetails())
                             .lifecycleState(o.getLifecycleState())
                             .timeCreated(o.getTimeCreated())
+                            .lastBackupTimestamp(o.getLastBackupTimestamp())
                             .dbBackupConfig(o.getDbBackupConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -388,6 +399,12 @@ public class DatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * The date and time when the latest database backup was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastBackupTimestamp")
+    java.util.Date lastBackupTimestamp;
 
     @com.fasterxml.jackson.annotation.JsonProperty("dbBackupConfig")
     DbBackupConfig dbBackupConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemBase.java
@@ -36,6 +36,10 @@ package com.oracle.bmc.database.model;
         name = "NONE"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = LaunchDbSystemFromDatabaseDetails.class,
+        name = "DATABASE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = LaunchDbSystemFromBackupDetails.class,
         name = "DB_BACKUP"
     )
@@ -249,12 +253,14 @@ public class LaunchDbSystemBase {
 
     /**
      * The source of the database:
-     * Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. The default is `NONE`.
+     * Use `NONE` for creating a new database. Use `DB_BACKUP` for creating a new database by restoring from a backup. Use `DATABASE` for creating
+     * a new database from an existing database, including archive redo log data. The default is `NONE`.
      *
      **/
     public enum Source {
         None("NONE"),
         DbBackup("DB_BACKUP"),
+        Database("DATABASE"),
         ;
 
         private final String value;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/LaunchDbSystemFromDatabaseDetails.java
@@ -1,0 +1,544 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Used for creating a new DB system from a database, including archived redo log data.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LaunchDbSystemFromDatabaseDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "source"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class LaunchDbSystemFromDatabaseDetails extends LaunchDbSystemBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("faultDomains")
+        private java.util.List<String> faultDomains;
+
+        public Builder faultDomains(java.util.List<String> faultDomains) {
+            this.faultDomains = faultDomains;
+            this.__explicitlySet__.add("faultDomains");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupSubnetId")
+        private String backupSubnetId;
+
+        public Builder backupSubnetId(String backupSubnetId) {
+            this.backupSubnetId = backupSubnetId;
+            this.__explicitlySet__.add("backupSubnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupNetworkNsgIds")
+        private java.util.List<String> backupNetworkNsgIds;
+
+        public Builder backupNetworkNsgIds(java.util.List<String> backupNetworkNsgIds) {
+            this.backupNetworkNsgIds = backupNetworkNsgIds;
+            this.__explicitlySet__.add("backupNetworkNsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
+        private String timeZone;
+
+        public Builder timeZone(String timeZone) {
+            this.timeZone = timeZone;
+            this.__explicitlySet__.add("timeZone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemOptions")
+        private DbSystemOptions dbSystemOptions;
+
+        public Builder dbSystemOptions(DbSystemOptions dbSystemOptions) {
+            this.dbSystemOptions = dbSystemOptions;
+            this.__explicitlySet__.add("dbSystemOptions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sparseDiskgroup")
+        private Boolean sparseDiskgroup;
+
+        public Builder sparseDiskgroup(Boolean sparseDiskgroup) {
+            this.sparseDiskgroup = sparseDiskgroup;
+            this.__explicitlySet__.add("sparseDiskgroup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKeys")
+        private java.util.List<String> sshPublicKeys;
+
+        public Builder sshPublicKeys(java.util.List<String> sshPublicKeys) {
+            this.sshPublicKeys = sshPublicKeys;
+            this.__explicitlySet__.add("sshPublicKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("domain")
+        private String domain;
+
+        public Builder domain(String domain) {
+            this.domain = domain;
+            this.__explicitlySet__.add("domain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterName")
+        private String clusterName;
+
+        public Builder clusterName(String clusterName) {
+            this.clusterName = clusterName;
+            this.__explicitlySet__.add("clusterName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStoragePercentage")
+        private Integer dataStoragePercentage;
+
+        public Builder dataStoragePercentage(Integer dataStoragePercentage) {
+            this.dataStoragePercentage = dataStoragePercentage;
+            this.__explicitlySet__.add("dataStoragePercentage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("initialDataStorageSizeInGB")
+        private Integer initialDataStorageSizeInGB;
+
+        public Builder initialDataStorageSizeInGB(Integer initialDataStorageSizeInGB) {
+            this.initialDataStorageSizeInGB = initialDataStorageSizeInGB;
+            this.__explicitlySet__.add("initialDataStorageSizeInGB");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+        private Integer nodeCount;
+
+        public Builder nodeCount(Integer nodeCount) {
+            this.nodeCount = nodeCount;
+            this.__explicitlySet__.add("nodeCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbHome")
+        private CreateDbHomeFromDatabaseDetails dbHome;
+
+        public Builder dbHome(CreateDbHomeFromDatabaseDetails dbHome) {
+            this.dbHome = dbHome;
+            this.__explicitlySet__.add("dbHome");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseEdition")
+        private DatabaseEdition databaseEdition;
+
+        public Builder databaseEdition(DatabaseEdition databaseEdition) {
+            this.databaseEdition = databaseEdition;
+            this.__explicitlySet__.add("databaseEdition");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("diskRedundancy")
+        private DiskRedundancy diskRedundancy;
+
+        public Builder diskRedundancy(DiskRedundancy diskRedundancy) {
+            this.diskRedundancy = diskRedundancy;
+            this.__explicitlySet__.add("diskRedundancy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+        private LicenseModel licenseModel;
+
+        public Builder licenseModel(LicenseModel licenseModel) {
+            this.licenseModel = licenseModel;
+            this.__explicitlySet__.add("licenseModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LaunchDbSystemFromDatabaseDetails build() {
+            LaunchDbSystemFromDatabaseDetails __instance__ =
+                    new LaunchDbSystemFromDatabaseDetails(
+                            compartmentId,
+                            faultDomains,
+                            displayName,
+                            availabilityDomain,
+                            subnetId,
+                            backupSubnetId,
+                            nsgIds,
+                            backupNetworkNsgIds,
+                            shape,
+                            timeZone,
+                            dbSystemOptions,
+                            sparseDiskgroup,
+                            sshPublicKeys,
+                            hostname,
+                            domain,
+                            cpuCoreCount,
+                            clusterName,
+                            dataStoragePercentage,
+                            initialDataStorageSizeInGB,
+                            nodeCount,
+                            freeformTags,
+                            definedTags,
+                            dbHome,
+                            databaseEdition,
+                            diskRedundancy,
+                            licenseModel);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LaunchDbSystemFromDatabaseDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .faultDomains(o.getFaultDomains())
+                            .displayName(o.getDisplayName())
+                            .availabilityDomain(o.getAvailabilityDomain())
+                            .subnetId(o.getSubnetId())
+                            .backupSubnetId(o.getBackupSubnetId())
+                            .nsgIds(o.getNsgIds())
+                            .backupNetworkNsgIds(o.getBackupNetworkNsgIds())
+                            .shape(o.getShape())
+                            .timeZone(o.getTimeZone())
+                            .dbSystemOptions(o.getDbSystemOptions())
+                            .sparseDiskgroup(o.getSparseDiskgroup())
+                            .sshPublicKeys(o.getSshPublicKeys())
+                            .hostname(o.getHostname())
+                            .domain(o.getDomain())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .clusterName(o.getClusterName())
+                            .dataStoragePercentage(o.getDataStoragePercentage())
+                            .initialDataStorageSizeInGB(o.getInitialDataStorageSizeInGB())
+                            .nodeCount(o.getNodeCount())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .dbHome(o.getDbHome())
+                            .databaseEdition(o.getDatabaseEdition())
+                            .diskRedundancy(o.getDiskRedundancy())
+                            .licenseModel(o.getLicenseModel());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public LaunchDbSystemFromDatabaseDetails(
+            String compartmentId,
+            java.util.List<String> faultDomains,
+            String displayName,
+            String availabilityDomain,
+            String subnetId,
+            String backupSubnetId,
+            java.util.List<String> nsgIds,
+            java.util.List<String> backupNetworkNsgIds,
+            String shape,
+            String timeZone,
+            DbSystemOptions dbSystemOptions,
+            Boolean sparseDiskgroup,
+            java.util.List<String> sshPublicKeys,
+            String hostname,
+            String domain,
+            Integer cpuCoreCount,
+            String clusterName,
+            Integer dataStoragePercentage,
+            Integer initialDataStorageSizeInGB,
+            Integer nodeCount,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            CreateDbHomeFromDatabaseDetails dbHome,
+            DatabaseEdition databaseEdition,
+            DiskRedundancy diskRedundancy,
+            LicenseModel licenseModel) {
+        super(
+                compartmentId,
+                faultDomains,
+                displayName,
+                availabilityDomain,
+                subnetId,
+                backupSubnetId,
+                nsgIds,
+                backupNetworkNsgIds,
+                shape,
+                timeZone,
+                dbSystemOptions,
+                sparseDiskgroup,
+                sshPublicKeys,
+                hostname,
+                domain,
+                cpuCoreCount,
+                clusterName,
+                dataStoragePercentage,
+                initialDataStorageSizeInGB,
+                nodeCount,
+                freeformTags,
+                definedTags);
+        this.dbHome = dbHome;
+        this.databaseEdition = databaseEdition;
+        this.diskRedundancy = diskRedundancy;
+        this.licenseModel = licenseModel;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("dbHome")
+    CreateDbHomeFromDatabaseDetails dbHome;
+    /**
+     * The Oracle Database Edition that applies to all the databases on the DB system.
+     * Exadata DB systems and 2-node RAC DB systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.
+     *
+     **/
+    public enum DatabaseEdition {
+        StandardEdition("STANDARD_EDITION"),
+        EnterpriseEdition("ENTERPRISE_EDITION"),
+        EnterpriseEditionHighPerformance("ENTERPRISE_EDITION_HIGH_PERFORMANCE"),
+        EnterpriseEditionExtremePerformance("ENTERPRISE_EDITION_EXTREME_PERFORMANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DatabaseEdition> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseEdition v : DatabaseEdition.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DatabaseEdition(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseEdition create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid DatabaseEdition: " + key);
+        }
+    };
+    /**
+     * The Oracle Database Edition that applies to all the databases on the DB system.
+     * Exadata DB systems and 2-node RAC DB systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseEdition")
+    DatabaseEdition databaseEdition;
+    /**
+     * The type of redundancy configured for the DB system.
+     * NORMAL 2-way redundancy, recommended for test and development systems.
+     * HIGH is 3-way redundancy, recommended for production systems.
+     *
+     **/
+    public enum DiskRedundancy {
+        High("HIGH"),
+        Normal("NORMAL"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DiskRedundancy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DiskRedundancy v : DiskRedundancy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DiskRedundancy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DiskRedundancy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid DiskRedundancy: " + key);
+        }
+    };
+    /**
+     * The type of redundancy configured for the DB system.
+     * NORMAL 2-way redundancy, recommended for test and development systems.
+     * HIGH is 3-way redundancy, recommended for production systems.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("diskRedundancy")
+    DiskRedundancy diskRedundancy;
+    /**
+     * The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
+     *
+     **/
+    public enum LicenseModel {
+        LicenseIncluded("LICENSE_INCLUDED"),
+        BringYourOwnLicense("BRING_YOUR_OWN_LICENSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LicenseModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LicenseModel v : LicenseModel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LicenseModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LicenseModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid LicenseModel: " + key);
+        }
+    };
+    /**
+     * The Oracle license model that applies to all the databases on the DB system. The default is LICENSE_INCLUDED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
+    LicenseModel licenseModel;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJob.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface ApplianceExportJob extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface ApplianceExportJobAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ApplianceExportJobAsyncClient implements ApplianceExportJobAsync {
     /**
@@ -32,7 +32,8 @@ public class ApplianceExportJobAsyncClient implements ApplianceExportJobAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("APPLIANCEEXPORTJOB")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ApplianceExportJobClient implements ApplianceExportJob {
     /**
@@ -19,7 +19,8 @@ public class ApplianceExportJobClient implements ApplianceExportJob {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("APPLIANCEEXPORTJOB")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobPaginators.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobPaginators.java
@@ -25,7 +25,7 @@ import com.oracle.bmc.dts.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class ApplianceExportJobPaginators {
     private final ApplianceExportJob client;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ApplianceExportJobWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class ApplianceExportJobWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendors.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface ShippingVendors extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface ShippingVendorsAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ShippingVendorsAsyncClient implements ShippingVendorsAsync {
     /**
@@ -32,7 +32,8 @@ public class ShippingVendorsAsyncClient implements ShippingVendorsAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("SHIPPINGVENDORS")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/ShippingVendorsClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ShippingVendorsClient implements ShippingVendors {
     /**
@@ -19,7 +19,8 @@ public class ShippingVendorsClient implements ShippingVendors {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("SHIPPINGVENDORS")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferAppliance.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferAppliance extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferApplianceAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceAsyncClient implements TransferApplianceAsync {
     /**
@@ -32,7 +32,8 @@ public class TransferApplianceAsyncClient implements TransferApplianceAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERAPPLIANCE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceClient implements TransferAppliance {
     /**
@@ -19,7 +19,8 @@ public class TransferApplianceClient implements TransferAppliance {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERAPPLIANCE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlement.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferApplianceEntitlement extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferApplianceEntitlementAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceEntitlementAsyncClient implements TransferApplianceEntitlementAsync {
     /**
@@ -32,7 +32,8 @@ public class TransferApplianceEntitlementAsyncClient implements TransferApplianc
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERAPPLIANCEENTITLEMENT")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferApplianceEntitlementClient implements TransferApplianceEntitlement {
     /**
@@ -19,7 +19,8 @@ public class TransferApplianceEntitlementClient implements TransferApplianceEnti
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERAPPLIANCEENTITLEMENT")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceEntitlementWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferApplianceEntitlementWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferApplianceWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferApplianceWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDevice.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferDevice extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferDeviceAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferDeviceAsyncClient implements TransferDeviceAsync {
     /**
@@ -32,7 +32,8 @@ public class TransferDeviceAsyncClient implements TransferDeviceAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERDEVICE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferDeviceClient implements TransferDevice {
     /**
@@ -19,7 +19,8 @@ public class TransferDeviceClient implements TransferDevice {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERDEVICE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferDeviceWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferDeviceWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJob.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferJob extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferJobAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferJobAsyncClient implements TransferJobAsync {
     /**
@@ -32,7 +32,8 @@ public class TransferJobAsyncClient implements TransferJobAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERJOB")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferJobClient implements TransferJob {
     /**
@@ -19,7 +19,8 @@ public class TransferJobClient implements TransferJob {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERJOB")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobPaginators.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobPaginators.java
@@ -25,7 +25,7 @@ import com.oracle.bmc.dts.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferJobPaginators {
     private final TransferJob client;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferJobWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferJobWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackage.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferPackage extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsync.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.dts;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 public interface TransferPackageAsync extends AutoCloseable {
 
     /**

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageAsyncClient.java
@@ -22,7 +22,7 @@ import com.oracle.bmc.dts.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferPackageAsyncClient implements TransferPackageAsync {
     /**
@@ -32,7 +32,8 @@ public class TransferPackageAsyncClient implements TransferPackageAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERPACKAGE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageClient.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.dts.internal.http.*;
 import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class TransferPackageClient implements TransferPackage {
     /**
@@ -19,7 +19,8 @@ public class TransferPackageClient implements TransferPackage {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("TRANSFERPACKAGE")
                     .serviceEndpointPrefix("")
-                    .serviceEndpointTemplate("https://datatransfer.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate(
+                            "https://datatransfer.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/TransferPackageWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.dts.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.RequiredArgsConstructor
 public class TransferPackageWaiters {
     private final java.util.concurrent.ExecutorService executorService;

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/AttachDevicesToTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class AttachDevicesToTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeApplianceExportJobCompartmentConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeApplianceExportJobCompartmentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ChangeApplianceExportJobCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ChangeTransferJobCompartmentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ChangeTransferJobCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateApplianceExportJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateApplianceExportJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateApplianceExportJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceAdminCredentialsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceAdminCredentialsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferApplianceEntitlementConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferApplianceEntitlementConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferDeviceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/CreateTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class CreateTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteApplianceExportJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteApplianceExportJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DeleteApplianceExportJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferApplianceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferDeviceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DeleteTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DeleteTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/DetachDevicesFromTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class DetachDevicesFromTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetApplianceExportJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetApplianceExportJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetApplianceExportJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceCertificateAuthorityCertificateConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceCertificateAuthorityCertificateConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEncryptionPassphraseConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceEncryptionPassphraseConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferApplianceEntitlementConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferApplianceEntitlementConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferDeviceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/GetTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class GetTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListApplianceExportJobsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListApplianceExportJobsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListApplianceExportJobsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListShippingVendorsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListShippingVendorsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferApplianceEntitlementConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferApplianceEntitlementConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferApplianceEntitlementConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferAppliancesConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferAppliancesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferDevicesConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferDevicesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferJobsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferJobsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/ListTransferPackagesConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class ListTransferPackagesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateApplianceExportJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateApplianceExportJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class UpdateApplianceExportJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferApplianceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferApplianceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferDeviceConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferDeviceConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/internal/http/UpdateTransferPackageConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.dts.requests.*;
 import com.oracle.bmc.dts.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.extern.slf4j.Slf4j
 public class UpdateTransferPackageConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ApplianceExportJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ApplianceExportJob.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ApplianceExportJobSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ApplianceExportJobSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/AttachDevicesDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeApplianceExportJobCompartmentDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeApplianceExportJobCompartmentDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ChangeTransferJobCompartmentDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateApplianceExportJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateApplianceExportJobDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferApplianceEntitlementDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferDeviceDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferJobDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/CreateTransferPackageDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/DetachDevicesDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferAppliances.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferDevices.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/MultipleTransferPackages.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/NewTransferDevice.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingAddress.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingAddress.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/ShippingVendors.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ShippingVendors.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliance.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceCertificate.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEncryptionPassphrase.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlement.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlementSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceEntitlementSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferAppliancePublicKey.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferApplianceSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDevice.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferDevice.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferDeviceSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJob.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferJob.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferJobSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackage.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TransferPackage.Builder.class)

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/TransferPackageSummary.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateApplianceExportJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateApplianceExportJobDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferApplianceDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferDeviceDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferJobDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/model/UpdateTransferPackageDetails.java
@@ -14,7 +14,7 @@ package com.oracle.bmc.dts.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/AttachDevicesToTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class AttachDevicesToTransferPackageRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeApplianceExportJobCompartmentRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeApplianceExportJobCompartmentRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ChangeApplianceExportJobCompartmentRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ChangeTransferJobCompartmentRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ChangeTransferJobCompartmentRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateApplianceExportJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateApplianceExportJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateApplianceExportJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceAdminCredentialsRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceAdminCredentialsRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceEntitlementRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceEntitlementRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferApplianceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferApplianceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferDeviceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferDeviceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/CreateTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class CreateTransferPackageRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteApplianceExportJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteApplianceExportJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteApplianceExportJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferApplianceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferApplianceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferDeviceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferDeviceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferJobRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DeleteTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeleteTransferPackageRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/DetachDevicesFromTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DetachDevicesFromTransferPackageRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetApplianceExportJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetApplianceExportJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetApplianceExportJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceCertificateAuthorityCertificateRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceCertificateAuthorityCertificateRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEncryptionPassphraseRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceEncryptionPassphraseRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceEntitlementRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceEntitlementRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferApplianceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferApplianceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferDeviceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferDeviceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferJobRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/GetTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class GetTransferPackageRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListApplianceExportJobsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListApplianceExportJobsRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListApplianceExportJobsRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListShippingVendorsRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListShippingVendorsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferApplianceEntitlementRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferApplianceEntitlementRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferApplianceEntitlementRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferAppliancesRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferAppliancesRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferDevicesRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferDevicesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferJobsRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/ListTransferPackagesRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class ListTransferPackagesRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateApplianceExportJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateApplianceExportJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateApplianceExportJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferApplianceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferApplianceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferDeviceRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferDeviceRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferJobRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferJobRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/requests/UpdateTransferPackageRequest.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.requests;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class UpdateTransferPackageRequest

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/AttachDevicesToTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class AttachDevicesToTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeApplianceExportJobCompartmentResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeApplianceExportJobCompartmentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ChangeApplianceExportJobCompartmentResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ChangeTransferJobCompartmentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ChangeTransferJobCompartmentResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateApplianceExportJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateApplianceExportJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateApplianceExportJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceAdminCredentialsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceAdminCredentialsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceEntitlementResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceEntitlementResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferApplianceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferDeviceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/CreateTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class CreateTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteApplianceExportJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteApplianceExportJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteApplianceExportJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferApplianceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferDeviceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DeleteTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DeleteTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/DetachDevicesFromTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class DetachDevicesFromTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetApplianceExportJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetApplianceExportJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetApplianceExportJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceCertificateAuthorityCertificateResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceCertificateAuthorityCertificateResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEncryptionPassphraseResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceEncryptionPassphraseResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceEntitlementResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceEntitlementResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferApplianceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferDeviceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/GetTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class GetTransferPackageResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListApplianceExportJobsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListApplianceExportJobsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListApplianceExportJobsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListShippingVendorsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListShippingVendorsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferApplianceEntitlementResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferApplianceEntitlementResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferApplianceEntitlementResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferAppliancesResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferAppliancesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferDevicesResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferDevicesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferJobsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferJobsResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/ListTransferPackagesResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class ListTransferPackagesResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateApplianceExportJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateApplianceExportJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateApplianceExportJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferApplianceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferApplianceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferDeviceResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferDeviceResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferJobResponse {

--- a/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
+++ b/bmc-dts/src/main/java/com/oracle/bmc/dts/responses/UpdateTransferPackageResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.dts.responses;
 
 import com.oracle.bmc.dts.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.014")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 1.0.015")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.Getter
 public class UpdateTransferPackageResponse {

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/FastConnectCrossConnectGroupExample.java
+++ b/bmc-examples/src/main/java/FastConnectCrossConnectGroupExample.java
@@ -128,7 +128,8 @@ public class FastConnectCrossConnectGroupExample {
 
             System.out.println("Change the CrossConnectGroup compartment.");
             changeCrossConnectGroupCompartment(
-                    virtualNetworkClient, cc.getId(), NEW_COMPARTMENT_ID);
+                    virtualNetworkClient, ccg.getId(), cc.getId(), NEW_COMPARTMENT_ID);
+
         } finally {
             System.out.println("Remove physical connection from LAG.");
             if (null != cc) {
@@ -346,7 +347,11 @@ public class FastConnectCrossConnectGroupExample {
      * Change Compartment
      */
     private static void changeCrossConnectGroupCompartment(
-            final VirtualNetwork virtualNetwork, final String ccgId, final String newCompartment) {
+            final VirtualNetwork virtualNetwork,
+            final String ccgId,
+            final String ccId,
+            final String newCompartment)
+            throws Exception {
         final ChangeCrossConnectGroupCompartmentRequest request =
                 ChangeCrossConnectGroupCompartmentRequest.builder()
                         .crossConnectGroupId(ccgId)
@@ -357,5 +362,19 @@ public class FastConnectCrossConnectGroupExample {
                         .build();
 
         virtualNetwork.changeCrossConnectGroupCompartment(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnect(
+                        GetCrossConnectRequest.builder().crossConnectId(ccId).build(),
+                        CrossConnect.LifecycleState.Provisioned)
+                .execute();
+
+        virtualNetwork
+                .getWaiters()
+                .forCrossConnectGroup(
+                        GetCrossConnectGroupRequest.builder().crossConnectGroupId(ccgId).build(),
+                        CrossConnectGroup.LifecycleState.Provisioned)
+                .execute();
     }
 }

--- a/bmc-examples/src/main/java/VpnIPSecConnectionExample.java
+++ b/bmc-examples/src/main/java/VpnIPSecConnectionExample.java
@@ -7,42 +7,54 @@ import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.core.VirtualNetwork;
 import com.oracle.bmc.core.VirtualNetworkClient;
+import com.oracle.bmc.core.model.ChangeIPSecConnectionCompartmentDetails;
 import com.oracle.bmc.core.model.Cpe;
+import com.oracle.bmc.core.model.CpeDeviceConfigAnswer;
 import com.oracle.bmc.core.model.CreateCpeDetails;
-import com.oracle.bmc.core.model.Drg;
 import com.oracle.bmc.core.model.CreateDrgDetails;
-import com.oracle.bmc.core.requests.CreateCpeRequest;
-import com.oracle.bmc.core.requests.DeleteCpeRequest;
-import com.oracle.bmc.core.requests.CreateDrgRequest;
-import com.oracle.bmc.core.requests.DeleteDrgRequest;
-import com.oracle.bmc.core.requests.GetDrgRequest;
+import com.oracle.bmc.core.model.CreateIPSecConnectionDetails;
+import com.oracle.bmc.core.model.Drg;
 import com.oracle.bmc.core.model.IPSecConnection;
+import com.oracle.bmc.core.model.IPSecConnectionDeviceConfig;
 import com.oracle.bmc.core.model.IPSecConnectionTunnel;
 import com.oracle.bmc.core.model.IPSecConnectionTunnelSharedSecret;
-import com.oracle.bmc.core.model.CreateIPSecConnectionDetails;
+import com.oracle.bmc.core.model.TunnelCpeDeviceConfig;
 import com.oracle.bmc.core.model.UpdateIPSecConnectionDetails;
 import com.oracle.bmc.core.model.UpdateIPSecConnectionTunnelDetails;
 import com.oracle.bmc.core.model.UpdateIPSecConnectionTunnelSharedSecretDetails;
-import com.oracle.bmc.core.model.ChangeIPSecConnectionCompartmentDetails;
+import com.oracle.bmc.core.model.UpdateTunnelCpeDeviceConfigDetails;
+import com.oracle.bmc.core.requests.ChangeIPSecConnectionCompartmentRequest;
+import com.oracle.bmc.core.requests.CreateCpeRequest;
+import com.oracle.bmc.core.requests.CreateDrgRequest;
 import com.oracle.bmc.core.requests.CreateIPSecConnectionRequest;
-import com.oracle.bmc.core.requests.UpdateIPSecConnectionRequest;
+import com.oracle.bmc.core.requests.DeleteCpeRequest;
+import com.oracle.bmc.core.requests.DeleteDrgRequest;
 import com.oracle.bmc.core.requests.DeleteIPSecConnectionRequest;
+import com.oracle.bmc.core.requests.GetDrgRequest;
+import com.oracle.bmc.core.requests.GetIPSecConnectionDeviceConfigRequest;
 import com.oracle.bmc.core.requests.GetIPSecConnectionRequest;
 import com.oracle.bmc.core.requests.GetIPSecConnectionTunnelRequest;
 import com.oracle.bmc.core.requests.GetIPSecConnectionTunnelSharedSecretRequest;
+import com.oracle.bmc.core.requests.GetTunnelCpeDeviceConfigRequest;
+import com.oracle.bmc.core.requests.ListIPSecConnectionTunnelsRequest;
+import com.oracle.bmc.core.requests.UpdateIPSecConnectionRequest;
 import com.oracle.bmc.core.requests.UpdateIPSecConnectionTunnelRequest;
 import com.oracle.bmc.core.requests.UpdateIPSecConnectionTunnelSharedSecretRequest;
-import com.oracle.bmc.core.requests.ChangeIPSecConnectionCompartmentRequest;
+import com.oracle.bmc.core.requests.UpdateTunnelCpeDeviceConfigRequest;
 import com.oracle.bmc.core.responses.CreateCpeResponse;
 import com.oracle.bmc.core.responses.CreateDrgResponse;
 import com.oracle.bmc.core.responses.CreateIPSecConnectionResponse;
-import com.oracle.bmc.core.responses.UpdateIPSecConnectionResponse;
+import com.oracle.bmc.core.responses.GetIPSecConnectionDeviceConfigResponse;
 import com.oracle.bmc.core.responses.GetIPSecConnectionResponse;
-import com.oracle.bmc.core.responses.GetIPSecConnectionTunnelResponse;
 import com.oracle.bmc.core.responses.GetIPSecConnectionTunnelSharedSecretResponse;
+import com.oracle.bmc.core.responses.GetTunnelCpeDeviceConfigResponse;
+import com.oracle.bmc.core.responses.ListIPSecConnectionTunnelsResponse;
+import com.oracle.bmc.core.responses.UpdateIPSecConnectionResponse;
 import com.oracle.bmc.core.responses.UpdateIPSecConnectionTunnelResponse;
 import com.oracle.bmc.core.responses.UpdateIPSecConnectionTunnelSharedSecretResponse;
+import com.oracle.bmc.core.responses.UpdateTunnelCpeDeviceConfigResponse;
 import com.oracle.bmc.identity.IdentityClient;
+import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,6 +116,8 @@ public class VpnIPSecConnectionExample {
         IPSecConnection ipsec = null;
         IPSecConnectionTunnel tunnel = null;
         IPSecConnectionTunnelSharedSecret sharedsecret = null;
+        IPSecConnectionDeviceConfig ipsecDeviceConfig = null;
+        TunnelCpeDeviceConfig tunnelCpeDeviceConfig = null;
         try {
             System.out.println("Create Cpe.");
             cpe = createCpe(virtualNetworkClient, region);
@@ -117,26 +131,44 @@ public class VpnIPSecConnectionExample {
             System.out.println("Activate the IPSecConnection.");
             ipsec = updateIPSecConnection(virtualNetworkClient, ipsec.getId());
 
+            System.out.println("Get the IPSecConnectionDeviceConfig of current IPSecConnection");
+
+            ipsecDeviceConfig = getIPSecConnectionDeviceConfig(virtualNetworkClient, ipsec.getId());
+            System.out.println(ipsecDeviceConfig);
+
             System.out.println("Change IPSecConnection compartment.");
             changeIPSecCompartment(virtualNetworkClient, ipsec.getId(), NEW_COMPARTMENT_ID);
 
             System.out.println("Get tunnel for the IPSecConnection.");
             tunnel = getIPSecConnectionTunnel(virtualNetworkClient, ipsec.getId());
 
-            System.out.println("update tunnel for the IPSecConnection.");
-            tunnel = updateIPSecConnectionTunnel(virtualNetworkClient, tunnel.getId());
+            System.out.println("Update TunnelCpeDeviceConfig");
+            tunnelCpeDeviceConfig =
+                    updateTunnelCpeDeviceConfig(
+                            virtualNetworkClient, ipsec.getId(), tunnel.getId());
+            System.out.println(tunnelCpeDeviceConfig);
 
-            System.out.println("get Shared Secret for tunnel.");
+            System.out.println("Get the TunnelCpeDeviceConfig of current tunnel");
+            tunnelCpeDeviceConfig =
+                    getTunnelCpeDeviceConfig(virtualNetworkClient, ipsec.getId(), tunnel.getId());
+            System.out.println(tunnelCpeDeviceConfig);
+
+            System.out.println("Update tunnel for the IPSecConnection.");
+            tunnel =
+                    updateIPSecConnectionTunnel(
+                            virtualNetworkClient, ipsec.getId(), tunnel.getId());
+
+            System.out.println("Get Shared Secret for tunnel.");
             sharedsecret =
                     getIPSecConnectionTunnelSharedSecret(
                             virtualNetworkClient, ipsec.getId(), tunnel.getId());
             System.out.println(sharedsecret);
 
-            System.out.println("update tunnel for the IPSecConnection.");
+            System.out.println("Update tunnel for the IPSecConnection.");
             updateIPSecConnectionTunnelSharedSecret(
                     virtualNetworkClient, ipsec.getId(), tunnel.getId());
 
-            System.out.println("get Shared Secret for tunnel again.");
+            System.out.println("Get Shared Secret for tunnel again.");
             sharedsecret =
                     getIPSecConnectionTunnelSharedSecret(
                             virtualNetworkClient, ipsec.getId(), tunnel.getId());
@@ -158,6 +190,9 @@ public class VpnIPSecConnectionExample {
         }
     }
 
+    /*
+     * Use CREATE to create a CPE
+     */
     public static Cpe createCpe(final VirtualNetwork virtualNetwork, final Region region) {
         final CreateCpeRequest request =
                 CreateCpeRequest.builder()
@@ -180,6 +215,9 @@ public class VpnIPSecConnectionExample {
         return response.getCpe();
     }
 
+    /*
+     * Use DELETE to delete the CPE
+     */
     public static void deleteCpe(final VirtualNetwork virtualNetwork, final Cpe cpe)
             throws Exception {
         final DeleteCpeRequest request = DeleteCpeRequest.builder().cpeId(cpe.getId()).build();
@@ -188,6 +226,9 @@ public class VpnIPSecConnectionExample {
         System.out.println("Deleted Cpe: " + cpe.getId());
     }
 
+    /*
+     * Use CREATE to create a DRG connection and activate connection
+     */
     public static Drg createDrg(final VirtualNetwork virtualNetwork, final Region region)
             throws Exception {
         final CreateDrgRequest request =
@@ -217,6 +258,9 @@ public class VpnIPSecConnectionExample {
         return response.getDrg();
     }
 
+    /*
+     * Use DELETE to delete the DRG
+     */
     public static void deleteDrg(final VirtualNetwork virtualNetwork, final Drg drg)
             throws Exception {
         final DeleteDrgRequest request = DeleteDrgRequest.builder().drgId(drg.getId()).build();
@@ -231,6 +275,9 @@ public class VpnIPSecConnectionExample {
         System.out.println("Deleted DRG: " + drg.getId());
     }
 
+    /*
+     * Use CREATE to create a IPSec connection and activate connection
+     */
     private static IPSecConnection createIPSecConnection(
             final VirtualNetwork virtualNetwork,
             final String compartmentId,
@@ -266,6 +313,9 @@ public class VpnIPSecConnectionExample {
         return response.getIPSecConnection();
     }
 
+    /*
+     * Use GET to get the IPSec connection
+     */
     private static IPSecConnection getIPSecConnection(
             final VirtualNetwork virtualNetwork, final String ipsecId) {
 
@@ -276,6 +326,9 @@ public class VpnIPSecConnectionExample {
         return response.getIPSecConnection();
     }
 
+    /*
+     * Use UPDATE to update the IPSec connection and activate connection
+     */
     private static IPSecConnection updateIPSecConnection(
             final VirtualNetwork virtualNetwork, final String ipsecId) throws Exception {
         final UpdateIPSecConnectionRequest request =
@@ -302,24 +355,32 @@ public class VpnIPSecConnectionExample {
         return response.getIPSecConnection();
     }
 
+    /*
+     * Use GET to get the IPSec tunnel
+     */
     private static IPSecConnectionTunnel getIPSecConnectionTunnel(
-            final VirtualNetwork virtualNetwork, final String ipsecId) throws Exception {
-        final GetIPSecConnectionTunnelRequest request =
-                GetIPSecConnectionTunnelRequest.builder().ipscId(ipsecId).build();
-        final GetIPSecConnectionTunnelResponse response =
-                virtualNetwork.getIPSecConnectionTunnel(request);
+            final VirtualNetwork virtualNetwork, final String ipsecId) {
+        final ListIPSecConnectionTunnelsRequest request =
+                ListIPSecConnectionTunnelsRequest.builder().ipscId(ipsecId).build();
 
-        return response.getIPSecConnectionTunnel();
+        final ListIPSecConnectionTunnelsResponse response =
+                virtualNetwork.listIPSecConnectionTunnels(request);
+
+        IPSecConnectionTunnel ipSecConnectionTunnel = response.getItems().get(0);
+
+        return ipSecConnectionTunnel;
     }
 
     /*
      * Use UPDATE to update display name and activate the physical connection
      */
     private static IPSecConnectionTunnel updateIPSecConnectionTunnel(
-            final VirtualNetwork virtualNetwork, final String ipsecId) throws Exception {
+            final VirtualNetwork virtualNetwork, final String ipsecId, final String tunnelId)
+            throws Exception {
         final UpdateIPSecConnectionTunnelRequest request =
                 UpdateIPSecConnectionTunnelRequest.builder()
                         .ipscId(ipsecId)
+                        .tunnelId(tunnelId)
                         .updateIPSecConnectionTunnelDetails(
                                 UpdateIPSecConnectionTunnelDetails.builder()
                                         .displayName(String.format("CC-%s", TIMESTAMP_SUFFIX))
@@ -333,7 +394,8 @@ public class VpnIPSecConnectionExample {
                 .getWaiters()
                 .forIPSecConnectionTunnel(
                         GetIPSecConnectionTunnelRequest.builder()
-                                .ipscId(response.getIPSecConnectionTunnel().getId())
+                                .ipscId(ipsecId)
+                                .tunnelId(tunnelId)
                                 .build(),
                         IPSecConnectionTunnel.LifecycleState.Available)
                 .execute();
@@ -341,6 +403,9 @@ public class VpnIPSecConnectionExample {
         return response.getIPSecConnectionTunnel();
     }
 
+    /*
+     * Use GET to get the TunnelSharedSecret
+     */
     private static IPSecConnectionTunnelSharedSecret getIPSecConnectionTunnelSharedSecret(
             final VirtualNetwork virtualNetwork, final String ipsecId, final String tunnelId)
             throws Exception {
@@ -377,6 +442,23 @@ public class VpnIPSecConnectionExample {
         return response.getIPSecConnectionTunnelSharedSecret();
     }
 
+    /*
+     * Use GET to get the device config of IPSec connection
+     */
+    private static IPSecConnectionDeviceConfig getIPSecConnectionDeviceConfig(
+            final VirtualNetwork virtualNetwork, final String ipsecId) {
+        final GetIPSecConnectionDeviceConfigRequest request =
+                GetIPSecConnectionDeviceConfigRequest.builder().ipscId(ipsecId).build();
+
+        final GetIPSecConnectionDeviceConfigResponse response =
+                virtualNetwork.getIPSecConnectionDeviceConfig(request);
+
+        return response.getIPSecConnectionDeviceConfig();
+    }
+
+    /*
+     * Use DELETE to delete the IPSec connection
+     */
     private static void deleteIPSecConnection(
             final VirtualNetwork virtualNetwork, final String ipsecId) throws Exception {
         // if resource is in provisioning state, wait until provisioned
@@ -402,9 +484,8 @@ public class VpnIPSecConnectionExample {
      * Change Compartment
      */
     private static void changeIPSecCompartment(
-            final VirtualNetwork virtualNetwork,
-            final String ipsecId,
-            final String newCompartment) {
+            final VirtualNetwork virtualNetwork, final String ipsecId, final String newCompartment)
+            throws Exception {
         final ChangeIPSecConnectionCompartmentRequest request =
                 ChangeIPSecConnectionCompartmentRequest.builder()
                         .ipscId(ipsecId)
@@ -415,5 +496,63 @@ public class VpnIPSecConnectionExample {
                         .build();
 
         virtualNetwork.changeIPSecConnectionCompartment(request);
+        virtualNetwork
+                .getWaiters()
+                .forIPSecConnection(
+                        GetIPSecConnectionRequest.builder().ipscId(ipsecId).build(),
+                        IPSecConnection.LifecycleState.Available)
+                .execute();
+    }
+
+    /*
+     * Use GET to get the device config of IPSec tunnel
+     */
+    private TunnelCpeDeviceConfig getTunnelCpeDeviceConfig(
+            final VirtualNetwork virtualNetwork, final String ipsecId, final String tunnelId) {
+        final GetTunnelCpeDeviceConfigRequest request =
+                GetTunnelCpeDeviceConfigRequest.builder()
+                        .ipscId(ipsecId)
+                        .tunnelId(tunnelId)
+                        .build();
+
+        final GetTunnelCpeDeviceConfigResponse response =
+                virtualNetwork.getTunnelCpeDeviceConfig(request);
+
+        return response.getTunnelCpeDeviceConfig();
+    }
+
+    /*
+     * Use UPDATE to update the device config of IPSec tunnel with configAnswer and activate tunnel
+     */
+    private TunnelCpeDeviceConfig updateTunnelCpeDeviceConfig(
+            final VirtualNetwork virtualNetwork, final String ipsecId, final String tunnelId)
+            throws Exception {
+        final UpdateTunnelCpeDeviceConfigDetails update =
+                UpdateTunnelCpeDeviceConfigDetails.builder()
+                        .tunnelCpeDeviceConfig(
+                                Arrays.asList(new CpeDeviceConfigAnswer("demo_key", "demo_value")))
+                        .build();
+
+        final UpdateTunnelCpeDeviceConfigRequest request =
+                UpdateTunnelCpeDeviceConfigRequest.builder()
+                        .ipscId(ipsecId)
+                        .tunnelId(tunnelId)
+                        .updateTunnelCpeDeviceConfigDetails(update)
+                        .build();
+
+        final UpdateTunnelCpeDeviceConfigResponse response =
+                virtualNetwork.updateTunnelCpeDeviceConfig(request);
+
+        virtualNetwork
+                .getWaiters()
+                .forIPSecConnectionTunnel(
+                        GetIPSecConnectionTunnelRequest.builder()
+                                .ipscId(ipsecId)
+                                .tunnelId(tunnelId)
+                                .build(),
+                        IPSecConnectionTunnel.LifecycleState.Available)
+                .execute();
+
+        return response.getTunnelCpeDeviceConfig();
     }
 }

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListCompartmentsConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListCompartmentsConverter.java
@@ -70,6 +70,38 @@ public class ListCompartmentsConverter {
                                     request.getCompartmentIdInSubtree()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListDynamicGroupsConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListDynamicGroupsConverter.java
@@ -54,6 +54,38 @@ public class ListDynamicGroupsConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListGroupsConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListGroupsConverter.java
@@ -54,6 +54,38 @@ public class ListGroupsConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListIdentityProviderGroupsConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListIdentityProviderGroupsConverter.java
@@ -55,6 +55,22 @@ public class ListIdentityProviderGroupsConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListIdentityProvidersConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListIdentityProvidersConverter.java
@@ -61,6 +61,38 @@ public class ListIdentityProvidersConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListNetworkSourcesConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListNetworkSourcesConverter.java
@@ -54,6 +54,38 @@ public class ListNetworkSourcesConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListPoliciesConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListPoliciesConverter.java
@@ -54,6 +54,38 @@ public class ListPoliciesConverter {
                                     request.getLimit()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListUsersConverter.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/internal/http/ListUsersConverter.java
@@ -70,6 +70,38 @@ public class ListUsersConverter {
                                     request.getExternalIdentifier()));
         }
 
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/User.java
@@ -88,6 +88,15 @@ public class User {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("emailVerified")
+        private Boolean emailVerified;
+
+        public Builder emailVerified(Boolean emailVerified) {
+            this.emailVerified = emailVerified;
+            this.__explicitlySet__.add("emailVerified");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("identityProviderId")
         private String identityProviderId;
 
@@ -181,6 +190,7 @@ public class User {
                             name,
                             description,
                             email,
+                            emailVerified,
                             identityProviderId,
                             externalIdentifier,
                             timeCreated,
@@ -202,6 +212,7 @@ public class User {
                             .name(o.getName())
                             .description(o.getDescription())
                             .email(o.getEmail())
+                            .emailVerified(o.getEmailVerified())
                             .identityProviderId(o.getIdentityProviderId())
                             .externalIdentifier(o.getExternalIdentifier())
                             .timeCreated(o.getTimeCreated())
@@ -257,6 +268,12 @@ public class User {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("email")
     String email;
+
+    /**
+     * Whether the email address has been validated.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("emailVerified")
+    Boolean emailVerified;
 
     /**
      * The OCID of the `IdentityProvider` this user belongs to.

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListCompartmentsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListCompartmentsRequest.java
@@ -93,6 +93,118 @@ public class ListCompartmentsRequest extends com.oracle.bmc.requests.BmcRequest<
      */
     private Boolean compartmentIdInSubtree;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private Compartment.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListCompartmentsRequest, java.lang.Void> {
@@ -133,6 +245,10 @@ public class ListCompartmentsRequest extends com.oracle.bmc.requests.BmcRequest<
             limit(o.getLimit());
             accessLevel(o.getAccessLevel());
             compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListDynamicGroupsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListDynamicGroupsRequest.java
@@ -29,6 +29,118 @@ public class ListDynamicGroupsRequest extends com.oracle.bmc.requests.BmcRequest
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private DynamicGroup.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListDynamicGroupsRequest, java.lang.Void> {
@@ -67,6 +179,10 @@ public class ListDynamicGroupsRequest extends com.oracle.bmc.requests.BmcRequest
             compartmentId(o.getCompartmentId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListGroupsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListGroupsRequest.java
@@ -29,6 +29,118 @@ public class ListGroupsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private Group.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListGroupsRequest, java.lang.Void> {
@@ -67,6 +179,10 @@ public class ListGroupsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
             compartmentId(o.getCompartmentId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListIdentityProviderGroupsRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListIdentityProviderGroupsRequest.java
@@ -29,6 +29,18 @@ public class ListIdentityProviderGroupsRequest
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private IdentityProvider.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListIdentityProviderGroupsRequest, java.lang.Void> {
@@ -67,6 +79,8 @@ public class ListIdentityProviderGroupsRequest
             identityProviderId(o.getIdentityProviderId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListIdentityProvidersRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListIdentityProvidersRequest.java
@@ -35,6 +35,118 @@ public class ListIdentityProvidersRequest
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private IdentityProvider.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListIdentityProvidersRequest, java.lang.Void> {
@@ -74,6 +186,10 @@ public class ListIdentityProvidersRequest
             compartmentId(o.getCompartmentId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListNetworkSourcesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListNetworkSourcesRequest.java
@@ -29,6 +29,118 @@ public class ListNetworkSourcesRequest extends com.oracle.bmc.requests.BmcReques
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private NetworkSources.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListNetworkSourcesRequest, java.lang.Void> {
@@ -67,6 +179,10 @@ public class ListNetworkSourcesRequest extends com.oracle.bmc.requests.BmcReques
             compartmentId(o.getCompartmentId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListPoliciesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListPoliciesRequest.java
@@ -29,6 +29,118 @@ public class ListPoliciesRequest extends com.oracle.bmc.requests.BmcRequest<java
      */
     private Integer limit;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private Policy.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListPoliciesRequest, java.lang.Void> {
@@ -67,6 +179,10 @@ public class ListPoliciesRequest extends com.oracle.bmc.requests.BmcRequest<java
             compartmentId(o.getCompartmentId());
             page(o.getPage());
             limit(o.getLimit());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListUsersRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListUsersRequest.java
@@ -41,6 +41,118 @@ public class ListUsersRequest extends com.oracle.bmc.requests.BmcRequest<java.la
      */
     private String externalIdentifier;
 
+    /**
+     * A filter to only return resources that match the given name exactly.
+     *
+     */
+    private String name;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for NAME is ascending. The NAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by Availability Domain if the scope of the resource type is within a
+     * single Availability Domain. If you call one of these \"List\" operations without specifying
+     * an Availability Domain, the resources are grouped by Availability Domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The NAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+     *
+     */
+    private User.LifecycleState lifecycleState;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListUsersRequest, java.lang.Void> {
@@ -81,6 +193,10 @@ public class ListUsersRequest extends com.oracle.bmc.requests.BmcRequest<java.la
             limit(o.getLimit());
             identityProviderId(o.getIdentityProviderId());
             externalIdentifier(o.getExternalIdentifier());
+            name(o.getName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.18.0</version>
+  <version>1.18.1</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for creating a new database from an existing database based on a given timestamp in the Database service

- Support for enabling archive log backups of databases in the Database service

- Support for returning the database version on autonomous container databases in the Database service

- Support for the new DNS format of the Data Transfer service

- Support for scheduled autoscaling, which allows for scaling actions triggered at particular times based on CRON expressions, in the Compute Autoscaling service

- Support for filtering of list APIs for groups, identity providers, identity provider groups, compartments, dynamic groups, network sources, policies, and users by name or lifecycle state in the Identity Service
