### PR TITLE
Releasing version 1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.19.2 - 2020-07-07
+### Added
+- Support for registering and deregistering autonomous dedicated databases with Data Safe in the Database service
+- Support for switching between non-private-endpoints and private endpoints on autonomous databases in the Database service
+- Support for returning group names when listing identity provider groups in the Identity service
+- Support for server-side object re-encryption in the Object Storage service
+- Support for private endpoint (ingress) and public endpoint whitelisting in the Analytics Cloud service
+
 ## 1.19.1 - 2020-06-30
 ### Added
 - Support for the Usage service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/Analytics.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/Analytics.java
@@ -53,6 +53,17 @@ public interface Analytics extends AutoCloseable {
             ChangeAnalyticsInstanceCompartmentRequest request);
 
     /**
+     * Change an Analytics instance network endpoint. The operation is long-running
+     * and creates a new WorkRequest.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeAnalyticsInstanceNetworkEndpointResponse changeAnalyticsInstanceNetworkEndpoint(
+            ChangeAnalyticsInstanceNetworkEndpointRequest request);
+
+    /**
      * Create a new AnalyticsInstance in the specified compartment. The operation is long-running
      * and creates a new WorkRequest.
      *

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsAsync.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsAsync.java
@@ -62,6 +62,26 @@ public interface AnalyticsAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Change an Analytics instance network endpoint. The operation is long-running
+     * and creates a new WorkRequest.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeAnalyticsInstanceNetworkEndpointResponse>
+            changeAnalyticsInstanceNetworkEndpoint(
+                    ChangeAnalyticsInstanceNetworkEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeAnalyticsInstanceNetworkEndpointRequest,
+                                    ChangeAnalyticsInstanceNetworkEndpointResponse>
+                            handler);
+
+    /**
      * Create a new AnalyticsInstance in the specified compartment. The operation is long-running
      * and creates a new WorkRequest.
      *

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsAsyncClient.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsAsyncClient.java
@@ -399,6 +399,104 @@ public class AnalyticsAsyncClient implements AnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeAnalyticsInstanceNetworkEndpointResponse>
+            changeAnalyticsInstanceNetworkEndpoint(
+                    final ChangeAnalyticsInstanceNetworkEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeAnalyticsInstanceNetworkEndpointRequest,
+                                    ChangeAnalyticsInstanceNetworkEndpointResponse>
+                            handler) {
+        LOG.trace("Called async changeAnalyticsInstanceNetworkEndpoint");
+        final ChangeAnalyticsInstanceNetworkEndpointRequest interceptedRequest =
+                ChangeAnalyticsInstanceNetworkEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeAnalyticsInstanceNetworkEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeAnalyticsInstanceNetworkEndpointResponse>
+                transformer = ChangeAnalyticsInstanceNetworkEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeAnalyticsInstanceNetworkEndpointRequest,
+                        ChangeAnalyticsInstanceNetworkEndpointResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeAnalyticsInstanceNetworkEndpointRequest,
+                            ChangeAnalyticsInstanceNetworkEndpointResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeAnalyticsInstanceNetworkEndpointDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeAnalyticsInstanceNetworkEndpointDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeAnalyticsInstanceNetworkEndpointResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeAnalyticsInstanceNetworkEndpointDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateAnalyticsInstanceResponse> createAnalyticsInstance(
             final CreateAnalyticsInstanceRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsClient.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/AnalyticsClient.java
@@ -454,6 +454,42 @@ public class AnalyticsClient implements Analytics {
     }
 
     @Override
+    public ChangeAnalyticsInstanceNetworkEndpointResponse changeAnalyticsInstanceNetworkEndpoint(
+            ChangeAnalyticsInstanceNetworkEndpointRequest request) {
+        LOG.trace("Called changeAnalyticsInstanceNetworkEndpoint");
+        final ChangeAnalyticsInstanceNetworkEndpointRequest interceptedRequest =
+                ChangeAnalyticsInstanceNetworkEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeAnalyticsInstanceNetworkEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeAnalyticsInstanceNetworkEndpointResponse>
+                transformer = ChangeAnalyticsInstanceNetworkEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeAnalyticsInstanceNetworkEndpointDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateAnalyticsInstanceResponse createAnalyticsInstance(
             CreateAnalyticsInstanceRequest request) {
         LOG.trace("Called createAnalyticsInstance");

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/internal/http/ChangeAnalyticsInstanceNetworkEndpointConverter.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/internal/http/ChangeAnalyticsInstanceNetworkEndpointConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.analytics.model.*;
+import com.oracle.bmc.analytics.requests.*;
+import com.oracle.bmc.analytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.extern.slf4j.Slf4j
+public class ChangeAnalyticsInstanceNetworkEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.analytics.requests.ChangeAnalyticsInstanceNetworkEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.analytics.requests.ChangeAnalyticsInstanceNetworkEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.analytics.requests.ChangeAnalyticsInstanceNetworkEndpointRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAnalyticsInstanceId(), "analyticsInstanceId must not be blank");
+        Validate.notNull(
+                request.getChangeAnalyticsInstanceNetworkEndpointDetails(),
+                "changeAnalyticsInstanceNetworkEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190331")
+                        .path("analyticsInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAnalyticsInstanceId()))
+                        .path("actions")
+                        .path("changeNetworkEndpoint");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.analytics.responses
+                            .ChangeAnalyticsInstanceNetworkEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.analytics.responses
+                                .ChangeAnalyticsInstanceNetworkEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.analytics.responses
+                                        .ChangeAnalyticsInstanceNetworkEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.analytics.responses
+                                            .ChangeAnalyticsInstanceNetworkEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.analytics.responses.ChangeAnalyticsInstanceNetworkEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.analytics.responses
+                                                .ChangeAnalyticsInstanceNetworkEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.analytics.responses
+                                                        .ChangeAnalyticsInstanceNetworkEndpointResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.analytics.responses
+                                                .ChangeAnalyticsInstanceNetworkEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/AnalyticsInstance.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/AnalyticsInstance.java
@@ -108,6 +108,15 @@ public class AnalyticsInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceUrl")
         private String serviceUrl;
 
@@ -169,6 +178,7 @@ public class AnalyticsInstance {
                             capacity,
                             licenseType,
                             emailNotification,
+                            networkEndpointDetails,
                             serviceUrl,
                             definedTags,
                             freeformTags,
@@ -190,6 +200,7 @@ public class AnalyticsInstance {
                             .capacity(o.getCapacity())
                             .licenseType(o.getLicenseType())
                             .emailNotification(o.getEmailNotification())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails())
                             .serviceUrl(o.getServiceUrl())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags())
@@ -266,6 +277,9 @@ public class AnalyticsInstance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("emailNotification")
     String emailNotification;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     /**
      * URL of the Analytics service.

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/AnalyticsInstanceSummary.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/AnalyticsInstanceSummary.java
@@ -108,6 +108,15 @@ public class AnalyticsInstanceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceUrl")
         private String serviceUrl;
 
@@ -150,6 +159,7 @@ public class AnalyticsInstanceSummary {
                             capacity,
                             licenseType,
                             emailNotification,
+                            networkEndpointDetails,
                             serviceUrl,
                             timeCreated,
                             timeUpdated);
@@ -169,6 +179,7 @@ public class AnalyticsInstanceSummary {
                             .capacity(o.getCapacity())
                             .licenseType(o.getLicenseType())
                             .emailNotification(o.getEmailNotification())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails())
                             .serviceUrl(o.getServiceUrl())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated());
@@ -243,6 +254,9 @@ public class AnalyticsInstanceSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("emailNotification")
     String emailNotification;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     /**
      * URL of the Analytics service.

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/ChangeAnalyticsInstanceNetworkEndpointDetails.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/ChangeAnalyticsInstanceNetworkEndpointDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Input payload to update an Analytics instance endpoint details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeAnalyticsInstanceNetworkEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeAnalyticsInstanceNetworkEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeAnalyticsInstanceNetworkEndpointDetails build() {
+            ChangeAnalyticsInstanceNetworkEndpointDetails __instance__ =
+                    new ChangeAnalyticsInstanceNetworkEndpointDetails(networkEndpointDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeAnalyticsInstanceNetworkEndpointDetails o) {
+            Builder copiedBuilder = networkEndpointDetails(o.getNetworkEndpointDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/CreateAnalyticsInstanceDetails.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/CreateAnalyticsInstanceDetails.java
@@ -90,6 +90,15 @@ public class CreateAnalyticsInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("idcsAccessToken")
         private String idcsAccessToken;
 
@@ -131,6 +140,7 @@ public class CreateAnalyticsInstanceDetails {
                             capacity,
                             licenseType,
                             emailNotification,
+                            networkEndpointDetails,
                             idcsAccessToken,
                             definedTags,
                             freeformTags);
@@ -148,6 +158,7 @@ public class CreateAnalyticsInstanceDetails {
                             .capacity(o.getCapacity())
                             .licenseType(o.getLicenseType())
                             .emailNotification(o.getEmailNotification())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails())
                             .idcsAccessToken(o.getIdcsAccessToken())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
@@ -208,6 +219,9 @@ public class CreateAnalyticsInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("emailNotification")
     String emailNotification;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     /**
      * IDCS access token identifying a stripe and service administrator user.

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/NetworkEndpointDetails.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/NetworkEndpointDetails.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Base representation of a network endpoint.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkEndpointType",
+    defaultImpl = NetworkEndpointDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PrivateEndpointDetails.class,
+        name = "PRIVATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PublicEndpointDetails.class,
+        name = "PUBLIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class NetworkEndpointDetails {}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/NetworkEndpointType.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/NetworkEndpointType.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Public/Private endpoint access type.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.extern.slf4j.Slf4j
+public enum NetworkEndpointType {
+    Public("PUBLIC"),
+    Private("PRIVATE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, NetworkEndpointType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (NetworkEndpointType v : NetworkEndpointType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    NetworkEndpointType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static NetworkEndpointType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'NetworkEndpointType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/PrivateEndpointDetails.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/PrivateEndpointDetails.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Private endpoint configuration details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PrivateEndpointDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkEndpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PrivateEndpointDetails extends NetworkEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PrivateEndpointDetails build() {
+            PrivateEndpointDetails __instance__ = new PrivateEndpointDetails(vcnId, subnetId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PrivateEndpointDetails o) {
+            Builder copiedBuilder = vcnId(o.getVcnId()).subnetId(o.getSubnetId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PrivateEndpointDetails(String vcnId, String subnetId) {
+        super();
+        this.vcnId = vcnId;
+        this.subnetId = subnetId;
+    }
+
+    /**
+     * The VCN OCID for the private endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    /**
+     * The subnet OCID for the private endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/PublicEndpointDetails.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/PublicEndpointDetails.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Public endpoint configuration details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PublicEndpointDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkEndpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PublicEndpointDetails extends NetworkEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
+        private java.util.List<String> whitelistedIps;
+
+        public Builder whitelistedIps(java.util.List<String> whitelistedIps) {
+            this.whitelistedIps = whitelistedIps;
+            this.__explicitlySet__.add("whitelistedIps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("whitelistedVcns")
+        private java.util.List<VirtualCloudNetwork> whitelistedVcns;
+
+        public Builder whitelistedVcns(java.util.List<VirtualCloudNetwork> whitelistedVcns) {
+            this.whitelistedVcns = whitelistedVcns;
+            this.__explicitlySet__.add("whitelistedVcns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PublicEndpointDetails build() {
+            PublicEndpointDetails __instance__ =
+                    new PublicEndpointDetails(whitelistedIps, whitelistedVcns);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PublicEndpointDetails o) {
+            Builder copiedBuilder =
+                    whitelistedIps(o.getWhitelistedIps()).whitelistedVcns(o.getWhitelistedVcns());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PublicEndpointDetails(
+            java.util.List<String> whitelistedIps,
+            java.util.List<VirtualCloudNetwork> whitelistedVcns) {
+        super();
+        this.whitelistedIps = whitelistedIps;
+        this.whitelistedVcns = whitelistedVcns;
+    }
+
+    /**
+     * Source IP addresses or IP address ranges igress rules.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
+    java.util.List<String> whitelistedIps;
+
+    /**
+     * Virtual Cloud Networks allowed to access this network endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("whitelistedVcns")
+    java.util.List<VirtualCloudNetwork> whitelistedVcns;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/SortBy.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/SortBy.java
@@ -12,6 +12,7 @@ package com.oracle.bmc.analytics.model;
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
 public enum SortBy {
     CapacityType("capacityType"),
+    CapacityValue("capacityValue"),
     FeatureSet("featureSet"),
     LifecycleState("lifecycleState"),
     Name("name"),

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/VirtualCloudNetwork.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/VirtualCloudNetwork.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.model;
+
+/**
+ * Virtual Cloud Network definition.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VirtualCloudNetwork.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VirtualCloudNetwork {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
+        private java.util.List<String> whitelistedIps;
+
+        public Builder whitelistedIps(java.util.List<String> whitelistedIps) {
+            this.whitelistedIps = whitelistedIps;
+            this.__explicitlySet__.add("whitelistedIps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VirtualCloudNetwork build() {
+            VirtualCloudNetwork __instance__ = new VirtualCloudNetwork(id, whitelistedIps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VirtualCloudNetwork o) {
+            Builder copiedBuilder = id(o.getId()).whitelistedIps(o.getWhitelistedIps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The Virtual Cloud Network OCID.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Source IP addresses or IP address ranges igress rules.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
+    java.util.List<String> whitelistedIps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/WorkRequestActionResult.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/WorkRequestActionResult.java
@@ -17,6 +17,7 @@ public enum WorkRequestActionResult {
     Started("STARTED"),
     Stopped("STOPPED"),
     Scaled("SCALED"),
+    NetworkEndpointChanged("NETWORK_ENDPOINT_CHANGED"),
     None("NONE"),
 
     /**

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/WorkRequestOperationType.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/model/WorkRequestOperationType.java
@@ -17,6 +17,7 @@ public enum WorkRequestOperationType {
     StopAnalyticsInstance("STOP_ANALYTICS_INSTANCE"),
     ScaleAnalyticsInstance("SCALE_ANALYTICS_INSTANCE"),
     ChangeAnalyticsInstanceCompartment("CHANGE_ANALYTICS_INSTANCE_COMPARTMENT"),
+    ChangeAnalyticsInstanceNetworkEndpoint("CHANGE_ANALYTICS_INSTANCE_NETWORK_ENDPOINT"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/requests/ChangeAnalyticsInstanceNetworkEndpointRequest.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/requests/ChangeAnalyticsInstanceNetworkEndpointRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.requests;
+
+import com.oracle.bmc.analytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeAnalyticsInstanceNetworkEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeAnalyticsInstanceNetworkEndpointDetails> {
+
+    /**
+     * The OCID of the AnalyticsInstance.
+     *
+     */
+    private String analyticsInstanceId;
+
+    /**
+     * Input payload for changing an Analytics instance network endpoint.
+     *
+     */
+    private ChangeAnalyticsInstanceNetworkEndpointDetails
+            changeAnalyticsInstanceNetworkEndpointDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeAnalyticsInstanceNetworkEndpointDetails getBody$() {
+        return changeAnalyticsInstanceNetworkEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeAnalyticsInstanceNetworkEndpointRequest,
+                    ChangeAnalyticsInstanceNetworkEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeAnalyticsInstanceNetworkEndpointRequest o) {
+            analyticsInstanceId(o.getAnalyticsInstanceId());
+            changeAnalyticsInstanceNetworkEndpointDetails(
+                    o.getChangeAnalyticsInstanceNetworkEndpointDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeAnalyticsInstanceNetworkEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeAnalyticsInstanceNetworkEndpointRequest
+         */
+        public ChangeAnalyticsInstanceNetworkEndpointRequest build() {
+            ChangeAnalyticsInstanceNetworkEndpointRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeAnalyticsInstanceNetworkEndpointDetails body) {
+            changeAnalyticsInstanceNetworkEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-analytics/src/main/java/com/oracle/bmc/analytics/responses/ChangeAnalyticsInstanceNetworkEndpointResponse.java
+++ b/bmc-analytics/src/main/java/com/oracle/bmc/analytics/responses/ChangeAnalyticsInstanceNetworkEndpointResponse.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.analytics.responses;
+
+import com.oracle.bmc.analytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeAnalyticsInstanceNetworkEndpointResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this ID to track the status
+     * of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeAnalyticsInstanceNetworkEndpointResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,318 +19,318 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/requests/BmcRequest.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/requests/BmcRequest.java
@@ -6,6 +6,7 @@ package com.oracle.bmc.requests;
 
 import javax.ws.rs.client.Invocation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.oracle.bmc.retrier.RetryConfiguration;
 import com.oracle.bmc.util.internal.Consumer;
 import lombok.Getter;
@@ -46,6 +47,7 @@ public class BmcRequest<B> {
      *
      * @throws IllegalStateException if this request does not support a body
      */
+    @JsonIgnore
     @com.oracle.bmc.InternalSdk
     public B getBody$() {
         throw new IllegalStateException("This request does not support a body");

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -3673,7 +3673,13 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
                                     new com.oracle.bmc.http.internal.ErrorConsumer<>(
                                             this, interceptedRequest);
-                            client.post(ib, interceptedRequest, onSuccess, onError);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getDeregisterAutonomousDatabaseDataSafeDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     };
         }
@@ -3690,7 +3696,12 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                                 handlerToUse, interceptedRequest);
 
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
-                client.post(ib, interceptedRequest, onSuccess, onError);
+                client.post(
+                        ib,
+                        interceptedRequest.getDeregisterAutonomousDatabaseDataSafeDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
 
         if (this.authenticationDetailsProvider
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
@@ -3704,7 +3715,13 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
-                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getDeregisterAutonomousDatabaseDataSafeDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     });
         } else {
@@ -9144,7 +9161,13 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
                                     new com.oracle.bmc.http.internal.ErrorConsumer<>(
                                             this, interceptedRequest);
-                            client.post(ib, interceptedRequest, onSuccess, onError);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getRegisterAutonomousDatabaseDataSafeDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     };
         }
