### PR TITLE
Releasing version 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.20.0 - 2020-07-28
+### Added
+- Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region
+- Support for updating the fault domain and launch options of VM instances in the Compute service
+- Support for image capability schemas and schema versions in the Compute service
+- Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service
+- Support for automatic performance and cost tuning on volumes in the Block Storage service
+
+
+### Breaking changes
+- Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service
+
 ## 1.19.4 - 2020-07-21
 ### Added
 - Support for license types on instances in the Content and Experience service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,324 +19,324 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -95,6 +95,7 @@ public final class Region implements Serializable, Comparable<Region> {
     public static final Region UK_LONDON_1 = register("uk-london-1", Realm.OC1, "lhr");
     public static final Region US_ASHBURN_1 = register("us-ashburn-1", Realm.OC1, "iad");
     public static final Region US_PHOENIX_1 = register("us-phoenix-1", Realm.OC1, "phx");
+    public static final Region US_SANJOSE_1 = register("us-sanjose-1", Realm.OC1, "sjc");
 
     // OC2
     public static final Region US_LANGLEY_1 = register("us-langley-1", Realm.OC2, "lfi");

--- a/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
@@ -84,7 +84,7 @@ public class RegionTest {
     @BeforeClass
     public static void init() throws Exception {
         String regionBlob =
-                "{ \"realmKey\" : \"OC7\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"SDO\",\"regionIdentifier\" : \"us-sandiego-1\"}";
+                "{ \"realmKey\" : \"UCX\",\"realmDomainComponent\" : \"oracle-foobar.com\",\"regionKey\" : \"ABV\",\"regionIdentifier\" : \"us-abv-1\"}";
         Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         setEnvironmentVariable(newEnvMap);
@@ -97,7 +97,7 @@ public class RegionTest {
                         .property(ClientProperties.CONNECT_TIMEOUT, 10000)
                         .property(ClientProperties.READ_TIMEOUT, 60000));
         Region.hasUsedInstanceMetadataService = false;
-        Region.enableInstanceMetadataService();
+        Region.skipInstanceMetadataService();
     }
 
     @Test
@@ -336,21 +336,21 @@ public class RegionTest {
     @Test
     public void checkIfValidRegionSchema() {
         RegionSchema regionSchema =
-                new RegionSchema("OC6", "oraclensrcloud.com", "FRD", "us-florida-1");
+                new RegionSchema("RTC", "foobar-oraclecloud.com", "YTE", "us-yte-1");
         Assert.assertTrue(RegionSchema.isValid(regionSchema));
     }
 
     @Test
     public void checkIfInValidRealm() {
         RegionSchema regionSchema =
-                new RegionSchema(null, "oraclensrcloud.com", "FRD", "us-florida-1");
+                new RegionSchema(null, "foobar-oraclecloud.com", "YTE", "us-yte-1");
         Assert.assertFalse(RegionSchema.isValid(regionSchema));
     }
 
     @Test
     public void checkIfEmptyRealm() {
         RegionSchema regionSchema =
-                new RegionSchema("", "oraclensrcloud.com", "FRD", "us-florida-1");
+                new RegionSchema("", "foobar-oraclecloud.com", "YTE", "us-yte-1");
         Assert.assertFalse(RegionSchema.isValid(regionSchema));
     }
 
@@ -369,7 +369,7 @@ public class RegionTest {
                         .property(ClientProperties.READ_TIMEOUT, 5000));
 
         String regionBlob =
-                "{ \"realmKey\" : \"OC1\",\"realmDomainComponent\" : \"\",\"regionKey\" : \"MSW\",\"regionIdentifier\" : \"us-moscow-1\"}";
+                "{ \"realmKey\" : \"YCX\",\"realmDomainComponent\" : \"\",\"regionKey\" : \"MSW\",\"regionIdentifier\" : \"us-moscow-1\"}";
         Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         setEnvironmentVariable(newEnvMap);
@@ -379,22 +379,21 @@ public class RegionTest {
     @Test
     public void testExistingEnvRegion() {
 
-        Region region = Region.fromRegionCodeOrId("SDO");
+        Region region = Region.fromRegionCodeOrId("ABV");
         Region US_SAN_DIEGO_TST =
-                Region.register(
-                        "us-sandiego-1", Realm.register("OC7", "oraclensrcloud.com"), "SDO");
+                Region.register("us-abv-1", Realm.register("UCX", "oracle-foobar.com"), "ABV");
         assertSame(US_SAN_DIEGO_TST, region);
     }
 
     @Test
     public void testExistingDuplicateEnv() throws Exception {
         String regionBlob =
-                "{ \"realmKey\" : \"OC7\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"SDO\",\"regionIdentifier\" : \"us-sandiego-1\"}";
+                "{ \"realmKey\" : \"UCX\",\"realmDomainComponent\" : \"oracle-foobar.com\",\"regionKey\" : \"ABV\",\"regionIdentifier\" : \"us-abv-1\"}";
         Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         setEnvironmentVariable(newEnvMap);
         int count = Region.values().length;
-        Region.fromRegionCodeOrId("SDO");
+        Region.fromRegionCodeOrId("ABV");
         int afterCheckEnvCount = Region.values().length;
         assertSame(count, afterCheckEnvCount);
     }
@@ -407,11 +406,11 @@ public class RegionTest {
                         .property(ClientProperties.READ_TIMEOUT, 5000));
 
         String regionBlob =
-                "{ \"realmKey\" : \"OC6\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"DBI\",\"regionIdentifier\" : \"us-dubai-1\"}";
+                "{ \"realmKey\" : \"RTC\",\"realmDomainComponent\" : \"oracle-cloudfoobar.com\",\"regionKey\" : \"HHH\",\"regionIdentifier\" : \"us-hhh-1\"}";
         Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         setEnvironmentVariable(newEnvMap);
-        Region.fromRegionCodeOrId("DBI");
+        Region.fromRegionCodeOrId("HHH");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -422,7 +421,7 @@ public class RegionTest {
                         .property(ClientProperties.READ_TIMEOUT, 5000));
 
         String regionBlob =
-                "{ \"realmKey\" : \"\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"BRN\",\"regionIdentifier\" : \"us-berlin-1\"}";
+                "{ \"realmKey\" : \"\",\"realmDomainComponent\" : \"foobar-oraclecloud.com\",\"regionKey\" : \"BRN\",\"regionIdentifier\" : \"us-berlin-1\"}";
         Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         setEnvironmentVariable(newEnvMap);
@@ -436,7 +435,7 @@ public class RegionTest {
         if (file.exists()) {
             Region region = Region.fromRegionCodeOrId("ATL");
             Region US_ATLANTA_TST =
-                    register("ap-atlanta-1", Realm.register("OC6", "oraclecloud.com"), "atl");
+                    register("ap-atl-1", Realm.register("RTC", "foobar-oraclecloud.com"), "atl");
             assertSame(US_ATLANTA_TST, region);
         }
     }

--- a/bmc-common/src/test/java/com/oracle/bmc/model/internal/JsonConverterTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/model/internal/JsonConverterTest.java
@@ -17,19 +17,19 @@ public class JsonConverterTest {
     public void parseJsonSchema() {
 
         String regionBlob =
-                "{ \"realmKey\" : \"OC5\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"TIW\",\"regionIdentifier\" : \"us-tacoma-1\"}";
+                "{ \"realmKey\" : \"RTC\",\"realmDomainComponent\" : \"oraclecloud-foobar.com\",\"regionKey\" : \"rrr\",\"regionIdentifier\" : \"us-rrr-1\"}";
         RegionSchema regionSchema = JsonConverter.jsonBlobToObject(regionBlob, RegionSchema.class);
-        assertThat(regionSchema.getRegionIdentifier(), is("us-tacoma-1"));
-        assertThat(regionSchema.getRegionKey(), is("TIW"));
-        assertThat(regionSchema.getRealmKey(), is("OC5"));
-        assertThat(regionSchema.getRealmDomainComponent(), is("oraclensrcloud.com"));
+        assertThat(regionSchema.getRegionIdentifier(), is("us-rrr-1"));
+        assertThat(regionSchema.getRegionKey(), is("rrr"));
+        assertThat(regionSchema.getRealmKey(), is("RTC"));
+        assertThat(regionSchema.getRealmDomainComponent(), is("oraclecloud-foobar.com"));
     }
 
     @Test
     public void parseJsonSchemaInvalid() {
 
         String regionBlob =
-                "{ \"realmKey\" :: \"OC5\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"TIW\",\"regionIdentifier\" : \"us-tacoma-1\"}";
+                "{ \"realmKey\" :: \"RTC\",\"realmDomainComponent\" : \"oraclecloud-foobar.com\",\"regionKey\" : \"rrr\",\"regionIdentifier\" : \"us-rrr-1\"}";
         RegionSchema regionSchema = JsonConverter.jsonBlobToObject(regionBlob, RegionSchema.class);
         assertNull(regionSchema);
     }
@@ -37,7 +37,7 @@ public class JsonConverterTest {
     @Test
     public void parseJsonArray() {
         String jsonArr =
-                "[{ \"realmKey\" : \"OC6\",\"realmDomainComponent\" : \"oraclecloud.com\",\"regionKey\" : \"ATL\",\"regionIdentifier\" : \"ap-atlanta-1\"},{ \"realmKey\" :\"OC7\",\"realmDomainComponent\" : \"oraclensrcloud.com\",\"regionKey\" : \"LAV\",\"regionIdentifier\" : \"us-lasvegas-1\"}]";
+                "[{ \"realmKey\" : \"RYT\",\"realmDomainComponent\" : \"oracleclour-bar.com\",\"regionKey\" : \"atl\",\"regionIdentifier\" : \"ap-atl-1\"},{ \"realmKey\" :\"YUT\",\"realmDomainComponent\" : \"oraclefoobar-cloud.com\",\"regionKey\" : \"LAV\",\"regionIdentifier\" : \"us-lav-1\"}]";
         RegionSchema[] regionSchemas =
                 JsonConverter.jsonBlobToObject(jsonArr, RegionSchema[].class);
         assertThat(regionSchemas.length, is(2));
@@ -46,9 +46,9 @@ public class JsonConverterTest {
     @Test
     public void parseRegionObjToJson() {
         String regionExpected =
-                "{\"realmKey\":\"OC6\",\"realmDomainComponent\":\"oraclensrcloud.com\",\"regionKey\":\"FRD\",\"regionIdentifier\":\"us-florida-1\"}";
+                "{\"realmKey\":\"RTC\",\"realmDomainComponent\":\"oraclecloud-foobar.com\",\"regionKey\":\"gty\",\"regionIdentifier\":\"us-gty-1\"}";
         RegionSchema regionSchema =
-                new RegionSchema("OC6", "oraclensrcloud.com", "FRD", "us-florida-1");
+                new RegionSchema("RTC", "oraclecloud-foobar.com", "gty", "us-gty-1");
         String regionBlob = JsonConverter.objectToJsonBlob(regionSchema);
         assertThat(regionExpected, is(regionBlob));
     }

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Compute.java
@@ -110,6 +110,19 @@ public interface Compute extends AutoCloseable {
     CaptureConsoleHistoryResponse captureConsoleHistory(CaptureConsoleHistoryRequest request);
 
     /**
+     * Moves a compute image capability schema into a different compartment within the same tenancy.
+     * For information about moving resources between compartments, see
+     *         [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeComputeImageCapabilitySchemaCompartmentResponse
+            changeComputeImageCapabilitySchemaCompartment(
+                    ChangeComputeImageCapabilitySchemaCompartmentRequest request);
+
+    /**
      * Moves a dedicated virtual machine host from one compartment to another.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -153,6 +166,16 @@ public interface Compute extends AutoCloseable {
      */
     CreateAppCatalogSubscriptionResponse createAppCatalogSubscription(
             CreateAppCatalogSubscriptionRequest request);
+
+    /**
+     * Creates compute image capability schema.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateComputeImageCapabilitySchemaResponse createComputeImageCapabilitySchema(
+            CreateComputeImageCapabilitySchemaRequest request);
 
     /**
      * Creates a new dedicated virtual machine host in the specified compartment and the specified availability domain.
@@ -219,6 +242,16 @@ public interface Compute extends AutoCloseable {
      */
     DeleteAppCatalogSubscriptionResponse deleteAppCatalogSubscription(
             DeleteAppCatalogSubscriptionRequest request);
+
+    /**
+     * Deletes the specified Compute Image Capability Schema
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteComputeImageCapabilitySchemaResponse deleteComputeImageCapabilitySchema(
+            DeleteComputeImageCapabilitySchemaRequest request);
 
     /**
      * Deletes the specified console history metadata and the console history data.
@@ -350,6 +383,35 @@ public interface Compute extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetBootVolumeAttachmentResponse getBootVolumeAttachment(GetBootVolumeAttachmentRequest request);
+
+    /**
+     * Gets the specified Compute Global Image Capability Schema
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetComputeGlobalImageCapabilitySchemaResponse getComputeGlobalImageCapabilitySchema(
+            GetComputeGlobalImageCapabilitySchemaRequest request);
+
+    /**
+     * Gets the specified Compute Global Image Capability Schema Version
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetComputeGlobalImageCapabilitySchemaVersionResponse
+            getComputeGlobalImageCapabilitySchemaVersion(
+                    GetComputeGlobalImageCapabilitySchemaVersionRequest request);
+
+    /**
+     * Gets the specified Compute Image Capability Schema
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetComputeImageCapabilitySchemaResponse getComputeImageCapabilitySchema(
+            GetComputeImageCapabilitySchemaRequest request);
 
     /**
      * Shows the metadata for the specified console history.
@@ -554,6 +616,37 @@ public interface Compute extends AutoCloseable {
             ListBootVolumeAttachmentsRequest request);
 
     /**
+     * Lists Compute Global Image Capability Schema versions in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListComputeGlobalImageCapabilitySchemaVersionsResponse
+            listComputeGlobalImageCapabilitySchemaVersions(
+                    ListComputeGlobalImageCapabilitySchemaVersionsRequest request);
+
+    /**
+     * Lists Compute Global Image Capability Schema in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListComputeGlobalImageCapabilitySchemasResponse listComputeGlobalImageCapabilitySchemas(
+            ListComputeGlobalImageCapabilitySchemasRequest request);
+
+    /**
+     * Lists Compute Image Capability Schema in the specified compartment. You can also query by a specific imageId.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListComputeImageCapabilitySchemasResponse listComputeImageCapabilitySchemas(
+            ListComputeImageCapabilitySchemasRequest request);
+
+    /**
      * Lists the console history metadata for the specified compartment or instance.
      *
      * @param request The request object containing the details to send
@@ -718,6 +811,16 @@ public interface Compute extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     TerminateInstanceResponse terminateInstance(TerminateInstanceRequest request);
+
+    /**
+     * Updates the specified Compute Image Capability Schema
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateComputeImageCapabilitySchemaResponse updateComputeImageCapabilitySchema(
+            UpdateComputeImageCapabilitySchemaRequest request);
 
     /**
      * Updates the specified console history metadata.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsync.java
@@ -146,6 +146,27 @@ public interface ComputeAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Moves a compute image capability schema into a different compartment within the same tenancy.
+     * For information about moving resources between compartments, see
+     *         [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeComputeImageCapabilitySchemaCompartmentResponse>
+            changeComputeImageCapabilitySchemaCompartment(
+                    ChangeComputeImageCapabilitySchemaCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeComputeImageCapabilitySchemaCompartmentRequest,
+                                    ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                            handler);
+
+    /**
      * Moves a dedicated virtual machine host from one compartment to another.
      *
      * @param request The request object containing the details to send
@@ -221,6 +242,25 @@ public interface ComputeAsync extends AutoCloseable {
                             CreateAppCatalogSubscriptionRequest,
                             CreateAppCatalogSubscriptionResponse>
                     handler);
+
+    /**
+     * Creates compute image capability schema.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateComputeImageCapabilitySchemaResponse>
+            createComputeImageCapabilitySchema(
+                    CreateComputeImageCapabilitySchemaRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    CreateComputeImageCapabilitySchemaRequest,
+                                    CreateComputeImageCapabilitySchemaResponse>
+                            handler);
 
     /**
      * Creates a new dedicated virtual machine host in the specified compartment and the specified availability domain.
@@ -318,6 +358,25 @@ public interface ComputeAsync extends AutoCloseable {
                             DeleteAppCatalogSubscriptionRequest,
                             DeleteAppCatalogSubscriptionResponse>
                     handler);
+
+    /**
+     * Deletes the specified Compute Image Capability Schema
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteComputeImageCapabilitySchemaResponse>
+            deleteComputeImageCapabilitySchema(
+                    DeleteComputeImageCapabilitySchemaRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteComputeImageCapabilitySchemaRequest,
+                                    DeleteComputeImageCapabilitySchemaResponse>
+                            handler);
 
     /**
      * Deletes the specified console history metadata and the console history data.
@@ -540,6 +599,61 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             GetBootVolumeAttachmentRequest, GetBootVolumeAttachmentResponse>
                     handler);
+
+    /**
+     * Gets the specified Compute Global Image Capability Schema
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetComputeGlobalImageCapabilitySchemaResponse>
+            getComputeGlobalImageCapabilitySchema(
+                    GetComputeGlobalImageCapabilitySchemaRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeGlobalImageCapabilitySchemaRequest,
+                                    GetComputeGlobalImageCapabilitySchemaResponse>
+                            handler);
+
+    /**
+     * Gets the specified Compute Global Image Capability Schema Version
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetComputeGlobalImageCapabilitySchemaVersionResponse>
+            getComputeGlobalImageCapabilitySchemaVersion(
+                    GetComputeGlobalImageCapabilitySchemaVersionRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeGlobalImageCapabilitySchemaVersionRequest,
+                                    GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                            handler);
+
+    /**
+     * Gets the specified Compute Image Capability Schema
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetComputeImageCapabilitySchemaResponse>
+            getComputeImageCapabilitySchema(
+                    GetComputeImageCapabilitySchemaRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeImageCapabilitySchemaRequest,
+                                    GetComputeImageCapabilitySchemaResponse>
+                            handler);
 
     /**
      * Shows the metadata for the specified console history.
@@ -866,6 +980,63 @@ public interface ComputeAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists Compute Global Image Capability Schema versions in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+            listComputeGlobalImageCapabilitySchemaVersions(
+                    ListComputeGlobalImageCapabilitySchemaVersionsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                                    ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                            handler);
+
+    /**
+     * Lists Compute Global Image Capability Schema in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListComputeGlobalImageCapabilitySchemasResponse>
+            listComputeGlobalImageCapabilitySchemas(
+                    ListComputeGlobalImageCapabilitySchemasRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeGlobalImageCapabilitySchemasRequest,
+                                    ListComputeGlobalImageCapabilitySchemasResponse>
+                            handler);
+
+    /**
+     * Lists Compute Image Capability Schema in the specified compartment. You can also query by a specific imageId.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListComputeImageCapabilitySchemasResponse>
+            listComputeImageCapabilitySchemas(
+                    ListComputeImageCapabilitySchemasRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeImageCapabilitySchemasRequest,
+                                    ListComputeImageCapabilitySchemasResponse>
+                            handler);
+
+    /**
      * Lists the console history metadata for the specified compartment or instance.
      *
      *
@@ -1148,6 +1319,25 @@ public interface ComputeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             TerminateInstanceRequest, TerminateInstanceResponse>
                     handler);
+
+    /**
+     * Updates the specified Compute Image Capability Schema
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateComputeImageCapabilitySchemaResponse>
+            updateComputeImageCapabilitySchema(
+                    UpdateComputeImageCapabilitySchemaRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateComputeImageCapabilitySchemaRequest,
+                                    UpdateComputeImageCapabilitySchemaResponse>
+                            handler);
 
     /**
      * Updates the specified console history metadata.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeAsyncClient.java
@@ -754,6 +754,107 @@ public class ComputeAsyncClient implements ComputeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeComputeImageCapabilitySchemaCompartmentResponse>
+            changeComputeImageCapabilitySchemaCompartment(
+                    final ChangeComputeImageCapabilitySchemaCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeComputeImageCapabilitySchemaCompartmentRequest,
+                                    ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeComputeImageCapabilitySchemaCompartment");
+        final ChangeComputeImageCapabilitySchemaCompartmentRequest interceptedRequest =
+                ChangeComputeImageCapabilitySchemaCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeComputeImageCapabilitySchemaCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                transformer = ChangeComputeImageCapabilitySchemaCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeComputeImageCapabilitySchemaCompartmentRequest,
+                        ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeComputeImageCapabilitySchemaCompartmentRequest,
+                            ChangeComputeImageCapabilitySchemaCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeComputeImageCapabilitySchemaCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest
+                                .getChangeComputeImageCapabilitySchemaCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    ChangeComputeImageCapabilitySchemaCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getChangeComputeImageCapabilitySchemaCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeDedicatedVmHostCompartmentResponse>
             changeDedicatedVmHostCompartment(
                     final ChangeDedicatedVmHostCompartmentRequest request,
@@ -1125,6 +1226,103 @@ public class ComputeAsyncClient implements ComputeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateComputeImageCapabilitySchemaResponse>
+            createComputeImageCapabilitySchema(
+                    final CreateComputeImageCapabilitySchemaRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    CreateComputeImageCapabilitySchemaRequest,
+                                    CreateComputeImageCapabilitySchemaResponse>
+                            handler) {
+        LOG.trace("Called async createComputeImageCapabilitySchema");
+        final CreateComputeImageCapabilitySchemaRequest interceptedRequest =
+                CreateComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateComputeImageCapabilitySchemaResponse>
+                transformer = CreateComputeImageCapabilitySchemaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateComputeImageCapabilitySchemaRequest,
+                        CreateComputeImageCapabilitySchemaResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateComputeImageCapabilitySchemaRequest,
+                            CreateComputeImageCapabilitySchemaResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getCreateComputeImageCapabilitySchemaDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateComputeImageCapabilitySchemaDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateComputeImageCapabilitySchemaResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest
+                                            .getCreateComputeImageCapabilitySchemaDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateDedicatedVmHostResponse> createDedicatedVmHost(
             final CreateDedicatedVmHostRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1460,6 +1658,86 @@ public class ComputeAsyncClient implements ComputeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, DeleteAppCatalogSubscriptionResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteComputeImageCapabilitySchemaResponse>
+            deleteComputeImageCapabilitySchema(
+                    final DeleteComputeImageCapabilitySchemaRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteComputeImageCapabilitySchemaRequest,
+                                    DeleteComputeImageCapabilitySchemaResponse>
+                            handler) {
+        LOG.trace("Called async deleteComputeImageCapabilitySchema");
+        final DeleteComputeImageCapabilitySchemaRequest interceptedRequest =
+                DeleteComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteComputeImageCapabilitySchemaResponse>
+                transformer = DeleteComputeImageCapabilitySchemaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteComputeImageCapabilitySchemaRequest,
+                        DeleteComputeImageCapabilitySchemaResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteComputeImageCapabilitySchemaRequest,
+                            DeleteComputeImageCapabilitySchemaResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteComputeImageCapabilitySchemaResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -2385,6 +2663,250 @@ public class ComputeAsyncClient implements ComputeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetComputeGlobalImageCapabilitySchemaResponse>
+            getComputeGlobalImageCapabilitySchema(
+                    final GetComputeGlobalImageCapabilitySchemaRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeGlobalImageCapabilitySchemaRequest,
+                                    GetComputeGlobalImageCapabilitySchemaResponse>
+                            handler) {
+        LOG.trace("Called async getComputeGlobalImageCapabilitySchema");
+        final GetComputeGlobalImageCapabilitySchemaRequest interceptedRequest =
+                GetComputeGlobalImageCapabilitySchemaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeGlobalImageCapabilitySchemaConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetComputeGlobalImageCapabilitySchemaResponse>
+                transformer = GetComputeGlobalImageCapabilitySchemaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetComputeGlobalImageCapabilitySchemaRequest,
+                        GetComputeGlobalImageCapabilitySchemaResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetComputeGlobalImageCapabilitySchemaRequest,
+                            GetComputeGlobalImageCapabilitySchemaResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetComputeGlobalImageCapabilitySchemaResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetComputeGlobalImageCapabilitySchemaVersionResponse>
+            getComputeGlobalImageCapabilitySchemaVersion(
+                    final GetComputeGlobalImageCapabilitySchemaVersionRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeGlobalImageCapabilitySchemaVersionRequest,
+                                    GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                            handler) {
+        LOG.trace("Called async getComputeGlobalImageCapabilitySchemaVersion");
+        final GetComputeGlobalImageCapabilitySchemaVersionRequest interceptedRequest =
+                GetComputeGlobalImageCapabilitySchemaVersionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeGlobalImageCapabilitySchemaVersionConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                transformer = GetComputeGlobalImageCapabilitySchemaVersionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetComputeGlobalImageCapabilitySchemaVersionRequest,
+                        GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetComputeGlobalImageCapabilitySchemaVersionRequest,
+                            GetComputeGlobalImageCapabilitySchemaVersionResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    GetComputeGlobalImageCapabilitySchemaVersionResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetComputeImageCapabilitySchemaResponse>
+            getComputeImageCapabilitySchema(
+                    final GetComputeImageCapabilitySchemaRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetComputeImageCapabilitySchemaRequest,
+                                    GetComputeImageCapabilitySchemaResponse>
+                            handler) {
+        LOG.trace("Called async getComputeImageCapabilitySchema");
+        final GetComputeImageCapabilitySchemaRequest interceptedRequest =
+                GetComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetComputeImageCapabilitySchemaResponse>
+                transformer = GetComputeImageCapabilitySchemaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetComputeImageCapabilitySchemaRequest,
+                        GetComputeImageCapabilitySchemaResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetComputeImageCapabilitySchemaRequest,
+                            GetComputeImageCapabilitySchemaResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetComputeImageCapabilitySchemaResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -3637,6 +4159,251 @@ public class ComputeAsyncClient implements ComputeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+            listComputeGlobalImageCapabilitySchemaVersions(
+                    final ListComputeGlobalImageCapabilitySchemaVersionsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                                    ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                            handler) {
+        LOG.trace("Called async listComputeGlobalImageCapabilitySchemaVersions");
+        final ListComputeGlobalImageCapabilitySchemaVersionsRequest interceptedRequest =
+                ListComputeGlobalImageCapabilitySchemaVersionsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeGlobalImageCapabilitySchemaVersionsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                transformer =
+                        ListComputeGlobalImageCapabilitySchemaVersionsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                            ListComputeGlobalImageCapabilitySchemaVersionsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    ListComputeGlobalImageCapabilitySchemaVersionsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListComputeGlobalImageCapabilitySchemasResponse>
+            listComputeGlobalImageCapabilitySchemas(
+                    final ListComputeGlobalImageCapabilitySchemasRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeGlobalImageCapabilitySchemasRequest,
+                                    ListComputeGlobalImageCapabilitySchemasResponse>
+                            handler) {
+        LOG.trace("Called async listComputeGlobalImageCapabilitySchemas");
+        final ListComputeGlobalImageCapabilitySchemasRequest interceptedRequest =
+                ListComputeGlobalImageCapabilitySchemasConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeGlobalImageCapabilitySchemasConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListComputeGlobalImageCapabilitySchemasResponse>
+                transformer = ListComputeGlobalImageCapabilitySchemasConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListComputeGlobalImageCapabilitySchemasRequest,
+                        ListComputeGlobalImageCapabilitySchemasResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListComputeGlobalImageCapabilitySchemasRequest,
+                            ListComputeGlobalImageCapabilitySchemasResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListComputeGlobalImageCapabilitySchemasResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListComputeImageCapabilitySchemasResponse>
+            listComputeImageCapabilitySchemas(
+                    final ListComputeImageCapabilitySchemasRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListComputeImageCapabilitySchemasRequest,
+                                    ListComputeImageCapabilitySchemasResponse>
+                            handler) {
+        LOG.trace("Called async listComputeImageCapabilitySchemas");
+        final ListComputeImageCapabilitySchemasRequest interceptedRequest =
+                ListComputeImageCapabilitySchemasConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeImageCapabilitySchemasConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListComputeImageCapabilitySchemasResponse>
+                transformer = ListComputeImageCapabilitySchemasConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListComputeImageCapabilitySchemasRequest,
+                        ListComputeImageCapabilitySchemasResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListComputeImageCapabilitySchemasRequest,
+                            ListComputeImageCapabilitySchemasResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListComputeImageCapabilitySchemasResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListConsoleHistoriesResponse> listConsoleHistories(
             final ListConsoleHistoriesRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -4774,6 +5541,103 @@ public class ComputeAsyncClient implements ComputeAsync {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
                             return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateComputeImageCapabilitySchemaResponse>
+            updateComputeImageCapabilitySchema(
+                    final UpdateComputeImageCapabilitySchemaRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateComputeImageCapabilitySchemaRequest,
+                                    UpdateComputeImageCapabilitySchemaResponse>
+                            handler) {
+        LOG.trace("Called async updateComputeImageCapabilitySchema");
+        final UpdateComputeImageCapabilitySchemaRequest interceptedRequest =
+                UpdateComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateComputeImageCapabilitySchemaResponse>
+                transformer = UpdateComputeImageCapabilitySchemaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateComputeImageCapabilitySchemaRequest,
+                        UpdateComputeImageCapabilitySchemaResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateComputeImageCapabilitySchemaRequest,
+                            UpdateComputeImageCapabilitySchemaResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest
+                                            .getUpdateComputeImageCapabilitySchemaDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateComputeImageCapabilitySchemaDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateComputeImageCapabilitySchemaResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest
+                                            .getUpdateComputeImageCapabilitySchemaDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     });
         } else {

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputeClient.java
@@ -586,6 +586,44 @@ public class ComputeClient implements Compute {
     }
 
     @Override
+    public ChangeComputeImageCapabilitySchemaCompartmentResponse
+            changeComputeImageCapabilitySchemaCompartment(
+                    ChangeComputeImageCapabilitySchemaCompartmentRequest request) {
+        LOG.trace("Called changeComputeImageCapabilitySchemaCompartment");
+        final ChangeComputeImageCapabilitySchemaCompartmentRequest interceptedRequest =
+                ChangeComputeImageCapabilitySchemaCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeComputeImageCapabilitySchemaCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                transformer = ChangeComputeImageCapabilitySchemaCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeComputeImageCapabilitySchemaCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeDedicatedVmHostCompartmentResponse changeDedicatedVmHostCompartment(
             ChangeDedicatedVmHostCompartmentRequest request) {
         LOG.trace("Called changeDedicatedVmHostCompartment");
@@ -724,6 +762,41 @@ public class ComputeClient implements Compute {
     }
 
     @Override
+    public CreateComputeImageCapabilitySchemaResponse createComputeImageCapabilitySchema(
+            CreateComputeImageCapabilitySchemaRequest request) {
+        LOG.trace("Called createComputeImageCapabilitySchema");
+        final CreateComputeImageCapabilitySchemaRequest interceptedRequest =
+                CreateComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateComputeImageCapabilitySchemaResponse>
+                transformer = CreateComputeImageCapabilitySchemaConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getCreateComputeImageCapabilitySchemaDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateDedicatedVmHostResponse createDedicatedVmHost(
             CreateDedicatedVmHostRequest request) {
         LOG.trace("Called createDedicatedVmHost");
@@ -834,6 +907,37 @@ public class ComputeClient implements Compute {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, DeleteAppCatalogSubscriptionResponse>
                 transformer = DeleteAppCatalogSubscriptionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteComputeImageCapabilitySchemaResponse deleteComputeImageCapabilitySchema(
+            DeleteComputeImageCapabilitySchemaRequest request) {
+        LOG.trace("Called deleteComputeImageCapabilitySchema");
+        final DeleteComputeImageCapabilitySchemaRequest interceptedRequest =
+                DeleteComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteComputeImageCapabilitySchemaResponse>
+                transformer = DeleteComputeImageCapabilitySchemaConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1190,6 +1294,100 @@ public class ComputeClient implements Compute {
                 GetBootVolumeAttachmentConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetBootVolumeAttachmentResponse>
                 transformer = GetBootVolumeAttachmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetComputeGlobalImageCapabilitySchemaResponse getComputeGlobalImageCapabilitySchema(
+            GetComputeGlobalImageCapabilitySchemaRequest request) {
+        LOG.trace("Called getComputeGlobalImageCapabilitySchema");
+        final GetComputeGlobalImageCapabilitySchemaRequest interceptedRequest =
+                GetComputeGlobalImageCapabilitySchemaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeGlobalImageCapabilitySchemaConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetComputeGlobalImageCapabilitySchemaResponse>
+                transformer = GetComputeGlobalImageCapabilitySchemaConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetComputeGlobalImageCapabilitySchemaVersionResponse
+            getComputeGlobalImageCapabilitySchemaVersion(
+                    GetComputeGlobalImageCapabilitySchemaVersionRequest request) {
+        LOG.trace("Called getComputeGlobalImageCapabilitySchemaVersion");
+        final GetComputeGlobalImageCapabilitySchemaVersionRequest interceptedRequest =
+                GetComputeGlobalImageCapabilitySchemaVersionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeGlobalImageCapabilitySchemaVersionConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                transformer = GetComputeGlobalImageCapabilitySchemaVersionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetComputeImageCapabilitySchemaResponse getComputeImageCapabilitySchema(
+            GetComputeImageCapabilitySchemaRequest request) {
+        LOG.trace("Called getComputeImageCapabilitySchema");
+        final GetComputeImageCapabilitySchemaRequest interceptedRequest =
+                GetComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetComputeImageCapabilitySchemaResponse>
+                transformer = GetComputeImageCapabilitySchemaConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1678,6 +1876,101 @@ public class ComputeClient implements Compute {
     }
 
     @Override
+    public ListComputeGlobalImageCapabilitySchemaVersionsResponse
+            listComputeGlobalImageCapabilitySchemaVersions(
+                    ListComputeGlobalImageCapabilitySchemaVersionsRequest request) {
+        LOG.trace("Called listComputeGlobalImageCapabilitySchemaVersions");
+        final ListComputeGlobalImageCapabilitySchemaVersionsRequest interceptedRequest =
+                ListComputeGlobalImageCapabilitySchemaVersionsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeGlobalImageCapabilitySchemaVersionsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                transformer =
+                        ListComputeGlobalImageCapabilitySchemaVersionsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListComputeGlobalImageCapabilitySchemasResponse listComputeGlobalImageCapabilitySchemas(
+            ListComputeGlobalImageCapabilitySchemasRequest request) {
+        LOG.trace("Called listComputeGlobalImageCapabilitySchemas");
+        final ListComputeGlobalImageCapabilitySchemasRequest interceptedRequest =
+                ListComputeGlobalImageCapabilitySchemasConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeGlobalImageCapabilitySchemasConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListComputeGlobalImageCapabilitySchemasResponse>
+                transformer = ListComputeGlobalImageCapabilitySchemasConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListComputeImageCapabilitySchemasResponse listComputeImageCapabilitySchemas(
+            ListComputeImageCapabilitySchemasRequest request) {
+        LOG.trace("Called listComputeImageCapabilitySchemas");
+        final ListComputeImageCapabilitySchemasRequest interceptedRequest =
+                ListComputeImageCapabilitySchemasConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListComputeImageCapabilitySchemasConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListComputeImageCapabilitySchemasResponse>
+                transformer = ListComputeImageCapabilitySchemasConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListConsoleHistoriesResponse listConsoleHistories(ListConsoleHistoriesRequest request) {
         LOG.trace("Called listConsoleHistories");
         final ListConsoleHistoriesRequest interceptedRequest =
@@ -2105,6 +2398,41 @@ public class ComputeClient implements Compute {
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
                                         client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateComputeImageCapabilitySchemaResponse updateComputeImageCapabilitySchema(
+            UpdateComputeImageCapabilitySchemaRequest request) {
+        LOG.trace("Called updateComputeImageCapabilitySchema");
+        final UpdateComputeImageCapabilitySchemaRequest interceptedRequest =
+                UpdateComputeImageCapabilitySchemaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateComputeImageCapabilitySchemaConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateComputeImageCapabilitySchemaResponse>
+                transformer = UpdateComputeImageCapabilitySchemaConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateComputeImageCapabilitySchemaDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-core/src/main/java/com/oracle/bmc/core/ComputePaginators.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/ComputePaginators.java
@@ -510,6 +510,401 @@ public class ComputePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listComputeGlobalImageCapabilitySchemaVersions operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+            listComputeGlobalImageCapabilitySchemaVersionsResponseIterator(
+                    final ListComputeGlobalImageCapabilitySchemaVersionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder,
+                ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                ListComputeGlobalImageCapabilitySchemaVersionsResponse>(
+                new com.google.common.base.Supplier<
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder get() {
+                        return ListComputeGlobalImageCapabilitySchemaVersionsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListComputeGlobalImageCapabilitySchemaVersionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder>,
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeGlobalImageCapabilitySchemaVersionsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsResponse apply(
+                            ListComputeGlobalImageCapabilitySchemaVersionsRequest request) {
+                        return client.listComputeGlobalImageCapabilitySchemaVersions(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaVersionSummary} objects
+     * contained in responses from the listComputeGlobalImageCapabilitySchemaVersions operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaVersionSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaVersionSummary>
+            listComputeGlobalImageCapabilitySchemaVersionsRecordIterator(
+                    final ListComputeGlobalImageCapabilitySchemaVersionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder,
+                ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                ListComputeGlobalImageCapabilitySchemaVersionsResponse,
+                com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaVersionSummary>(
+                new com.google.common.base.Supplier<
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder get() {
+                        return ListComputeGlobalImageCapabilitySchemaVersionsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListComputeGlobalImageCapabilitySchemaVersionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeGlobalImageCapabilitySchemaVersionsRequest.Builder>,
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeGlobalImageCapabilitySchemaVersionsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemaVersionsRequest,
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemaVersionsResponse apply(
+                            ListComputeGlobalImageCapabilitySchemaVersionsRequest request) {
+                        return client.listComputeGlobalImageCapabilitySchemaVersions(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemaVersionsResponse,
+                        java.util.List<
+                                com.oracle.bmc.core.model
+                                        .ComputeGlobalImageCapabilitySchemaVersionSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.core.model
+                                            .ComputeGlobalImageCapabilitySchemaVersionSummary>
+                            apply(ListComputeGlobalImageCapabilitySchemaVersionsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listComputeGlobalImageCapabilitySchemas operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListComputeGlobalImageCapabilitySchemasResponse>
+            listComputeGlobalImageCapabilitySchemasResponseIterator(
+                    final ListComputeGlobalImageCapabilitySchemasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListComputeGlobalImageCapabilitySchemasRequest.Builder,
+                ListComputeGlobalImageCapabilitySchemasRequest,
+                ListComputeGlobalImageCapabilitySchemasResponse>(
+                new com.google.common.base.Supplier<
+                        ListComputeGlobalImageCapabilitySchemasRequest.Builder>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasRequest.Builder get() {
+                        return ListComputeGlobalImageCapabilitySchemasRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemasResponse, String>() {
+                    @Override
+                    public String apply(ListComputeGlobalImageCapabilitySchemasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeGlobalImageCapabilitySchemasRequest.Builder>,
+                        ListComputeGlobalImageCapabilitySchemasRequest>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeGlobalImageCapabilitySchemasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemasRequest,
+                        ListComputeGlobalImageCapabilitySchemasResponse>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasResponse apply(
+                            ListComputeGlobalImageCapabilitySchemasRequest request) {
+                        return client.listComputeGlobalImageCapabilitySchemas(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaSummary} objects
+     * contained in responses from the listComputeGlobalImageCapabilitySchemas operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaSummary>
+            listComputeGlobalImageCapabilitySchemasRecordIterator(
+                    final ListComputeGlobalImageCapabilitySchemasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListComputeGlobalImageCapabilitySchemasRequest.Builder,
+                ListComputeGlobalImageCapabilitySchemasRequest,
+                ListComputeGlobalImageCapabilitySchemasResponse,
+                com.oracle.bmc.core.model.ComputeGlobalImageCapabilitySchemaSummary>(
+                new com.google.common.base.Supplier<
+                        ListComputeGlobalImageCapabilitySchemasRequest.Builder>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasRequest.Builder get() {
+                        return ListComputeGlobalImageCapabilitySchemasRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemasResponse, String>() {
+                    @Override
+                    public String apply(ListComputeGlobalImageCapabilitySchemasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeGlobalImageCapabilitySchemasRequest.Builder>,
+                        ListComputeGlobalImageCapabilitySchemasRequest>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeGlobalImageCapabilitySchemasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemasRequest,
+                        ListComputeGlobalImageCapabilitySchemasResponse>() {
+                    @Override
+                    public ListComputeGlobalImageCapabilitySchemasResponse apply(
+                            ListComputeGlobalImageCapabilitySchemasRequest request) {
+                        return client.listComputeGlobalImageCapabilitySchemas(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeGlobalImageCapabilitySchemasResponse,
+                        java.util.List<
+                                com.oracle.bmc.core.model
+                                        .ComputeGlobalImageCapabilitySchemaSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.core.model
+                                            .ComputeGlobalImageCapabilitySchemaSummary>
+                            apply(ListComputeGlobalImageCapabilitySchemasResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listComputeImageCapabilitySchemas operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListComputeImageCapabilitySchemasResponse>
+            listComputeImageCapabilitySchemasResponseIterator(
+                    final ListComputeImageCapabilitySchemasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListComputeImageCapabilitySchemasRequest.Builder,
+                ListComputeImageCapabilitySchemasRequest,
+                ListComputeImageCapabilitySchemasResponse>(
+                new com.google.common.base.Supplier<
+                        ListComputeImageCapabilitySchemasRequest.Builder>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasRequest.Builder get() {
+                        return ListComputeImageCapabilitySchemasRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeImageCapabilitySchemasResponse, String>() {
+                    @Override
+                    public String apply(ListComputeImageCapabilitySchemasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeImageCapabilitySchemasRequest.Builder>,
+                        ListComputeImageCapabilitySchemasRequest>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeImageCapabilitySchemasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeImageCapabilitySchemasRequest,
+                        ListComputeImageCapabilitySchemasResponse>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasResponse apply(
+                            ListComputeImageCapabilitySchemasRequest request) {
+                        return client.listComputeImageCapabilitySchemas(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary} objects
+     * contained in responses from the listComputeImageCapabilitySchemas operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary>
+            listComputeImageCapabilitySchemasRecordIterator(
+                    final ListComputeImageCapabilitySchemasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListComputeImageCapabilitySchemasRequest.Builder,
+                ListComputeImageCapabilitySchemasRequest, ListComputeImageCapabilitySchemasResponse,
+                com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary>(
+                new com.google.common.base.Supplier<
+                        ListComputeImageCapabilitySchemasRequest.Builder>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasRequest.Builder get() {
+                        return ListComputeImageCapabilitySchemasRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeImageCapabilitySchemasResponse, String>() {
+                    @Override
+                    public String apply(ListComputeImageCapabilitySchemasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListComputeImageCapabilitySchemasRequest.Builder>,
+                        ListComputeImageCapabilitySchemasRequest>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListComputeImageCapabilitySchemasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeImageCapabilitySchemasRequest,
+                        ListComputeImageCapabilitySchemasResponse>() {
+                    @Override
+                    public ListComputeImageCapabilitySchemasResponse apply(
+                            ListComputeImageCapabilitySchemasRequest request) {
+                        return client.listComputeImageCapabilitySchemas(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListComputeImageCapabilitySchemasResponse,
+                        java.util.List<
+                                com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.core.model.ComputeImageCapabilitySchemaSummary>
+                            apply(ListComputeImageCapabilitySchemasResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listConsoleHistories operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeComputeImageCapabilitySchemaCompartmentConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ChangeComputeImageCapabilitySchemaCompartmentConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeComputeImageCapabilitySchemaCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ChangeComputeImageCapabilitySchemaCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests
+                                    .ChangeComputeImageCapabilitySchemaCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ChangeComputeImageCapabilitySchemaCompartmentRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeImageCapabilitySchemaId(),
+                "computeImageCapabilitySchemaId must not be blank");
+        Validate.notNull(
+                request.getChangeComputeImageCapabilitySchemaCompartmentDetails(),
+                "changeComputeImageCapabilitySchemaCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeImageCapabilitySchemaId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses
+                            .ChangeComputeImageCapabilitySchemaCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses
+                                .ChangeComputeImageCapabilitySchemaCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .ChangeComputeImageCapabilitySchemaCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .ChangeComputeImageCapabilitySchemaCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ChangeComputeImageCapabilitySchemaCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .ChangeComputeImageCapabilitySchemaCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .ChangeComputeImageCapabilitySchemaCompartmentResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .ChangeComputeImageCapabilitySchemaCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateComputeImageCapabilitySchemaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CreateComputeImageCapabilitySchemaConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateComputeImageCapabilitySchemaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.CreateComputeImageCapabilitySchemaRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.CreateComputeImageCapabilitySchemaRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.CreateComputeImageCapabilitySchemaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateComputeImageCapabilitySchemaDetails(),
+                "createComputeImageCapabilitySchemaDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("computeImageCapabilitySchemas");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.CreateComputeImageCapabilitySchemaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.CreateComputeImageCapabilitySchemaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .CreateComputeImageCapabilitySchemaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .CreateComputeImageCapabilitySchemaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.CreateComputeImageCapabilitySchemaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ComputeImageCapabilitySchema>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ComputeImageCapabilitySchema.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ComputeImageCapabilitySchema>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .CreateComputeImageCapabilitySchemaResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .CreateComputeImageCapabilitySchemaResponse
+                                                        .builder();
+
+                                builder.computeImageCapabilitySchema(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .CreateComputeImageCapabilitySchemaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteComputeImageCapabilitySchemaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/DeleteComputeImageCapabilitySchemaConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteComputeImageCapabilitySchemaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.DeleteComputeImageCapabilitySchemaRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.DeleteComputeImageCapabilitySchemaRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.DeleteComputeImageCapabilitySchemaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeImageCapabilitySchemaId(),
+                "computeImageCapabilitySchemaId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeImageCapabilitySchemaId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.DeleteComputeImageCapabilitySchemaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.DeleteComputeImageCapabilitySchemaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .DeleteComputeImageCapabilitySchemaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .DeleteComputeImageCapabilitySchemaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.DeleteComputeImageCapabilitySchemaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .DeleteComputeImageCapabilitySchemaResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .DeleteComputeImageCapabilitySchemaResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .DeleteComputeImageCapabilitySchemaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeGlobalImageCapabilitySchemaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeGlobalImageCapabilitySchemaConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetComputeGlobalImageCapabilitySchemaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeGlobalImageCapabilitySchemaId(),
+                "computeGlobalImageCapabilitySchemaId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeGlobalImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeGlobalImageCapabilitySchemaId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.GetComputeGlobalImageCapabilitySchemaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.GetComputeGlobalImageCapabilitySchemaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .GetComputeGlobalImageCapabilitySchemaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .GetComputeGlobalImageCapabilitySchemaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.GetComputeGlobalImageCapabilitySchemaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ComputeGlobalImageCapabilitySchema>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ComputeGlobalImageCapabilitySchema.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ComputeGlobalImageCapabilitySchema>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeGlobalImageCapabilitySchemaResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .GetComputeGlobalImageCapabilitySchemaResponse
+                                                        .builder();
+
+                                builder.computeGlobalImageCapabilitySchema(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeGlobalImageCapabilitySchemaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeGlobalImageCapabilitySchemaVersionConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeGlobalImageCapabilitySchemaVersionConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetComputeGlobalImageCapabilitySchemaVersionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaVersionRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaVersionRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.GetComputeGlobalImageCapabilitySchemaVersionRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeGlobalImageCapabilitySchemaId(),
+                "computeGlobalImageCapabilitySchemaId must not be blank");
+        Validate.notBlank(
+                request.getComputeGlobalImageCapabilitySchemaVersionName(),
+                "computeGlobalImageCapabilitySchemaVersionName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeGlobalImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeGlobalImageCapabilitySchemaId()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getComputeGlobalImageCapabilitySchemaVersionName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses
+                            .GetComputeGlobalImageCapabilitySchemaVersionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses
+                                .GetComputeGlobalImageCapabilitySchemaVersionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .GetComputeGlobalImageCapabilitySchemaVersionResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .GetComputeGlobalImageCapabilitySchemaVersionResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.GetComputeGlobalImageCapabilitySchemaVersionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ComputeGlobalImageCapabilitySchemaVersion>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ComputeGlobalImageCapabilitySchemaVersion
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ComputeGlobalImageCapabilitySchemaVersion>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeGlobalImageCapabilitySchemaVersionResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .GetComputeGlobalImageCapabilitySchemaVersionResponse
+                                                        .builder();
+
+                                builder.computeGlobalImageCapabilitySchemaVersion(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeGlobalImageCapabilitySchemaVersionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeImageCapabilitySchemaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetComputeImageCapabilitySchemaConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetComputeImageCapabilitySchemaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.GetComputeImageCapabilitySchemaRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.GetComputeImageCapabilitySchemaRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.GetComputeImageCapabilitySchemaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeImageCapabilitySchemaId(),
+                "computeImageCapabilitySchemaId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeImageCapabilitySchemaId()));
+
+        if (request.getIsMergeEnabled() != null) {
+            target =
+                    target.queryParam(
+                            "isMergeEnabled",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsMergeEnabled()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.GetComputeImageCapabilitySchemaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.GetComputeImageCapabilitySchemaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .GetComputeImageCapabilitySchemaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .GetComputeImageCapabilitySchemaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.GetComputeImageCapabilitySchemaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ComputeImageCapabilitySchema>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ComputeImageCapabilitySchema.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ComputeImageCapabilitySchema>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeImageCapabilitySchemaResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .GetComputeImageCapabilitySchemaResponse
+                                                        .builder();
+
+                                builder.computeImageCapabilitySchema(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .GetComputeImageCapabilitySchemaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeGlobalImageCapabilitySchemaVersionsConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeGlobalImageCapabilitySchemaVersionsConverter.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListComputeGlobalImageCapabilitySchemaVersionsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ListComputeGlobalImageCapabilitySchemaVersionsRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests
+                                    .ListComputeGlobalImageCapabilitySchemaVersionsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ListComputeGlobalImageCapabilitySchemaVersionsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeGlobalImageCapabilitySchemaId(),
+                "computeGlobalImageCapabilitySchemaId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeGlobalImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeGlobalImageCapabilitySchemaId()))
+                        .path("versions");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses
+                            .ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses
+                                .ListComputeGlobalImageCapabilitySchemaVersionsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .ListComputeGlobalImageCapabilitySchemaVersionsResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .ListComputeGlobalImageCapabilitySchemaVersionsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ListComputeGlobalImageCapabilitySchemaVersionsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                ComputeGlobalImageCapabilitySchemaVersionSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ComputeGlobalImageCapabilitySchemaVersionSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        ComputeGlobalImageCapabilitySchemaVersionSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeGlobalImageCapabilitySchemaVersionsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .ListComputeGlobalImageCapabilitySchemaVersionsResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeGlobalImageCapabilitySchemaVersionsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeGlobalImageCapabilitySchemasConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeGlobalImageCapabilitySchemasConverter.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListComputeGlobalImageCapabilitySchemasConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ListComputeGlobalImageCapabilitySchemasRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.ListComputeGlobalImageCapabilitySchemasRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ListComputeGlobalImageCapabilitySchemasRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeGlobalImageCapabilitySchemas");
+
+        if (request.getCompartmentId() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.ListComputeGlobalImageCapabilitySchemasResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses
+                                .ListComputeGlobalImageCapabilitySchemasResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .ListComputeGlobalImageCapabilitySchemasResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .ListComputeGlobalImageCapabilitySchemasResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ListComputeGlobalImageCapabilitySchemasResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                ComputeGlobalImageCapabilitySchemaSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ComputeGlobalImageCapabilitySchemaSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        ComputeGlobalImageCapabilitySchemaSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeGlobalImageCapabilitySchemasResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .ListComputeGlobalImageCapabilitySchemasResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeGlobalImageCapabilitySchemasResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeImageCapabilitySchemasConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListComputeImageCapabilitySchemasConverter.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListComputeImageCapabilitySchemasConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ListComputeImageCapabilitySchemasRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.ListComputeImageCapabilitySchemasRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ListComputeImageCapabilitySchemasRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("computeImageCapabilitySchemas");
+
+        if (request.getCompartmentId() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentId()));
+        }
+
+        if (request.getImageId() != null) {
+            target =
+                    target.queryParam(
+                            "imageId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getImageId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.ListComputeImageCapabilitySchemasResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.ListComputeImageCapabilitySchemasResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .ListComputeImageCapabilitySchemasResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .ListComputeImageCapabilitySchemasResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ListComputeImageCapabilitySchemasResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                ComputeImageCapabilitySchemaSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ComputeImageCapabilitySchemaSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ComputeImageCapabilitySchemaSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeImageCapabilitySchemasResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .ListComputeImageCapabilitySchemasResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .ListComputeImageCapabilitySchemasResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateComputeImageCapabilitySchemaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateComputeImageCapabilitySchemaConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateComputeImageCapabilitySchemaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.UpdateComputeImageCapabilitySchemaRequest
+            interceptRequest(
+                    com.oracle.bmc.core.requests.UpdateComputeImageCapabilitySchemaRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.UpdateComputeImageCapabilitySchemaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getComputeImageCapabilitySchemaId(),
+                "computeImageCapabilitySchemaId must not be blank");
+        Validate.notNull(
+                request.getUpdateComputeImageCapabilitySchemaDetails(),
+                "updateComputeImageCapabilitySchemaDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("computeImageCapabilitySchemas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getComputeImageCapabilitySchemaId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.UpdateComputeImageCapabilitySchemaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.UpdateComputeImageCapabilitySchemaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .UpdateComputeImageCapabilitySchemaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .UpdateComputeImageCapabilitySchemaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.UpdateComputeImageCapabilitySchemaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ComputeImageCapabilitySchema>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ComputeImageCapabilitySchema.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ComputeImageCapabilitySchema>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses
+                                                .UpdateComputeImageCapabilitySchemaResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .UpdateComputeImageCapabilitySchemaResponse
+                                                        .builder();
+
+                                builder.computeImageCapabilitySchema(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses
+                                                .UpdateComputeImageCapabilitySchemaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BooleanImageCapabilitySchemaDescriptor.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BooleanImageCapabilitySchemaDescriptor.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Boolean type ImageCapabilitySchemaDescriptor
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BooleanImageCapabilitySchemaDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "descriptorType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BooleanImageCapabilitySchemaDescriptor extends ImageCapabilitySchemaDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private Source source;
+
+        public Builder source(Source source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+        private Boolean defaultValue;
+
+        public Builder defaultValue(Boolean defaultValue) {
+            this.defaultValue = defaultValue;
+            this.__explicitlySet__.add("defaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BooleanImageCapabilitySchemaDescriptor build() {
+            BooleanImageCapabilitySchemaDescriptor __instance__ =
+                    new BooleanImageCapabilitySchemaDescriptor(source, defaultValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BooleanImageCapabilitySchemaDescriptor o) {
+            Builder copiedBuilder = source(o.getSource()).defaultValue(o.getDefaultValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public BooleanImageCapabilitySchemaDescriptor(Source source, Boolean defaultValue) {
+        super(source);
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * the default value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+    Boolean defaultValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolume.java
@@ -187,6 +187,24 @@ public class BootVolume {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")
+        private Long autoTunedVpusPerGB;
+
+        public Builder autoTunedVpusPerGB(Long autoTunedVpusPerGB) {
+            this.autoTunedVpusPerGB = autoTunedVpusPerGB;
+            this.__explicitlySet__.add("autoTunedVpusPerGB");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -209,7 +227,9 @@ public class BootVolume {
                             sourceDetails,
                             timeCreated,
                             volumeGroupId,
-                            kmsKeyId);
+                            kmsKeyId,
+                            isAutoTuneEnabled,
+                            autoTunedVpusPerGB);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -233,7 +253,9 @@ public class BootVolume {
                             .sourceDetails(o.getSourceDetails())
                             .timeCreated(o.getTimeCreated())
                             .volumeGroupId(o.getVolumeGroupId())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled())
+                            .autoTunedVpusPerGB(o.getAutoTunedVpusPerGB());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -427,6 +449,20 @@ public class BootVolume {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
+
+    /**
+     * The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")
+    Long autoTunedVpusPerGB;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeComputeImageCapabilitySchemaCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeComputeImageCapabilitySchemaCompartmentDetails.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The configuration details for the move operation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeComputeImageCapabilitySchemaCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeComputeImageCapabilitySchemaCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeComputeImageCapabilitySchemaCompartmentDetails build() {
+            ChangeComputeImageCapabilitySchemaCompartmentDetails __instance__ =
+                    new ChangeComputeImageCapabilitySchemaCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeComputeImageCapabilitySchemaCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+     * move the instance configuration to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchema.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchema.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Compute Global Image Capability Schema is a container for a set of compute global image capability schema versions
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeGlobalImageCapabilitySchema.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeGlobalImageCapabilitySchema {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentVersionName")
+        private String currentVersionName;
+
+        public Builder currentVersionName(String currentVersionName) {
+            this.currentVersionName = currentVersionName;
+            this.__explicitlySet__.add("currentVersionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeGlobalImageCapabilitySchema build() {
+            ComputeGlobalImageCapabilitySchema __instance__ =
+                    new ComputeGlobalImageCapabilitySchema(
+                            id,
+                            compartmentId,
+                            currentVersionName,
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeGlobalImageCapabilitySchema o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .currentVersionName(o.getCurrentVersionName())
+                            .definedTags(o.getDefinedTags())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment that contains the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The name of the global capabilities version resource that is considered the current version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentVersionName")
+    String currentVersionName;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * A user-friendly name for the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * The date and time the compute global image capability schema was created, in the format defined by
+     * [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaSummary.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Summary information for a compute global image capability schema
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeGlobalImageCapabilitySchemaSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeGlobalImageCapabilitySchemaSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentVersionName")
+        private String currentVersionName;
+
+        public Builder currentVersionName(String currentVersionName) {
+            this.currentVersionName = currentVersionName;
+            this.__explicitlySet__.add("currentVersionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeGlobalImageCapabilitySchemaSummary build() {
+            ComputeGlobalImageCapabilitySchemaSummary __instance__ =
+                    new ComputeGlobalImageCapabilitySchemaSummary(
+                            id,
+                            compartmentId,
+                            currentVersionName,
+                            displayName,
+                            timeCreated,
+                            definedTags,
+                            freeformTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeGlobalImageCapabilitySchemaSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .currentVersionName(o.getCurrentVersionName())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compute global image capability schema [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment containing the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The name of the global capabilities version resource that is considered the current version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentVersionName")
+    String currentVersionName;
+
+    /**
+     * A user-friendly name for the compute global image capability schema.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time the compute global image capability schema was created, in the format defined by
+     * [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaVersion.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaVersion.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Compute Global Image Capability Schema Version is a set of all possible capabilities for a collection of images.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeGlobalImageCapabilitySchemaVersion.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeGlobalImageCapabilitySchemaVersion {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+        private String computeGlobalImageCapabilitySchemaId;
+
+        public Builder computeGlobalImageCapabilitySchemaId(
+                String computeGlobalImageCapabilitySchemaId) {
+            this.computeGlobalImageCapabilitySchemaId = computeGlobalImageCapabilitySchemaId;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+        private java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+        public Builder schemaData(
+                java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData) {
+            this.schemaData = schemaData;
+            this.__explicitlySet__.add("schemaData");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeGlobalImageCapabilitySchemaVersion build() {
+            ComputeGlobalImageCapabilitySchemaVersion __instance__ =
+                    new ComputeGlobalImageCapabilitySchemaVersion(
+                            name,
+                            computeGlobalImageCapabilitySchemaId,
+                            displayName,
+                            schemaData,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeGlobalImageCapabilitySchemaVersion o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .computeGlobalImageCapabilitySchemaId(
+                                    o.getComputeGlobalImageCapabilitySchemaId())
+                            .displayName(o.getDisplayName())
+                            .schemaData(o.getSchemaData())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the compute global image capability schema version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The ocid of the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+    String computeGlobalImageCapabilitySchemaId;
+
+    /**
+     * A user-friendly name for the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The map of each capability name to its ImageCapabilityDescriptor.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+    java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+    /**
+     * The date and time the compute global image capability schema version was created, in the format defined by
+     * [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaVersionSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeGlobalImageCapabilitySchemaVersionSummary.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Summary information for a compute global image capability schema
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeGlobalImageCapabilitySchemaVersionSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeGlobalImageCapabilitySchemaVersionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+        private String computeGlobalImageCapabilitySchemaId;
+
+        public Builder computeGlobalImageCapabilitySchemaId(
+                String computeGlobalImageCapabilitySchemaId) {
+            this.computeGlobalImageCapabilitySchemaId = computeGlobalImageCapabilitySchemaId;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeGlobalImageCapabilitySchemaVersionSummary build() {
+            ComputeGlobalImageCapabilitySchemaVersionSummary __instance__ =
+                    new ComputeGlobalImageCapabilitySchemaVersionSummary(
+                            name, computeGlobalImageCapabilitySchemaId, displayName, timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeGlobalImageCapabilitySchemaVersionSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .computeGlobalImageCapabilitySchemaId(
+                                    o.getComputeGlobalImageCapabilitySchemaId())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compute global image capability schema version name
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The OCID of the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+    String computeGlobalImageCapabilitySchemaId;
+
+    /**
+     * The display name of the version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time the compute global image capability schema version was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeImageCapabilitySchema.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeImageCapabilitySchema.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Compute Image Capability Schema is a set of capabilities that filter the compute global capability schema
+ * version for an image.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeImageCapabilitySchema.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeImageCapabilitySchema {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+        private String computeGlobalImageCapabilitySchemaId;
+
+        public Builder computeGlobalImageCapabilitySchemaId(
+                String computeGlobalImageCapabilitySchemaId) {
+            this.computeGlobalImageCapabilitySchemaId = computeGlobalImageCapabilitySchemaId;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeGlobalImageCapabilitySchemaVersionName")
+        private String computeGlobalImageCapabilitySchemaVersionName;
+
+        public Builder computeGlobalImageCapabilitySchemaVersionName(
+                String computeGlobalImageCapabilitySchemaVersionName) {
+            this.computeGlobalImageCapabilitySchemaVersionName =
+                    computeGlobalImageCapabilitySchemaVersionName;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaVersionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+        private String imageId;
+
+        public Builder imageId(String imageId) {
+            this.imageId = imageId;
+            this.__explicitlySet__.add("imageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+        private java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+        public Builder schemaData(
+                java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData) {
+            this.schemaData = schemaData;
+            this.__explicitlySet__.add("schemaData");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeImageCapabilitySchema build() {
+            ComputeImageCapabilitySchema __instance__ =
+                    new ComputeImageCapabilitySchema(
+                            id,
+                            compartmentId,
+                            computeGlobalImageCapabilitySchemaId,
+                            computeGlobalImageCapabilitySchemaVersionName,
+                            imageId,
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            schemaData,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeImageCapabilitySchema o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .computeGlobalImageCapabilitySchemaId(
+                                    o.getComputeGlobalImageCapabilitySchemaId())
+                            .computeGlobalImageCapabilitySchemaVersionName(
+                                    o.getComputeGlobalImageCapabilitySchemaVersionName())
+                            .imageId(o.getImageId())
+                            .definedTags(o.getDefinedTags())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .schemaData(o.getSchemaData())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The id of the compute global image capability schema version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment that contains the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The ocid of the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaId")
+    String computeGlobalImageCapabilitySchemaId;
+
+    /**
+     * The name of the compute global image capability schema version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaVersionName")
+    String computeGlobalImageCapabilitySchemaVersionName;
+
+    /**
+     * The OCID of the image associated with this compute image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+    String imageId;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * A user-friendly name for the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * The map of each capability name to its ImageCapabilityDescriptor.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+    java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+    /**
+     * The date and time the compute image capability schema was created, in the format defined by
+     * [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeImageCapabilitySchemaSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ComputeImageCapabilitySchemaSummary.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Summary information for a compute image capability schema
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ComputeImageCapabilitySchemaSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ComputeImageCapabilitySchemaSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeGlobalImageCapabilitySchemaVersionName")
+        private String computeGlobalImageCapabilitySchemaVersionName;
+
+        public Builder computeGlobalImageCapabilitySchemaVersionName(
+                String computeGlobalImageCapabilitySchemaVersionName) {
+            this.computeGlobalImageCapabilitySchemaVersionName =
+                    computeGlobalImageCapabilitySchemaVersionName;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaVersionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+        private String imageId;
+
+        public Builder imageId(String imageId) {
+            this.imageId = imageId;
+            this.__explicitlySet__.add("imageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ComputeImageCapabilitySchemaSummary build() {
+            ComputeImageCapabilitySchemaSummary __instance__ =
+                    new ComputeImageCapabilitySchemaSummary(
+                            id,
+                            compartmentId,
+                            computeGlobalImageCapabilitySchemaVersionName,
+                            imageId,
+                            displayName,
+                            timeCreated,
+                            definedTags,
+                            freeformTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ComputeImageCapabilitySchemaSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .computeGlobalImageCapabilitySchemaVersionName(
+                                    o.getComputeGlobalImageCapabilitySchemaVersionName())
+                            .imageId(o.getImageId())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compute image capability schema [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment containing the compute global image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The name of the compute global image capability schema version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaVersionName")
+    String computeGlobalImageCapabilitySchemaVersionName;
+
+    /**
+     * The OCID of the image associated with this compute image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+    String imageId;
+
+    /**
+     * A user-friendly name for the compute image capability schema.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time the compute image capability schema was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateBootVolumeDetails.java
@@ -117,6 +117,15 @@ public class CreateBootVolumeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -132,7 +141,8 @@ public class CreateBootVolumeDetails {
                             kmsKeyId,
                             sizeInGBs,
                             vpusPerGB,
-                            sourceDetails);
+                            sourceDetails,
+                            isAutoTuneEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -149,7 +159,8 @@ public class CreateBootVolumeDetails {
                             .kmsKeyId(o.getKmsKeyId())
                             .sizeInGBs(o.getSizeInGBs())
                             .vpusPerGB(o.getVpusPerGB())
-                            .sourceDetails(o.getSourceDetails());
+                            .sourceDetails(o.getSourceDetails())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -250,6 +261,13 @@ public class CreateBootVolumeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
     BootVolumeSourceDetails sourceDetails;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateComputeImageCapabilitySchemaDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateComputeImageCapabilitySchemaDetails.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Create Image Capability Schema for an image.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateComputeImageCapabilitySchemaDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateComputeImageCapabilitySchemaDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "computeGlobalImageCapabilitySchemaVersionName")
+        private String computeGlobalImageCapabilitySchemaVersionName;
+
+        public Builder computeGlobalImageCapabilitySchemaVersionName(
+                String computeGlobalImageCapabilitySchemaVersionName) {
+            this.computeGlobalImageCapabilitySchemaVersionName =
+                    computeGlobalImageCapabilitySchemaVersionName;
+            this.__explicitlySet__.add("computeGlobalImageCapabilitySchemaVersionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+        private String imageId;
+
+        public Builder imageId(String imageId) {
+            this.imageId = imageId;
+            this.__explicitlySet__.add("imageId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+        private java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+        public Builder schemaData(
+                java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData) {
+            this.schemaData = schemaData;
+            this.__explicitlySet__.add("schemaData");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateComputeImageCapabilitySchemaDetails build() {
+            CreateComputeImageCapabilitySchemaDetails __instance__ =
+                    new CreateComputeImageCapabilitySchemaDetails(
+                            compartmentId,
+                            computeGlobalImageCapabilitySchemaVersionName,
+                            imageId,
+                            freeformTags,
+                            displayName,
+                            definedTags,
+                            schemaData);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateComputeImageCapabilitySchemaDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .computeGlobalImageCapabilitySchemaVersionName(
+                                    o.getComputeGlobalImageCapabilitySchemaVersionName())
+                            .imageId(o.getImageId())
+                            .freeformTags(o.getFreeformTags())
+                            .displayName(o.getDisplayName())
+                            .definedTags(o.getDefinedTags())
+                            .schemaData(o.getSchemaData());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment that contains the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The name of the compute global image capability schema version
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeGlobalImageCapabilitySchemaVersionName")
+    String computeGlobalImageCapabilitySchemaVersionName;
+
+    /**
+     * The ocid of the image
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageId")
+    String imageId;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * A user-friendly name for the compute image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The map of each capability name to its ImageCapabilitySchemaDescriptor.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+    java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateImageDetails.java
@@ -183,7 +183,7 @@ public class CreateImageDetails {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/
@@ -225,7 +225,7 @@ public class CreateImageDetails {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeDetails.java
@@ -135,6 +135,15 @@ public class CreateVolumeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -152,7 +161,8 @@ public class CreateVolumeDetails {
                             sizeInGBs,
                             sizeInMBs,
                             sourceDetails,
-                            volumeBackupId);
+                            volumeBackupId,
+                            isAutoTuneEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -171,7 +181,8 @@ public class CreateVolumeDetails {
                             .sizeInGBs(o.getSizeInGBs())
                             .sizeInMBs(o.getSizeInMBs())
                             .sourceDetails(o.getSourceDetails())
-                            .volumeBackupId(o.getVolumeBackupId());
+                            .volumeBackupId(o.getVolumeBackupId())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -292,6 +303,13 @@ public class CreateVolumeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("volumeBackupId")
     String volumeBackupId;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/EnumIntegerImageCapabilityDescriptor.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/EnumIntegerImageCapabilityDescriptor.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Enum Integer type CapabilityDescriptor
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnumIntegerImageCapabilityDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "descriptorType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnumIntegerImageCapabilityDescriptor extends ImageCapabilitySchemaDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private Source source;
+
+        public Builder source(Source source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("values")
+        private java.util.List<Integer> values;
+
+        public Builder values(java.util.List<Integer> values) {
+            this.values = values;
+            this.__explicitlySet__.add("values");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+        private Integer defaultValue;
+
+        public Builder defaultValue(Integer defaultValue) {
+            this.defaultValue = defaultValue;
+            this.__explicitlySet__.add("defaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnumIntegerImageCapabilityDescriptor build() {
+            EnumIntegerImageCapabilityDescriptor __instance__ =
+                    new EnumIntegerImageCapabilityDescriptor(source, values, defaultValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnumIntegerImageCapabilityDescriptor o) {
+            Builder copiedBuilder =
+                    source(o.getSource()).values(o.getValues()).defaultValue(o.getDefaultValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public EnumIntegerImageCapabilityDescriptor(
+            Source source, java.util.List<Integer> values, Integer defaultValue) {
+        super(source);
+        this.values = values;
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * the list of values for the enum
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    java.util.List<Integer> values;
+
+    /**
+     * the default value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+    Integer defaultValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/EnumStringImageCapabilitySchemaDescriptor.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/EnumStringImageCapabilitySchemaDescriptor.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Enum String type of ImageCapabilitySchemaDescriptor
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnumStringImageCapabilitySchemaDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "descriptorType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnumStringImageCapabilitySchemaDescriptor extends ImageCapabilitySchemaDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private Source source;
+
+        public Builder source(Source source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("values")
+        private java.util.List<String> values;
+
+        public Builder values(java.util.List<String> values) {
+            this.values = values;
+            this.__explicitlySet__.add("values");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+        private String defaultValue;
+
+        public Builder defaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+            this.__explicitlySet__.add("defaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnumStringImageCapabilitySchemaDescriptor build() {
+            EnumStringImageCapabilitySchemaDescriptor __instance__ =
+                    new EnumStringImageCapabilitySchemaDescriptor(source, values, defaultValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnumStringImageCapabilitySchemaDescriptor o) {
+            Builder copiedBuilder =
+                    source(o.getSource()).values(o.getValues()).defaultValue(o.getDefaultValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public EnumStringImageCapabilitySchemaDescriptor(
+            Source source, java.util.List<String> values, String defaultValue) {
+        super(source);
+        this.values = values;
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * the list of values for the enum
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    java.util.List<String> values;
+
+    /**
+     * the default value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+    String defaultValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
@@ -289,7 +289,7 @@ public class Image {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/
@@ -342,7 +342,7 @@ public class Image {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageCapabilitySchemaDescriptor.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ImageCapabilitySchemaDescriptor.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Image Capability Schema Descriptor is a type of capability for an image.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "descriptorType",
+    defaultImpl = ImageCapabilitySchemaDescriptor.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = EnumStringImageCapabilitySchemaDescriptor.class,
+        name = "enumstring"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = EnumIntegerImageCapabilityDescriptor.class,
+        name = "enuminteger"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = BooleanImageCapabilitySchemaDescriptor.class,
+        name = "boolean"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ImageCapabilitySchemaDescriptor {
+
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Source {
+        Global("GLOBAL"),
+        Image("IMAGE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Source> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Source v : Source.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Source(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Source create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Source', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    Source source;
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
@@ -358,9 +358,11 @@ public class Instance {
     String displayName;
 
     /**
-     * Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+     * Additional metadata key/value pairs that you provide. They serve the same purpose and functionality
+     * as fields in the `metadata` object.
      * <p>
-     * They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+     * They are distinguished from `metadata` fields in that these can be nested JSON objects (whereas `metadata`
+     * fields are string/string maps only).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")
@@ -375,8 +377,7 @@ public class Instance {
      * A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
      * instances in other fault domains.
      * <p>
-     * If you do not specify the fault domain, the system selects one for you. To change the fault
-     * domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+     * If you do not specify the fault domain, the system selects one for you.
      * <p>
      * Example: `FAULT-DOMAIN-1`
      *
@@ -438,7 +439,7 @@ public class Instance {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/
@@ -491,7 +492,7 @@ public class Instance {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
@@ -313,9 +313,14 @@ public class InstanceConfigurationLaunchInstanceDetails {
     String displayName;
 
     /**
-     * Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+     * Additional metadata key/value pairs that you provide. They serve the same purpose and
+     * functionality as fields in the `metadata` object.
      * <p>
-     * They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+     * They are distinguished from `metadata` fields in that these can be nested JSON objects
+     * (whereas `metadata` fields are string/string maps only).
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+     * 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")
@@ -408,6 +413,8 @@ public class InstanceConfigurationLaunchInstanceDetails {
      * <p>
      * You'll get back a response that includes all the instance information; only the metadata information; or
      *  the metadata information for the specified key name, respectively.
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")
@@ -441,9 +448,9 @@ public class InstanceConfigurationLaunchInstanceDetails {
      * A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
      * instances in other fault domains.
      * <p>
-     * If you do not specify the fault domain, the system selects one for you. To change the fault
-     * domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+     * If you do not specify the fault domain, the system selects one for you.
      * <p>
+     *
      * To get a list of fault domains, use the
      * {@link #listFaultDomains(ListFaultDomainsRequest) listFaultDomains} operation in the
      * Identity and Access Management Service API.
@@ -467,7 +474,7 @@ public class InstanceConfigurationLaunchInstanceDetails {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/
@@ -520,7 +527,7 @@ public class InstanceConfigurationLaunchInstanceDetails {
      * Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
      * * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
      * * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      * * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchOptions.java
@@ -122,14 +122,14 @@ public class InstanceConfigurationLaunchOptions {
     }
 
     /**
-     * Emulation type for volume.
+     * Emulation type for the boot volume.
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
      * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -179,14 +179,14 @@ public class InstanceConfigurationLaunchOptions {
         }
     };
     /**
-     * Emulation type for volume.
+     * Emulation type for the boot volume.
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
      * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeType")
@@ -196,7 +196,7 @@ public class InstanceConfigurationLaunchOptions {
      * * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
      * systems that boot using MBR style bootloaders.
      * * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-     * default for Oracle provided images.
+     * default for Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -247,7 +247,7 @@ public class InstanceConfigurationLaunchOptions {
      * * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
      * systems that boot using MBR style bootloaders.
      * * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-     * default for Oracle provided images.
+     * default for Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("firmware")
@@ -257,7 +257,7 @@ public class InstanceConfigurationLaunchOptions {
      * * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
      * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
      * when you launch an instance using hardware-assisted (SR-IOV) networking.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -309,7 +309,7 @@ public class InstanceConfigurationLaunchOptions {
      * * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
      * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
      * when you launch an instance using hardware-assisted (SR-IOV) networking.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("networkType")
@@ -319,10 +319,10 @@ public class InstanceConfigurationLaunchOptions {
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
      * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -376,10 +376,10 @@ public class InstanceConfigurationLaunchOptions {
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
      * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("remoteDataVolumeType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSummary.java
@@ -197,7 +197,7 @@ public class InstanceSummary {
     String displayName;
 
     /**
-     * The name of the Fault Domain the instance is running in.
+     * The fault domain the instance is running in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("faultDomain")
     String faultDomain;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -326,9 +326,14 @@ public class LaunchInstanceDetails {
     String displayName;
 
     /**
-     * Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
+     * Additional metadata key/value pairs that you provide. They serve the same purpose and
+     * functionality as fields in the `metadata` object.
      * <p>
-     * They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+     * They are distinguished from `metadata` fields in that these can be nested JSON objects
+     * (whereas `metadata` fields are string/string maps only).
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+     * 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")
@@ -341,9 +346,9 @@ public class LaunchInstanceDetails {
      * A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
      * instances in other fault domains.
      * <p>
-     * If you do not specify the fault domain, the system selects one for you. To change the fault
-     * domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+     * If you do not specify the fault domain, the system selects one for you.
      * <p>
+     *
      * To get a list of fault domains, use the
      * {@link #listFaultDomains(ListFaultDomainsRequest) listFaultDomains} operation in the
      * Identity and Access Management Service API.
@@ -466,6 +471,8 @@ public class LaunchInstanceDetails {
      * <p>
      * You'll get back a response that includes all the instance information; only the metadata information; or
      *  the metadata information for the specified key name, respectively.
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchOptions.java
@@ -120,14 +120,14 @@ public class LaunchOptions {
     }
 
     /**
-     * Emulation type for volume.
+     * Emulation type for the boot volume.
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-     * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+     * volumes on Oracle-provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -177,14 +177,14 @@ public class LaunchOptions {
         }
     };
     /**
-     * Emulation type for volume.
+     * Emulation type for the boot volume.
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-     * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+     * volumes on Oracle-provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeType")
@@ -194,7 +194,7 @@ public class LaunchOptions {
      * * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
      * systems that boot using MBR style bootloaders.
      * * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-     * default for Oracle provided images.
+     * default for Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -245,7 +245,7 @@ public class LaunchOptions {
      * * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
      * systems that boot using MBR style bootloaders.
      * * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-     * default for Oracle provided images.
+     * default for Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("firmware")
@@ -255,7 +255,7 @@ public class LaunchOptions {
      * * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
      * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
      * when you launch an instance using hardware-assisted (SR-IOV) networking.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -307,7 +307,7 @@ public class LaunchOptions {
      * * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
      * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
      * when you launch an instance using hardware-assisted (SR-IOV) networking.
-     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("networkType")
@@ -317,10 +317,10 @@ public class LaunchOptions {
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-     * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+     * volumes on Oracle-provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -374,10 +374,10 @@ public class LaunchOptions {
      * * `ISCSI` - ISCSI attached block storage device.
      * * `SCSI` - Emulated SCSI disk.
      * * `IDE` - Emulated IDE disk.
-     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-     * volumes on Oracle provided images.
-     * * `PARAVIRTUALIZED` - Paravirtualized disk.This is the default for Boot Volumes and Remote Block
-     * Storage volumes on Oracle provided images.
+     * * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+     * volumes on Oracle-provided images.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided images.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("remoteDataVolumeType")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateBootVolumeDetails.java
@@ -72,13 +72,27 @@ public class UpdateBootVolumeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateBootVolumeDetails build() {
             UpdateBootVolumeDetails __instance__ =
                     new UpdateBootVolumeDetails(
-                            definedTags, displayName, freeformTags, sizeInGBs, vpusPerGB);
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            sizeInGBs,
+                            vpusPerGB,
+                            isAutoTuneEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +104,8 @@ public class UpdateBootVolumeDetails {
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .sizeInGBs(o.getSizeInGBs())
-                            .vpusPerGB(o.getVpusPerGB());
+                            .vpusPerGB(o.getVpusPerGB())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -152,6 +167,13 @@ public class UpdateBootVolumeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vpusPerGB")
     Long vpusPerGB;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this boot volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateComputeImageCapabilitySchemaDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateComputeImageCapabilitySchemaDetails.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Create Image Capability Schema for an image.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateComputeImageCapabilitySchemaDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateComputeImageCapabilitySchemaDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+        private java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+        public Builder schemaData(
+                java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData) {
+            this.schemaData = schemaData;
+            this.__explicitlySet__.add("schemaData");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateComputeImageCapabilitySchemaDetails build() {
+            UpdateComputeImageCapabilitySchemaDetails __instance__ =
+                    new UpdateComputeImageCapabilitySchemaDetails(
+                            displayName, freeformTags, schemaData, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateComputeImageCapabilitySchemaDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .schemaData(o.getSchemaData())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name for the compute image capability schema
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * The map of each capability name to its ImageCapabilitySchemaDescriptor.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaData")
+    java.util.Map<String, ImageCapabilitySchemaDescriptor> schemaData;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
@@ -99,6 +99,24 @@ public class UpdateInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("faultDomain")
+        private String faultDomain;
+
+        public Builder faultDomain(String faultDomain) {
+            this.faultDomain = faultDomain;
+            this.__explicitlySet__.add("faultDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
+        private UpdateLaunchOptions launchOptions;
+
+        public Builder launchOptions(UpdateLaunchOptions launchOptions) {
+            this.launchOptions = launchOptions;
+            this.__explicitlySet__.add("launchOptions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -112,7 +130,9 @@ public class UpdateInstanceDetails {
                             metadata,
                             extendedMetadata,
                             shape,
-                            shapeConfig);
+                            shapeConfig,
+                            faultDomain,
+                            launchOptions);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -127,7 +147,9 @@ public class UpdateInstanceDetails {
                             .metadata(o.getMetadata())
                             .extendedMetadata(o.getExtendedMetadata())
                             .shape(o.getShape())
-                            .shapeConfig(o.getShapeConfig());
+                            .shapeConfig(o.getShapeConfig())
+                            .faultDomain(o.getFaultDomain())
+                            .launchOptions(o.getLaunchOptions());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -180,13 +202,16 @@ public class UpdateInstanceDetails {
 
     /**
      * Custom metadata key/value string pairs that you provide. Any set of key/value pairs
-     * provided here will completely replace the current set of key/value pairs in the 'metadata'
+     * provided here will completely replace the current set of key/value pairs in the `metadata`
      * field on the instance.
      * <p>
-     * Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-     * has launched. Any request which updates, removes, or adds either of these fields will be
-     * rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+     * The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+     * has launched. Any request that updates, removes, or adds either of these fields will be
+     * rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
      * already exist on the instance.
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+     * 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadata")
@@ -194,15 +219,18 @@ public class UpdateInstanceDetails {
 
     /**
      * Additional metadata key/value pairs that you provide. They serve the same purpose and
-     * functionality as fields in the 'metadata' object.
+     * functionality as fields in the `metadata` object.
      * <p>
-     * They are distinguished from 'metadata' fields in that these can be nested JSON objects
-     * (whereas 'metadata' fields are string/string maps only).
+     * They are distinguished from `metadata` fields in that these can be nested JSON objects
+     * (whereas `metadata` fields are string/string maps only).
      * <p>
-     * Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-     * has launched. Any request which updates, removes, or adds either of these fields will be
-     * rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+     * The \"user_data\" field and the \"ssh_authorized_keys\" field cannot be changed after an instance
+     * has launched. Any request that updates, removes, or adds either of these fields will be
+     * rejected. You must provide the same values for \"user_data\" and \"ssh_authorized_keys\" that
      * already exist on the instance.
+     * <p>
+     * The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+     * 32,000 bytes.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")
@@ -212,7 +240,7 @@ public class UpdateInstanceDetails {
      * The shape of the instance. The shape determines the number of CPUs and the amount of memory
      * allocated to the instance. For more information about how to change shapes, and a list of
      * shapes that are supported, see
-     * [Changing the Shape of an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+     * [Editing an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
      * <p>
      * For details about the CPUs, memory, and other properties of each shape, see
      * [Compute Shapes](https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm).
@@ -231,6 +259,30 @@ public class UpdateInstanceDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("shapeConfig")
     UpdateInstanceShapeConfigDetails shapeConfig;
+
+    /**
+     * A fault domain is a grouping of hardware and infrastructure within an availability domain.
+     * Each availability domain contains three fault domains. Fault domains let you distribute your
+     * instances so that they are not on the same physical hardware within a single availability domain.
+     * A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+     * instances in other fault domains.
+     * <p>
+     * To get a list of fault domains, use the
+     * {@link #listFaultDomains(ListFaultDomainsRequest) listFaultDomains} operation in the
+     * Identity and Access Management Service API.
+     * <p>
+     * Example: `FAULT-DOMAIN-1`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("faultDomain")
+    String faultDomain;
+
+    /**
+     * Options for tuning the compatibility and performance of VM shapes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
+    UpdateLaunchOptions launchOptions;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLaunchOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLaunchOptions.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Options for tuning the compatibility and performance of VM shapes.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateLaunchOptions.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateLaunchOptions {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeType")
+        private BootVolumeType bootVolumeType;
+
+        public Builder bootVolumeType(BootVolumeType bootVolumeType) {
+            this.bootVolumeType = bootVolumeType;
+            this.__explicitlySet__.add("bootVolumeType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+        private NetworkType networkType;
+
+        public Builder networkType(NetworkType networkType) {
+            this.networkType = networkType;
+            this.__explicitlySet__.add("networkType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+        private Boolean isPvEncryptionInTransitEnabled;
+
+        public Builder isPvEncryptionInTransitEnabled(Boolean isPvEncryptionInTransitEnabled) {
+            this.isPvEncryptionInTransitEnabled = isPvEncryptionInTransitEnabled;
+            this.__explicitlySet__.add("isPvEncryptionInTransitEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateLaunchOptions build() {
+            UpdateLaunchOptions __instance__ =
+                    new UpdateLaunchOptions(
+                            bootVolumeType, networkType, isPvEncryptionInTransitEnabled);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateLaunchOptions o) {
+            Builder copiedBuilder =
+                    bootVolumeType(o.getBootVolumeType())
+                            .networkType(o.getNetworkType())
+                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Emulation type for the boot volume.
+     * * `ISCSI` - ISCSI attached block storage device.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided plaform images.
+     * <p>
+     * Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+     * the boot volume and the primary VNIC.
+     * <p>
+     * If the instance is running when you change the boot volume attachment type, it will be rebooted.
+     * <p>
+     **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+     * the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+     * as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+     *
+     **/
+    public enum BootVolumeType {
+        Iscsi("ISCSI"),
+        Paravirtualized("PARAVIRTUALIZED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, BootVolumeType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BootVolumeType v : BootVolumeType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        BootVolumeType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BootVolumeType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid BootVolumeType: " + key);
+        }
+    };
+    /**
+     * Emulation type for the boot volume.
+     * * `ISCSI` - ISCSI attached block storage device.
+     * * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+     * storage volumes on Oracle-provided plaform images.
+     * <p>
+     * Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+     * the boot volume and the primary VNIC.
+     * <p>
+     * If the instance is running when you change the boot volume attachment type, it will be rebooted.
+     * <p>
+     **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+     * the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+     * as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeType")
+    BootVolumeType bootVolumeType;
+    /**
+     * Emulation type for the physical network interface card (NIC).
+     * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+     * when you launch an instance using hardware-assisted (SR-IOV) networking.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+     * <p>
+     * Before you change the networking type, detach all VNICs and block volumes except for the primary
+     * VNIC and the boot volume.
+     * <p>
+     * The image must have paravirtualized drivers installed. For more information, see
+     * [Editing an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+     * <p>
+     * If the instance is running when you change the network type, it will be rebooted.
+     * <p>
+     **Note:** Some instances might not function properly if you change the networking type. After
+     * the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+     * as expected, the changes are not supported. Revert the instance to the original networking type.
+     *
+     **/
+    public enum NetworkType {
+        Vfio("VFIO"),
+        Paravirtualized("PARAVIRTUALIZED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, NetworkType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NetworkType v : NetworkType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        NetworkType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NetworkType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid NetworkType: " + key);
+        }
+    };
+    /**
+     * Emulation type for the physical network interface card (NIC).
+     * * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+     * when you launch an instance using hardware-assisted (SR-IOV) networking.
+     * * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+     * <p>
+     * Before you change the networking type, detach all VNICs and block volumes except for the primary
+     * VNIC and the boot volume.
+     * <p>
+     * The image must have paravirtualized drivers installed. For more information, see
+     * [Editing an Instance](https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+     * <p>
+     * If the instance is running when you change the network type, it will be rebooted.
+     * <p>
+     **Note:** Some instances might not function properly if you change the networking type. After
+     * the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+     * as expected, the changes are not supported. Revert the instance to the original networking type.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("networkType")
+    NetworkType networkType;
+
+    /**
+     * Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+     * <p>
+     * Data in transit is transferred over an internal and highly secure network. If you have specific
+     * compliance requirements related to the encryption of the data while it is moving between the
+     * instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
+     * not enabled by default.
+     * <p>
+     * All boot volumes are encrypted at rest.
+     * <p>
+     * For more information, see [Block Volume Encryption](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm#Encrypti).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+    Boolean isPvEncryptionInTransitEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeDetails.java
@@ -72,13 +72,27 @@ public class UpdateVolumeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateVolumeDetails build() {
             UpdateVolumeDetails __instance__ =
                     new UpdateVolumeDetails(
-                            definedTags, displayName, freeformTags, vpusPerGB, sizeInGBs);
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            vpusPerGB,
+                            sizeInGBs,
+                            isAutoTuneEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +104,8 @@ public class UpdateVolumeDetails {
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .vpusPerGB(o.getVpusPerGB())
-                            .sizeInGBs(o.getSizeInGBs());
+                            .sizeInGBs(o.getSizeInGBs())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -154,6 +169,13 @@ public class UpdateVolumeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
     Long sizeInGBs;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Volume.java
@@ -179,6 +179,24 @@ public class Volume {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+        private Boolean isAutoTuneEnabled;
+
+        public Builder isAutoTuneEnabled(Boolean isAutoTuneEnabled) {
+            this.isAutoTuneEnabled = isAutoTuneEnabled;
+            this.__explicitlySet__.add("isAutoTuneEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")
+        private Long autoTunedVpusPerGB;
+
+        public Builder autoTunedVpusPerGB(Long autoTunedVpusPerGB) {
+            this.autoTunedVpusPerGB = autoTunedVpusPerGB;
+            this.__explicitlySet__.add("autoTunedVpusPerGB");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -200,7 +218,9 @@ public class Volume {
                             sizeInMBs,
                             sourceDetails,
                             timeCreated,
-                            volumeGroupId);
+                            volumeGroupId,
+                            isAutoTuneEnabled,
+                            autoTunedVpusPerGB);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -223,7 +243,9 @@ public class Volume {
                             .sizeInMBs(o.getSizeInMBs())
                             .sourceDetails(o.getSourceDetails())
                             .timeCreated(o.getTimeCreated())
-                            .volumeGroupId(o.getVolumeGroupId());
+                            .volumeGroupId(o.getVolumeGroupId())
+                            .isAutoTuneEnabled(o.getIsAutoTuneEnabled())
+                            .autoTunedVpusPerGB(o.getAutoTunedVpusPerGB());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -409,6 +431,20 @@ public class Volume {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupId")
     String volumeGroupId;
+
+    /**
+     * Specifies whether the auto-tune performance is enabled for this volume.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoTuneEnabled")
+    Boolean isAutoTuneEnabled;
+
+    /**
+     * The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autoTunedVpusPerGB")
+    Long autoTunedVpusPerGB;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeComputeImageCapabilitySchemaCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeComputeImageCapabilitySchemaCompartmentRequest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeComputeImageCapabilitySchemaCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                ChangeComputeImageCapabilitySchemaCompartmentDetails> {
+
+    /**
+     * The id of the compute image capability schema or the image ocid
+     */
+    private String computeImageCapabilitySchemaId;
+
+    /**
+     * Compute Image Capability Schema change compartment details
+     */
+    private ChangeComputeImageCapabilitySchemaCompartmentDetails
+            changeComputeImageCapabilitySchemaCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeComputeImageCapabilitySchemaCompartmentDetails getBody$() {
+        return changeComputeImageCapabilitySchemaCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeComputeImageCapabilitySchemaCompartmentRequest,
+                    ChangeComputeImageCapabilitySchemaCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeComputeImageCapabilitySchemaCompartmentRequest o) {
+            computeImageCapabilitySchemaId(o.getComputeImageCapabilitySchemaId());
+            changeComputeImageCapabilitySchemaCompartmentDetails(
+                    o.getChangeComputeImageCapabilitySchemaCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeComputeImageCapabilitySchemaCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeComputeImageCapabilitySchemaCompartmentRequest
+         */
+        public ChangeComputeImageCapabilitySchemaCompartmentRequest build() {
+            ChangeComputeImageCapabilitySchemaCompartmentRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeComputeImageCapabilitySchemaCompartmentDetails body) {
+            changeComputeImageCapabilitySchemaCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateComputeImageCapabilitySchemaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/CreateComputeImageCapabilitySchemaRequest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateComputeImageCapabilitySchemaRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateComputeImageCapabilitySchemaDetails> {
+
+    /**
+     * Compute Image Capability Schema creation details
+     */
+    private CreateComputeImageCapabilitySchemaDetails createComputeImageCapabilitySchemaDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateComputeImageCapabilitySchemaDetails getBody$() {
+        return createComputeImageCapabilitySchemaDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateComputeImageCapabilitySchemaRequest,
+                    CreateComputeImageCapabilitySchemaDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateComputeImageCapabilitySchemaRequest o) {
+            createComputeImageCapabilitySchemaDetails(
+                    o.getCreateComputeImageCapabilitySchemaDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateComputeImageCapabilitySchemaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateComputeImageCapabilitySchemaRequest
+         */
+        public CreateComputeImageCapabilitySchemaRequest build() {
+            CreateComputeImageCapabilitySchemaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateComputeImageCapabilitySchemaDetails body) {
+            createComputeImageCapabilitySchemaDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteComputeImageCapabilitySchemaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteComputeImageCapabilitySchemaRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteComputeImageCapabilitySchemaRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The id of the compute image capability schema or the image ocid
+     */
+    private String computeImageCapabilitySchemaId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteComputeImageCapabilitySchemaRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteComputeImageCapabilitySchemaRequest o) {
+            computeImageCapabilitySchemaId(o.getComputeImageCapabilitySchemaId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteComputeImageCapabilitySchemaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteComputeImageCapabilitySchemaRequest
+         */
+        public DeleteComputeImageCapabilitySchemaRequest build() {
+            DeleteComputeImageCapabilitySchemaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeGlobalImageCapabilitySchemaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeGlobalImageCapabilitySchemaRequest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetComputeGlobalImageCapabilitySchemaRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+     */
+    private String computeGlobalImageCapabilitySchemaId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetComputeGlobalImageCapabilitySchemaRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeGlobalImageCapabilitySchemaRequest o) {
+            computeGlobalImageCapabilitySchemaId(o.getComputeGlobalImageCapabilitySchemaId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetComputeGlobalImageCapabilitySchemaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetComputeGlobalImageCapabilitySchemaRequest
+         */
+        public GetComputeGlobalImageCapabilitySchemaRequest build() {
+            GetComputeGlobalImageCapabilitySchemaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeGlobalImageCapabilitySchemaVersionRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeGlobalImageCapabilitySchemaVersionRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetComputeGlobalImageCapabilitySchemaVersionRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+     */
+    private String computeGlobalImageCapabilitySchemaId;
+
+    /**
+     * The name of the compute global image capability schema version
+     */
+    private String computeGlobalImageCapabilitySchemaVersionName;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetComputeGlobalImageCapabilitySchemaVersionRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeGlobalImageCapabilitySchemaVersionRequest o) {
+            computeGlobalImageCapabilitySchemaId(o.getComputeGlobalImageCapabilitySchemaId());
+            computeGlobalImageCapabilitySchemaVersionName(
+                    o.getComputeGlobalImageCapabilitySchemaVersionName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetComputeGlobalImageCapabilitySchemaVersionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetComputeGlobalImageCapabilitySchemaVersionRequest
+         */
+        public GetComputeGlobalImageCapabilitySchemaVersionRequest build() {
+            GetComputeGlobalImageCapabilitySchemaVersionRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeImageCapabilitySchemaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetComputeImageCapabilitySchemaRequest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetComputeImageCapabilitySchemaRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The id of the compute image capability schema or the image ocid
+     */
+    private String computeImageCapabilitySchemaId;
+
+    /**
+     * Merge the image capability schema with the global image capability schema
+     *
+     */
+    private Boolean isMergeEnabled;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetComputeImageCapabilitySchemaRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeImageCapabilitySchemaRequest o) {
+            computeImageCapabilitySchemaId(o.getComputeImageCapabilitySchemaId());
+            isMergeEnabled(o.getIsMergeEnabled());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetComputeImageCapabilitySchemaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetComputeImageCapabilitySchemaRequest
+         */
+        public GetComputeImageCapabilitySchemaRequest build() {
+            GetComputeImageCapabilitySchemaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeGlobalImageCapabilitySchemaVersionsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeGlobalImageCapabilitySchemaVersionsRequest.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListComputeGlobalImageCapabilitySchemaVersionsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+     */
+    private String computeGlobalImageCapabilitySchemaId;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListComputeGlobalImageCapabilitySchemaVersionsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeGlobalImageCapabilitySchemaVersionsRequest o) {
+            computeGlobalImageCapabilitySchemaId(o.getComputeGlobalImageCapabilitySchemaId());
+            displayName(o.getDisplayName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListComputeGlobalImageCapabilitySchemaVersionsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListComputeGlobalImageCapabilitySchemaVersionsRequest
+         */
+        public ListComputeGlobalImageCapabilitySchemaVersionsRequest build() {
+            ListComputeGlobalImageCapabilitySchemaVersionsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeGlobalImageCapabilitySchemasRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeGlobalImageCapabilitySchemasRequest.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListComputeGlobalImageCapabilitySchemasRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * A filter to return only resources that match the given compartment OCID exactly.
+     *
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListComputeGlobalImageCapabilitySchemasRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeGlobalImageCapabilitySchemasRequest o) {
+            compartmentId(o.getCompartmentId());
+            displayName(o.getDisplayName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListComputeGlobalImageCapabilitySchemasRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListComputeGlobalImageCapabilitySchemasRequest
+         */
+        public ListComputeGlobalImageCapabilitySchemasRequest build() {
+            ListComputeGlobalImageCapabilitySchemasRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeImageCapabilitySchemasRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListComputeImageCapabilitySchemasRequest.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListComputeImageCapabilitySchemasRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * A filter to return only resources that match the given compartment OCID exactly.
+     *
+     */
+    private String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an image.
+     */
+    private String imageId;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListComputeImageCapabilitySchemasRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeImageCapabilitySchemasRequest o) {
+            compartmentId(o.getCompartmentId());
+            imageId(o.getImageId());
+            displayName(o.getDisplayName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListComputeImageCapabilitySchemasRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListComputeImageCapabilitySchemasRequest
+         */
+        public ListComputeImageCapabilitySchemasRequest build() {
+            ListComputeImageCapabilitySchemasRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateComputeImageCapabilitySchemaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateComputeImageCapabilitySchemaRequest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateComputeImageCapabilitySchemaRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateComputeImageCapabilitySchemaDetails> {
+
+    /**
+     * The id of the compute image capability schema or the image ocid
+     */
+    private String computeImageCapabilitySchemaId;
+
+    /**
+     * Updates the freeFormTags, definedTags, and display name of the image capability schema
+     */
+    private UpdateComputeImageCapabilitySchemaDetails updateComputeImageCapabilitySchemaDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateComputeImageCapabilitySchemaDetails getBody$() {
+        return updateComputeImageCapabilitySchemaDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateComputeImageCapabilitySchemaRequest,
+                    UpdateComputeImageCapabilitySchemaDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateComputeImageCapabilitySchemaRequest o) {
+            computeImageCapabilitySchemaId(o.getComputeImageCapabilitySchemaId());
+            updateComputeImageCapabilitySchemaDetails(
+                    o.getUpdateComputeImageCapabilitySchemaDetails());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateComputeImageCapabilitySchemaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateComputeImageCapabilitySchemaRequest
+         */
+        public UpdateComputeImageCapabilitySchemaRequest build() {
+            UpdateComputeImageCapabilitySchemaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateComputeImageCapabilitySchemaDetails body) {
+            updateComputeImageCapabilitySchemaDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeComputeImageCapabilitySchemaCompartmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeComputeImageCapabilitySchemaCompartmentResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeComputeImageCapabilitySchemaCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeComputeImageCapabilitySchemaCompartmentResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateComputeImageCapabilitySchemaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CreateComputeImageCapabilitySchemaResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateComputeImageCapabilitySchemaResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ComputeImageCapabilitySchema instance.
+     */
+    private ComputeImageCapabilitySchema computeImageCapabilitySchema;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateComputeImageCapabilitySchemaResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            computeImageCapabilitySchema(o.getComputeImageCapabilitySchema());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteComputeImageCapabilitySchemaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/DeleteComputeImageCapabilitySchemaResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteComputeImageCapabilitySchemaResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteComputeImageCapabilitySchemaResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeGlobalImageCapabilitySchemaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeGlobalImageCapabilitySchemaResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetComputeGlobalImageCapabilitySchemaResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ComputeGlobalImageCapabilitySchema instance.
+     */
+    private ComputeGlobalImageCapabilitySchema computeGlobalImageCapabilitySchema;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeGlobalImageCapabilitySchemaResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            computeGlobalImageCapabilitySchema(o.getComputeGlobalImageCapabilitySchema());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeGlobalImageCapabilitySchemaVersionResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeGlobalImageCapabilitySchemaVersionResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetComputeGlobalImageCapabilitySchemaVersionResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ComputeGlobalImageCapabilitySchemaVersion instance.
+     */
+    private ComputeGlobalImageCapabilitySchemaVersion computeGlobalImageCapabilitySchemaVersion;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeGlobalImageCapabilitySchemaVersionResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            computeGlobalImageCapabilitySchemaVersion(
+                    o.getComputeGlobalImageCapabilitySchemaVersion());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeImageCapabilitySchemaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetComputeImageCapabilitySchemaResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetComputeImageCapabilitySchemaResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ComputeImageCapabilitySchema instance.
+     */
+    private ComputeImageCapabilitySchema computeImageCapabilitySchema;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetComputeImageCapabilitySchemaResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            computeImageCapabilitySchema(o.getComputeImageCapabilitySchema());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeGlobalImageCapabilitySchemaVersionsResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeGlobalImageCapabilitySchemaVersionsResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListComputeGlobalImageCapabilitySchemaVersionsResponse {
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of ComputeGlobalImageCapabilitySchemaVersionSummary instances.
+     */
+    private java.util.List<ComputeGlobalImageCapabilitySchemaVersionSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeGlobalImageCapabilitySchemaVersionsResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeGlobalImageCapabilitySchemasResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeGlobalImageCapabilitySchemasResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListComputeGlobalImageCapabilitySchemasResponse {
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of ComputeGlobalImageCapabilitySchemaSummary instances.
+     */
+    private java.util.List<ComputeGlobalImageCapabilitySchemaSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeGlobalImageCapabilitySchemasResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeImageCapabilitySchemasResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListComputeImageCapabilitySchemasResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListComputeImageCapabilitySchemasResponse {
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of ComputeImageCapabilitySchemaSummary instances.
+     */
+    private java.util.List<ComputeImageCapabilitySchemaSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListComputeImageCapabilitySchemasResponse o) {
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateComputeImageCapabilitySchemaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/UpdateComputeImageCapabilitySchemaResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateComputeImageCapabilitySchemaResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ComputeImageCapabilitySchema instance.
+     */
+    private ComputeImageCapabilitySchema computeImageCapabilitySchema;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateComputeImageCapabilitySchemaResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            computeImageCapabilitySchema(o.getComputeImageCapabilitySchema());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateMaintenanceRunDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateMaintenanceRunDetails.java
@@ -45,19 +45,31 @@ public class UpdateMaintenanceRunDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isPatchNowEnabled")
+        private Boolean isPatchNowEnabled;
+
+        public Builder isPatchNowEnabled(Boolean isPatchNowEnabled) {
+            this.isPatchNowEnabled = isPatchNowEnabled;
+            this.__explicitlySet__.add("isPatchNowEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateMaintenanceRunDetails build() {
             UpdateMaintenanceRunDetails __instance__ =
-                    new UpdateMaintenanceRunDetails(isEnabled, timeScheduled);
+                    new UpdateMaintenanceRunDetails(isEnabled, timeScheduled, isPatchNowEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateMaintenanceRunDetails o) {
-            Builder copiedBuilder = isEnabled(o.getIsEnabled()).timeScheduled(o.getTimeScheduled());
+            Builder copiedBuilder =
+                    isEnabled(o.getIsEnabled())
+                            .timeScheduled(o.getTimeScheduled())
+                            .isPatchNowEnabled(o.getIsPatchNowEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -82,6 +94,12 @@ public class UpdateMaintenanceRunDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeScheduled")
     java.util.Date timeScheduled;
+
+    /**
+     * If set to `TRUE`, starts patching immediately.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPatchNowEnabled")
+    Boolean isPatchNowEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.19.4</version>
+        <version>1.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManager.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManager.java
@@ -98,7 +98,8 @@ public interface ResourceManager extends AutoCloseable {
 
     /**
      * Creates a stack in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * You can create a stack from a Terraform configuration file.
+     * The Terraform configuration file can be directly uploaded or referenced from a source code control system.
      * For more information, see
      * [To create a stack](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Tasks/managingstacksandjobs.htm#CreateStack).
      *

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManagerAsync.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManagerAsync.java
@@ -135,7 +135,8 @@ public interface ResourceManagerAsync extends AutoCloseable {
 
     /**
      * Creates a stack in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * You can create a stack from a Terraform configuration file.
+     * The Terraform configuration file can be directly uploaded or referenced from a source code control system.
      * For more information, see
      * [To create a stack](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Tasks/managingstacksandjobs.htm#CreateStack).
      *

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateConfigSourceDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateConfigSourceDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.resourcemanager.model;
 
 /**
- * Property details for the configuration source.
+ * Property details for the configuration source used for the stack.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateGitlabAccessTokenConfigurationSourceProviderDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateGitlabAccessTokenConfigurationSourceProviderDetails.java
@@ -155,7 +155,7 @@ public class CreateGitlabAccessTokenConfigurationSourceProviderDetails
 
     /**
      * The Git service API endpoint.
-     * Example: `https://gitlab.com/api/v3/`
+     * Example: `https://gitlab.com/api/v4/`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("apiEndpoint")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateStackDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateStackDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.resourcemanager.model;
 
 /**
- * Properties provided for creating a stack.
+ * The configuration details for creating a stack.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -164,7 +165,7 @@ public class CreateStackDetails {
 
     /**
      * Terraform variables associated with this resource.
-     * Maximum number of variables supported is 100.
+     * Maximum number of variables supported is 250.
      * The maximum size of each variable, including both name and value, is 4096 bytes.
      * Example: `{\"CompartmentId\": \"compartment-id-value\"}`
      *

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/GitlabAccessTokenConfigurationSourceProvider.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/GitlabAccessTokenConfigurationSourceProvider.java
@@ -116,15 +116,6 @@ public class GitlabAccessTokenConfigurationSourceProvider extends ConfigurationS
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("accessToken")
-        private String accessToken;
-
-        public Builder accessToken(String accessToken) {
-            this.accessToken = accessToken;
-            this.__explicitlySet__.add("accessToken");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -139,8 +130,7 @@ public class GitlabAccessTokenConfigurationSourceProvider extends ConfigurationS
                             lifecycleState,
                             freeformTags,
                             definedTags,
-                            apiEndpoint,
-                            accessToken);
+                            apiEndpoint);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -156,8 +146,7 @@ public class GitlabAccessTokenConfigurationSourceProvider extends ConfigurationS
                             .lifecycleState(o.getLifecycleState())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .apiEndpoint(o.getApiEndpoint())
-                            .accessToken(o.getAccessToken());
+                            .apiEndpoint(o.getApiEndpoint());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -181,8 +170,7 @@ public class GitlabAccessTokenConfigurationSourceProvider extends ConfigurationS
             LifecycleState lifecycleState,
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
-            String apiEndpoint,
-            String accessToken) {
+            String apiEndpoint) {
         super(
                 id,
                 compartmentId,
@@ -193,22 +181,15 @@ public class GitlabAccessTokenConfigurationSourceProvider extends ConfigurationS
                 freeformTags,
                 definedTags);
         this.apiEndpoint = apiEndpoint;
-        this.accessToken = accessToken;
     }
 
     /**
      * The Git service API endpoint.
-     * Example: `https://gitlab.com/api/v3/`
+     * Example: `https://gitlab.com/api/v4/`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("apiEndpoint")
     String apiEndpoint;
-
-    /**
-     * The personal access token configured on the Git repository.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("accessToken")
-    String accessToken;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/GitlabAccessTokenConfigurationSourceProviderSummary.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/GitlabAccessTokenConfigurationSourceProviderSummary.java
@@ -186,7 +186,7 @@ public class GitlabAccessTokenConfigurationSourceProviderSummary
 
     /**
      * The Git service API endpoint.
-     * Example: `https://gitlab.com/api/v3/`
+     * Example: `https://gitlab.com/api/v4/`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("apiEndpoint")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
@@ -421,14 +421,16 @@ public class Job {
     FailureDetails failureDetails;
 
     /**
-     * The file path to the directory within the configuration from which the job runs.
+     * File path to the directory from which Terraform runs.
+     * If not specified, the root directory is used.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workingDirectory")
     String workingDirectory;
 
     /**
      * Terraform variables associated with this resource.
-     * Maximum number of variables supported is 100.
+     * Maximum number of variables supported is 250.
      * The maximum size of each variable, including both name and value, is 4096 bytes.
      * Example: `{\"CompartmentId\": \"compartment-id-value\"}`
      *

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Stack.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Stack.java
@@ -293,7 +293,7 @@ public class Stack {
 
     /**
      * Terraform variables associated with this resource.
-     * Maximum number of variables supported is 100.
+     * Maximum number of variables supported is 250.
      * The maximum size of each variable, including both name and value, is 4096 bytes.
      * Example: `{\"CompartmentId\": \"compartment-id-value\"}`
      *

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateGitlabAccessTokenConfigurationSourceProviderDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateGitlabAccessTokenConfigurationSourceProviderDetails.java
@@ -143,7 +143,7 @@ public class UpdateGitlabAccessTokenConfigurationSourceProviderDetails
 
     /**
      * The Git service API endpoint.
-     * Example: `https://gitlab.com/api/v3/`
+     * Example: `https://gitlab.com/api/v4/`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("apiEndpoint")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateStackDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateStackDetails.java
@@ -148,7 +148,7 @@ public class UpdateStackDetails {
 
     /**
      * Terraform variables associated with this resource.
-     * The maximum number of variables supported is 100.
+     * The maximum number of variables supported is 250.
      * The maximum size of each variable, including both name and value, is 4096 bytes.
      * Example: `{\"CompartmentId\": \"compartment-id-value\"}`
      *

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.19.4</version>
+    <version>1.20.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.19.4</version>
+      <version>1.20.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.19.4</version>
+  <version>1.20.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for calling Oracle Cloud Infrastructure services in the us-sanjose-1 region

- Support for updating the fault domain and launch options of VM instances in the Compute service

- Support for image capability schemas and schema versions in the Compute service

- Support for 'Patch Now' maintenance runs for autonomous Exadata infrastructure and autonomous container database resources in the Database service

- Support for automatic performance and cost tuning on volumes in the Block Storage service





### Breaking changes

- Removed the accessToken field from the GitlabAccessTokenConfigurationSourceProvider model in the Resource Manager service