@@ -9161,7 +9184,12 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                                 handlerToUse, interceptedRequest);
 
         java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
-                client.post(ib, interceptedRequest, onSuccess, onError);
+                client.post(
+                        ib,
+                        interceptedRequest.getRegisterAutonomousDatabaseDataSafeDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
 
         if (this.authenticationDetailsProvider
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
@@ -9175,7 +9203,13 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                             java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
-                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getRegisterAutonomousDatabaseDataSafeDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     });
         } else {

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -1701,7 +1701,11 @@ public class DatabaseClient implements Database {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
-                                        client.post(ib, retriedRequest);
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getDeregisterAutonomousDatabaseDataSafeDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -3771,7 +3775,11 @@ public class DatabaseClient implements Database {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
-                                        client.post(ib, retriedRequest);
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getRegisterAutonomousDatabaseDataSafeDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -798,7 +798,7 @@ public class AutonomousDatabase {
     String privateEndpoint;
 
     /**
-     * The private endpoint label for the resource.
+     * The private endpoint label for the resource. Setting this to an empty string, after the private endpoint database gets created, will change the same private endpoint database to the public endpoint database.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointLabel")
     String privateEndpointLabel;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -800,7 +800,7 @@ public class AutonomousDatabaseSummary {
     String privateEndpoint;
 
     /**
-     * The private endpoint label for the resource.
+     * The private endpoint label for the resource. Setting this to an empty string, after the private endpoint database gets created, will change the same private endpoint database to the public endpoint database.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointLabel")
     String privateEndpointLabel;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -250,7 +250,7 @@ public class CreateAutonomousDatabaseBase {
     java.util.List<String> nsgIds;
 
     /**
-     * The private endpoint label for the resource.
+     * The private endpoint label for the resource. Setting this to an empty string, after the private endpoint database gets created, will change the same private endpoint database to the public endpoint database.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointLabel")
     String privateEndpointLabel;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DeregisterAutonomousDatabaseDataSafeDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DeregisterAutonomousDatabaseDataSafeDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details to deregister an Autonomous Database with Data Safe.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DeregisterAutonomousDatabaseDataSafeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DeregisterAutonomousDatabaseDataSafeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+        private String pdbAdminPassword;
+
+        public Builder pdbAdminPassword(String pdbAdminPassword) {
+            this.pdbAdminPassword = pdbAdminPassword;
+            this.__explicitlySet__.add("pdbAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DeregisterAutonomousDatabaseDataSafeDetails build() {
+            DeregisterAutonomousDatabaseDataSafeDetails __instance__ =
+                    new DeregisterAutonomousDatabaseDataSafeDetails(pdbAdminPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DeregisterAutonomousDatabaseDataSafeDetails o) {
+            Builder copiedBuilder = pdbAdminPassword(o.getPdbAdminPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The admin password provided during the creation of the database. This password is between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (\") or the username \"admin\", regardless of casing.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+    String pdbAdminPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/RegisterAutonomousDatabaseDataSafeDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/RegisterAutonomousDatabaseDataSafeDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for registering an Autonomous Database with Data Safe.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RegisterAutonomousDatabaseDataSafeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RegisterAutonomousDatabaseDataSafeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+        private String pdbAdminPassword;
+
+        public Builder pdbAdminPassword(String pdbAdminPassword) {
+            this.pdbAdminPassword = pdbAdminPassword;
+            this.__explicitlySet__.add("pdbAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RegisterAutonomousDatabaseDataSafeDetails build() {
+            RegisterAutonomousDatabaseDataSafeDetails __instance__ =
+                    new RegisterAutonomousDatabaseDataSafeDetails(pdbAdminPassword);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RegisterAutonomousDatabaseDataSafeDetails o) {
+            Builder copiedBuilder = pdbAdminPassword(o.getPdbAdminPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The admin password provided during the creation of the database. This password is between 12 and 30 characters long, and must contain at least 1 uppercase, 1 lowercase, and 1 numeric character. It cannot contain the double quote symbol (\") or the username \"admin\", regardless of casing.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+    String pdbAdminPassword;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -138,6 +138,24 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointLabel")
+        private String privateEndpointLabel;
+
+        public Builder privateEndpointLabel(String privateEndpointLabel) {
+            this.privateEndpointLabel = privateEndpointLabel;
+            this.__explicitlySet__.add("privateEndpointLabel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
         private java.util.List<String> nsgIds;
 
@@ -165,6 +183,8 @@ public class UpdateAutonomousDatabaseDetails {
                             whitelistedIps,
                             isAutoScalingEnabled,
                             dbVersion,
+                            subnetId,
+                            privateEndpointLabel,
                             nsgIds);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -185,6 +205,8 @@ public class UpdateAutonomousDatabaseDetails {
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .dbVersion(o.getDbVersion())
+                            .subnetId(o.getSubnetId())
+                            .privateEndpointLabel(o.getPrivateEndpointLabel())
                             .nsgIds(o.getNsgIds());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -326,6 +348,28 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
     String dbVersion;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the resource is associated with.
+     * <p>
+     **Subnet Restrictions:**
+     * - For bare metal DB systems and for single node virtual machine DB systems, do not use a subnet that overlaps with 192.168.16.16/28.
+     * - For Exadata and virtual machine 2-node RAC DB systems, do not use a subnet that overlaps with 192.168.128.0/20.
+     * - For Autonomous Database, setting this will disable public secure access to the database.
+     * <p>
+     * These subnets are used by the Oracle Clusterware private interconnect on the database instance.
+     * Specifying an overlapping subnet will cause the private interconnect to malfunction.
+     * This restriction applies to both the client subnet and the backup subnet.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * The private endpoint label for the resource. Setting this to an empty string, after the private endpoint database gets created, will change the same private endpoint database to the public endpoint database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointLabel")
+    String privateEndpointLabel;
 
     /**
      * A list of the [OCIDs](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security groups (NSGs) that this resource belongs to. Setting this to an empty array after the list is created removes the resource from all NSGs. For more information about NSGs, see [Security Rules](https://docs.cloud.oracle.com/Content/Network/Concepts/securityrules.htm).

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeregisterAutonomousDatabaseDataSafeRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DeregisterAutonomousDatabaseDataSafeRequest.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.database.model.*;
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class DeregisterAutonomousDatabaseDataSafeRequest
-        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+        extends com.oracle.bmc.requests.BmcRequest<DeregisterAutonomousDatabaseDataSafeDetails> {
 
     /**
      * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
@@ -23,9 +23,25 @@ public class DeregisterAutonomousDatabaseDataSafeRequest
      */
     private String opcRequestId;
 
+    /**
+     * Details for deregistering an Autonomous Database with Data Safe.
+     */
+    private DeregisterAutonomousDatabaseDataSafeDetails deregisterAutonomousDatabaseDataSafeDetails;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public DeregisterAutonomousDatabaseDataSafeDetails getBody$() {
+        return deregisterAutonomousDatabaseDataSafeDetails;
+    }
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
-                    DeregisterAutonomousDatabaseDataSafeRequest, java.lang.Void> {
+                    DeregisterAutonomousDatabaseDataSafeRequest,
+                    DeregisterAutonomousDatabaseDataSafeDetails> {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
         private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
@@ -60,6 +76,8 @@ public class DeregisterAutonomousDatabaseDataSafeRequest
         public Builder copy(DeregisterAutonomousDatabaseDataSafeRequest o) {
             autonomousDatabaseId(o.getAutonomousDatabaseId());
             opcRequestId(o.getOpcRequestId());
+            deregisterAutonomousDatabaseDataSafeDetails(
+                    o.getDeregisterAutonomousDatabaseDataSafeDetails());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;
@@ -80,6 +98,17 @@ public class DeregisterAutonomousDatabaseDataSafeRequest
             request.setInvocationCallback(invocationCallback);
             request.setRetryConfiguration(retryConfiguration);
             return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(DeregisterAutonomousDatabaseDataSafeDetails body) {
+            deregisterAutonomousDatabaseDataSafeDetails(body);
+            return this;
         }
     }
 }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/RegisterAutonomousDatabaseDataSafeRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/RegisterAutonomousDatabaseDataSafeRequest.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.database.model.*;
 @lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
 @lombok.Getter
 public class RegisterAutonomousDatabaseDataSafeRequest
-        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+        extends com.oracle.bmc.requests.BmcRequest<RegisterAutonomousDatabaseDataSafeDetails> {
 
     /**
      * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
@@ -23,9 +23,25 @@ public class RegisterAutonomousDatabaseDataSafeRequest
      */
     private String opcRequestId;
 
+    /**
+     * Request to register an Autonomous Database with Data Safe.
+     */
+    private RegisterAutonomousDatabaseDataSafeDetails registerAutonomousDatabaseDataSafeDetails;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public RegisterAutonomousDatabaseDataSafeDetails getBody$() {
+        return registerAutonomousDatabaseDataSafeDetails;
+    }
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
-                    RegisterAutonomousDatabaseDataSafeRequest, java.lang.Void> {
+                    RegisterAutonomousDatabaseDataSafeRequest,
+                    RegisterAutonomousDatabaseDataSafeDetails> {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
                 invocationCallback = null;
         private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
@@ -60,6 +76,8 @@ public class RegisterAutonomousDatabaseDataSafeRequest
         public Builder copy(RegisterAutonomousDatabaseDataSafeRequest o) {
             autonomousDatabaseId(o.getAutonomousDatabaseId());
             opcRequestId(o.getOpcRequestId());
+            registerAutonomousDatabaseDataSafeDetails(
+                    o.getRegisterAutonomousDatabaseDataSafeDetails());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;
@@ -80,6 +98,17 @@ public class RegisterAutonomousDatabaseDataSafeRequest
             request.setInvocationCallback(invocationCallback);
             request.setRetryConfiguration(retryConfiguration);
             return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(RegisterAutonomousDatabaseDataSafeDetails body) {
+            registerAutonomousDatabaseDataSafeDetails(body);
+            return this;
         }
     }
 }

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-examples</artifactId>
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.19.1</version>
+        <version>1.19.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/Identity.java
@@ -74,8 +74,11 @@ public interface Identity extends AutoCloseable {
     AssembleEffectiveTagSetResponse assembleEffectiveTagSet(AssembleEffectiveTagSetRequest request);
 
     /**
-     * Bulk delete resources in the compartment. All resources must be in the same compartment.
-     * This API can only be invoked from tenancy's home region.
+     * Deletes multiple resources in the compartment. All resources must be in the same compartment. You must have the appropriate
+     * permissions to delete the resources in the request. This API can only be invoked from the tenancy's
+     * [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home). This operation creates a
+     * {@link WorkRequest}. Use the {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}
+     * API to monitor the status of the bulk action.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -113,8 +116,11 @@ public interface Identity extends AutoCloseable {
     BulkDeleteTagsResponse bulkDeleteTags(BulkDeleteTagsRequest request);
 
     /**
-     * Bulk move resources in the compartment. All resources must be in the same compartment.
-     * This API can only be invoked from tenancy's home region.
+     * Moves multiple resources from one compartment to another. All resources must be in the same compartment.
+     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home).
+     * To move resources, you must have the appropriate permissions to move the resource in both the source and target
+     * compartments. This operation creates a {@link WorkRequest}.
+     * Use the {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} API to monitor the status of the bulk action.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -975,7 +981,13 @@ public interface Identity extends AutoCloseable {
     ListAvailabilityDomainsResponse listAvailabilityDomains(ListAvailabilityDomainsRequest request);
 
     /**
-     * Lists the resource types supported by compartment bulk actions.
+     * Lists the resource-types supported by compartment bulk actions. Use this API to help you provide the correct
+     * resource-type information to the {@link #bulkDeleteResources(BulkDeleteResourcesRequest) bulkDeleteResources}
+     * and {@link #bulkMoveResources(BulkMoveResourcesRequest) bulkMoveResources} operations. The returned list of
+     * resource-types provides the appropriate resource-type names to use with the bulk action operations along with
+     * the type of identifying information you'll need to provide for each resource-type. Most resource-types just
+     * require an [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to identify a specific resource, but some resource-types,
+     * such as buckets, require you to provide other identifying information.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/IdentityAsync.java
@@ -97,8 +97,11 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Bulk delete resources in the compartment. All resources must be in the same compartment.
-     * This API can only be invoked from tenancy's home region.
+     * Deletes multiple resources in the compartment. All resources must be in the same compartment. You must have the appropriate
+     * permissions to delete the resources in the request. This API can only be invoked from the tenancy's
+     * [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home). This operation creates a
+     * {@link WorkRequest}. Use the {@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}
+     * API to monitor the status of the bulk action.
      *
      *
      * @param request The request object containing the details to send
@@ -151,8 +154,11 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Bulk move resources in the compartment. All resources must be in the same compartment.
-     * This API can only be invoked from tenancy's home region.
+     * Moves multiple resources from one compartment to another. All resources must be in the same compartment.
+     * This API can only be invoked from the tenancy's [home region](https://docs.cloud.oracle.com/Content/Identity/Tasks/managingregions.htm#Home).
+     * To move resources, you must have the appropriate permissions to move the resource in both the source and target
+     * compartments. This operation creates a {@link WorkRequest}.
+     * Use the {@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest} API to monitor the status of the bulk action.
      *
      *
      * @param request The request object containing the details to send
@@ -1466,7 +1472,13 @@ public interface IdentityAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists the resource types supported by compartment bulk actions.
+     * Lists the resource-types supported by compartment bulk actions. Use this API to help you provide the correct
+     * resource-type information to the {@link #bulkDeleteResources(BulkDeleteResourcesRequest, Consumer, Consumer) bulkDeleteResources}
+     * and {@link #bulkMoveResources(BulkMoveResourcesRequest, Consumer, Consumer) bulkMoveResources} operations. The returned list of
+     * resource-types provides the appropriate resource-type names to use with the bulk action operations along with
+     * the type of identifying information you'll need to provide for each resource-type. Most resource-types just
+     * require an [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) to identify a specific resource, but some resource-types,
+     * such as buckets, require you to provide other identifying information.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResource.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResource.java
@@ -84,13 +84,15 @@ public class BulkActionResource {
     }
 
     /**
-     * The resource identifier.
+     * The resource OCID.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("identifier")
     String identifier;
 
     /**
-     * The resource type.
+     * The resource-type. To get the list of supported resource-types use
+     * {@link #listBulkActionResourceTypes(ListBulkActionResourceTypesRequest) listBulkActionResourceTypes}.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entityType")
     String entityType;
@@ -98,11 +100,30 @@ public class BulkActionResource {
     /**
      * Additional information that helps to identity the resource for bulk action.
      * <p>
-     * DELETE and UPDATE APIs for most resource types only require the resource identifier(ocid).
-     * But additional metadata is required for some resource types.
+     * The APIs to delete and move most resource types only require the resource identifier (ocid).
+     * But some resource-types require additional identifying information.
      * <p>
      * This information is provided in the resource's public API document. It is also
-     * available through the ListBulkActionResourceTypes API.
+     * available through the
+     * {@link #listBulkActionResourceTypes(ListBulkActionResourceTypesRequest) listBulkActionResourceTypes}.
+     * <p>
+     **Example**:
+     * The APIs to delete or move the `buckets` resource-type require `namespaceName` and `bucketName` to identify the resource, as
+     * shown in the APIs, {@link #deleteBucket(DeleteBucketRequest) deleteBucket} and
+     * {@link #updateBucket(UpdateBucketRequest) updateBucket}.
+     * <p>
+     * To add a bucket for bulk actions, specify `namespaceName` and `bucketName` in
+     * the metadata property as shown in this example
+     * <p>
+     * {
+     *       \"identifier\": \"<OCID_of_bucket>\"
+     *       \"entityType\": \"bucket\",
+     *       \"metadata\":
+     *       {
+     *         \"namespaceName\": \"sampleNamespace\",
+     *         \"bucketName\": \"sampleBucket\"
+     *       }
+     *     }
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceType.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceType.java
@@ -70,17 +70,15 @@ public class BulkActionResourceType {
     }
 
     /**
-     * The unique name of the resource type.
+     * The unique name of the resource-type.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * List of metadata keys required to identify the resource.
-     * E.g. for bucket, metadataKeys will be [\"namespaceName\", \"bucketName\"].
-     * This informatino will match the public API document:
-     * https://docs.cloud.oracle.com/en-us/iaas/api/#/en/objectstorage/20160918/Bucket/GetBucket
+     * List of metadata keys required to identify a specific resource. Some resource-types require information besides an OCID to identify
+     * a specific resource. For example, the resource-type `buckets` requires metadataKeys {@link #deleteBucket(DeleteBucketRequest) deleteBucket}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataKeys")

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceTypeCollection.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/BulkActionResourceTypeCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.identity.model;
 
 /**
- * Collection of resource types supported by bulk action.
+ * Collection of resource-types supported by a compartment bulk action.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -63,7 +63,7 @@ public class BulkActionResourceTypeCollection {
     }
 
     /**
-     * Collection of resource types supported by bulk action.
+     * Collection of the resource-types supported by a compartment bulk action.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<BulkActionResourceType> items;

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdentityProviderGroupSummary.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/model/IdentityProviderGroupSummary.java
@@ -54,6 +54,15 @@ public class IdentityProviderGroupSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("externalIdentifier")
         private String externalIdentifier;
 
@@ -90,6 +99,7 @@ public class IdentityProviderGroupSummary {
                             id,
                             identityProviderId,
                             displayName,
+                            name,
                             externalIdentifier,
                             timeCreated,
                             timeModified);
@@ -103,6 +113,7 @@ public class IdentityProviderGroupSummary {
                     id(o.getId())
                             .identityProviderId(o.getIdentityProviderId())
                             .displayName(o.getDisplayName())
+                            .name(o.getName())
                             .externalIdentifier(o.getExternalIdentifier())
                             .timeCreated(o.getTimeCreated())
                             .timeModified(o.getTimeModified());
@@ -136,6 +147,12 @@ public class IdentityProviderGroupSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Display name of the group
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
 
     /**
      * Identifier of the group in the identity provider

--- a/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListBulkActionResourceTypesRequest.java
+++ b/bmc-identity/src/main/java/com/oracle/bmc/identity/requests/ListBulkActionResourceTypesRequest.java
@@ -13,13 +13,13 @@ public class ListBulkActionResourceTypesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The type of the bulk action.
+     * The type of bulk action.
      *
      */
     private BulkActionType bulkActionType;
 
     /**
-     * The type of the bulk action.
+     * The type of bulk action.
      *
      **/
     public enum BulkActionType {

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
@@ -502,6 +502,23 @@ public interface ObjectStorage extends AutoCloseable {
     ReencryptBucketResponse reencryptBucket(ReencryptBucketRequest request);
 
     /**
+     * Re-encrypts the data encryption keys that encrypt the object and its chunks. By default, when you create a bucket, the Object Storage
+     * service manages the master encryption key used to encrypt each object's data encryption keys. The encryption mechanism that you specify for
+     * the bucket applies to the objects it contains.
+     * <p>
+     * You can alternatively employ one of these encryption strategies for an object:
+     * <p>
+     * - You can assign a key that you created and control through the Oracle Cloud Infrastructure Vault service.
+     * <p>
+     * - You can encrypt an object using your own encryption key. The key you supply is known as a customer-provided encryption key (SSE-C).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ReencryptObjectResponse reencryptObject(ReencryptObjectRequest request);
+
+    /**
      * Rename an object in the given Object Storage namespace.
      *
      * @param request The request object containing the details to send

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
@@ -784,6 +784,30 @@ public interface ObjectStorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Re-encrypts the data encryption keys that encrypt the object and its chunks. By default, when you create a bucket, the Object Storage
+     * service manages the master encryption key used to encrypt each object's data encryption keys. The encryption mechanism that you specify for
+     * the bucket applies to the objects it contains.
+     * <p>
+     * You can alternatively employ one of these encryption strategies for an object:
+     * <p>
+     * - You can assign a key that you created and control through the Oracle Cloud Infrastructure Vault service.
+     * <p>
+     * - You can encrypt an object using your own encryption key. The key you supply is known as a customer-provided encryption key (SSE-C).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ReencryptObjectResponse> reencryptObject(
+            ReencryptObjectRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ReencryptObjectRequest, ReencryptObjectResponse>
+                    handler);
+
+    /**
      * Rename an object in the given Object Storage namespace.
      *
      *

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsyncClient.java
@@ -3593,6 +3593,95 @@ public class ObjectStorageAsyncClient implements ObjectStorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ReencryptObjectResponse> reencryptObject(
+            final ReencryptObjectRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ReencryptObjectRequest, ReencryptObjectResponse>
+                    handler) {
+        LOG.trace("Called async reencryptObject");
+        final ReencryptObjectRequest interceptedRequest =
+                ReencryptObjectConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReencryptObjectConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ReencryptObjectResponse>
+                transformer = ReencryptObjectConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ReencryptObjectRequest, ReencryptObjectResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ReencryptObjectRequest, ReencryptObjectResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getReencryptObjectDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getReencryptObjectDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ReencryptObjectResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getReencryptObjectDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RenameObjectResponse> renameObject(
             final RenameObjectRequest request,
             final com.oracle.bmc.responses.AsyncHandler<RenameObjectRequest, RenameObjectResponse>

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageClient.java
@@ -1684,6 +1684,38 @@ public class ObjectStorageClient implements ObjectStorage {
     }
 
     @Override
+    public ReencryptObjectResponse reencryptObject(ReencryptObjectRequest request) {
+        LOG.trace("Called reencryptObject");
+        final ReencryptObjectRequest interceptedRequest =
+                ReencryptObjectConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReencryptObjectConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ReencryptObjectResponse>
+                transformer = ReencryptObjectConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getReencryptObjectDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RenameObjectResponse renameObject(RenameObjectRequest request) {
         LOG.trace("Called renameObject");
         final RenameObjectRequest interceptedRequest =

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/ReencryptObjectConverter.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/ReencryptObjectConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.objectstorage.model.*;
+import com.oracle.bmc.objectstorage.requests.*;
+import com.oracle.bmc.objectstorage.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ReencryptObjectConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.objectstorage.requests.ReencryptObjectRequest interceptRequest(
+            com.oracle.bmc.objectstorage.requests.ReencryptObjectRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.objectstorage.requests.ReencryptObjectRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getBucketName(), "bucketName must not be blank");
+        Validate.notBlank(request.getObjectName(), "objectName must not be blank");
+        Validate.notNull(request.getReencryptObjectDetails(), "reencryptObjectDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/")
+                        .path("n")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("b")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBucketName()))
+                        .path("actions")
+                        .path("reencrypt")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getObjectName()));
+
+        if (request.getVersionId() != null) {
+            target =
+                    target.queryParam(
+                            "versionId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVersionId()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcClientRequestId() != null) {
+            ib.header("opc-client-request-id", request.getOpcClientRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse>() {
+                            @Override
+                            public com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.objectstorage.responses
+                                                        .ReencryptObjectResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcClientRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-client-request-id");
+                                if (opcClientRequestIdHeader.isPresent()) {
+                                    builder.opcClientRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-client-request-id",
+                                                    opcClientRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.objectstorage.responses.ReencryptObjectResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ReencryptObjectDetails.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ReencryptObjectDetails.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.model;
+
+/**
+ * The details used to re-encrypt the data encryption keys associated with an object.
+ * You can only specify either a kmsKeyId or an sseCustomerKey in the request payload, not both.
+ * If the request payload is empty, the object is encrypted using the encryption key assigned to the
+ * bucket. The bucket encryption mechanism can either be a master encryption key managed by Oracle or the Vault service.
+ * <p>
+ * - The sseCustomerKey field specifies the customer-provided encryption key (SSE-C) that will be used to re-encrypt the data encryption keys of the
+ *   object and its chunks.
+ * <p>
+ * - The sourceSSECustomerKey field specifies information about the customer-provided encryption key that is currently
+ *   associated with the object source. Specify a value for the sourceSSECustomerKey only if the object
+ *   is encrypted with a customer-provided encryption key.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ReencryptObjectDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ReencryptObjectDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sseCustomerKey")
+        private SSECustomerKeyDetails sseCustomerKey;
+
+        public Builder sseCustomerKey(SSECustomerKeyDetails sseCustomerKey) {
+            this.sseCustomerKey = sseCustomerKey;
+            this.__explicitlySet__.add("sseCustomerKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceSseCustomerKey")
+        private SSECustomerKeyDetails sourceSseCustomerKey;
+
+        public Builder sourceSseCustomerKey(SSECustomerKeyDetails sourceSseCustomerKey) {
+            this.sourceSseCustomerKey = sourceSseCustomerKey;
+            this.__explicitlySet__.add("sourceSseCustomerKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ReencryptObjectDetails build() {
+            ReencryptObjectDetails __instance__ =
+                    new ReencryptObjectDetails(kmsKeyId, sseCustomerKey, sourceSseCustomerKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ReencryptObjectDetails o) {
+            Builder copiedBuilder =
+                    kmsKeyId(o.getKmsKeyId())
+                            .sseCustomerKey(o.getSseCustomerKey())
+                            .sourceSseCustomerKey(o.getSourceSseCustomerKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the master encryption key used to call the Vault
+     * service to re-encrypt the data encryption keys associated with the object and its chunks. If the kmsKeyId value is
+     * empty, whether null or an empty string, the API will perform re-encryption by using the kmsKeyId associated with the
+     * bucket or the master encryption key managed by Oracle, depending on the bucket encryption mechanism.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sseCustomerKey")
+    SSECustomerKeyDetails sseCustomerKey;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceSseCustomerKey")
+    SSECustomerKeyDetails sourceSseCustomerKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/SSECustomerKeyDetails.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/SSECustomerKeyDetails.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.model;
+
+/**
+ * Specifies the details of the customer-provided encryption key (SSE-C) associated with an object.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SSECustomerKeyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SSECustomerKeyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("algorithm")
+        private Algorithm algorithm;
+
+        public Builder algorithm(Algorithm algorithm) {
+            this.algorithm = algorithm;
+            this.__explicitlySet__.add("algorithm");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keySha256")
+        private String keySha256;
+
+        public Builder keySha256(String keySha256) {
+            this.keySha256 = keySha256;
+            this.__explicitlySet__.add("keySha256");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SSECustomerKeyDetails build() {
+            SSECustomerKeyDetails __instance__ =
+                    new SSECustomerKeyDetails(algorithm, key, keySha256);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SSECustomerKeyDetails o) {
+            Builder copiedBuilder =
+                    algorithm(o.getAlgorithm()).key(o.getKey()).keySha256(o.getKeySha256());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Specifies the encryption algorithm. The only supported value is \"AES256\".
+     *
+     **/
+    public enum Algorithm {
+        Aes256("AES256"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Algorithm> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Algorithm v : Algorithm.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Algorithm(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Algorithm create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Algorithm: " + key);
+        }
+    };
+    /**
+     * Specifies the encryption algorithm. The only supported value is \"AES256\".
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("algorithm")
+    Algorithm algorithm;
+
+    /**
+     * Specifies the base64-encoded 256-bit encryption key to use to encrypt or decrypt the object data.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Specifies the base64-encoded SHA256 hash of the encryption key. This value is used to check the integrity
+     * of the encryption key.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("keySha256")
+    String keySha256;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/CopyObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/CopyObjectRequest.java
@@ -35,7 +35,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -43,7 +43,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -51,7 +51,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;
@@ -59,7 +59,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm to use to decrypt the source
      * object. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSourceSseCustomerAlgorithm;
@@ -67,7 +67,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to decrypt
      * the source object. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSourceSseCustomerKey;
@@ -76,7 +76,7 @@ public class CopyObjectRequest extends com.oracle.bmc.requests.BmcRequest<CopyOb
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key used to
      * decrypt the source object. This value is used to check the integrity of the encryption key. For
      * more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSourceSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/CreateMultipartUploadRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/CreateMultipartUploadRequest.java
@@ -51,7 +51,7 @@ public class CreateMultipartUploadRequest
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -59,7 +59,7 @@ public class CreateMultipartUploadRequest
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -67,7 +67,7 @@ public class CreateMultipartUploadRequest
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetObjectRequest.java
@@ -64,7 +64,7 @@ public class GetObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.la
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -72,7 +72,7 @@ public class GetObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -80,7 +80,7 @@ public class GetObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/HeadObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/HeadObjectRequest.java
@@ -57,7 +57,7 @@ public class HeadObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.l
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -65,7 +65,7 @@ public class HeadObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -73,7 +73,7 @@ public class HeadObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/PutObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/PutObjectRequest.java
@@ -124,7 +124,7 @@ public class PutObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.io
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -132,7 +132,7 @@ public class PutObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.io
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -140,7 +140,7 @@ public class PutObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.io
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/ReencryptObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/ReencryptObjectRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.requests;
+
+import com.oracle.bmc.objectstorage.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ReencryptObjectRequest
+        extends com.oracle.bmc.requests.BmcRequest<ReencryptObjectDetails> {
+
+    /**
+     * The Object Storage namespace used for the request.
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the bucket. Avoid entering confidential information.
+     * Example: `my-new-bucket1`
+     *
+     */
+    private String bucketName;
+
+    /**
+     * The name of the object. Avoid entering confidential information.
+     * Example: `test/object1.log`
+     *
+     */
+    private String objectName;
+
+    /**
+     * Request object for re-encrypting the data encryption key associated with an object.
+     */
+    private ReencryptObjectDetails reencryptObjectDetails;
+
+    /**
+     * VersionId used to identify a particular version of the object
+     */
+    private String versionId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcClientRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ReencryptObjectDetails getBody$() {
+        return reencryptObjectDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ReencryptObjectRequest, ReencryptObjectDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ReencryptObjectRequest o) {
+            namespaceName(o.getNamespaceName());
+            bucketName(o.getBucketName());
+            objectName(o.getObjectName());
+            reencryptObjectDetails(o.getReencryptObjectDetails());
+            versionId(o.getVersionId());
+            opcClientRequestId(o.getOpcClientRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ReencryptObjectRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ReencryptObjectRequest
+         */
+        public ReencryptObjectRequest build() {
+            ReencryptObjectRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ReencryptObjectDetails body) {
+            reencryptObjectDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/UploadPartRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/UploadPartRequest.java
@@ -88,7 +88,7 @@ public class UploadPartRequest extends com.oracle.bmc.requests.BmcRequest<java.i
 
     /**
      * The optional header that specifies \"AES256\" as the encryption algorithm. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerAlgorithm;
@@ -96,7 +96,7 @@ public class UploadPartRequest extends com.oracle.bmc.requests.BmcRequest<java.i
     /**
      * The optional header that specifies the base64-encoded 256-bit encryption key to use to encrypt or
      * decrypt the data. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKey;
@@ -104,7 +104,7 @@ public class UploadPartRequest extends com.oracle.bmc.requests.BmcRequest<java.i
     /**
      * The optional header that specifies the base64-encoded SHA256 hash of the encryption key. This
      * value is used to check the integrity of the encryption key. For more information, see
-     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourecryptionkeys.htm).
+     * [Using Your Own Keys for Server-Side Encryption](https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm).
      *
      */
     private String opcSseCustomerKeySha256;

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/ReencryptObjectResponse.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/ReencryptObjectResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.responses;
+
+import com.oracle.bmc.objectstorage.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ReencryptObjectResponse {
+
+    /**
+     * Echoes back the value passed in the opc-client-request-id header, for use by clients when debugging.
+     */
+    private String opcClientRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular
+     * request, provide this request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ReencryptObjectResponse o) {
+            opcClientRequestId(o.getOpcClientRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.1</version>
+    <version>1.19.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.1</version>
+      <version>1.19.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.19.1</version>
+  <version>1.19.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for registering and deregistering autonomous dedicated databases with Data Safe in the Database service

- Support for switching between non-private-endpoints and private endpoints on autonomous databases in the Database service

- Support for returning group names when listing identity provider groups in the Identity service

- Support for server-side object re-encryption in the Object Storage service

- Support for private endpoint (ingress) and public endpoint whitelisting in the Analytics Cloud service