### PR TITLE
Releasing version 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.22.0 - 2020-08-11
+### Added
+- Support for autonomous json databases in the Database service
+- Support for cleaning up uncommitted multipart uploads in the Object Storage service
+- Support for additional list API filters in the Data Catalog service
+
+
+### Breaking Changes
+- Some unusable region enums were removed from the Support Management service
+- Parameter `opcRetryToken` was removed from the Support Management service
+
 ## 1.21.0 - 2020-08-04
 ### Added
 - Support for calling Oracle Cloud Infrastructure services in the uk-gov-cardiff-1 region

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,324 +19,324 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/Incident.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/Incident.java
@@ -41,7 +41,7 @@ public interface Incident extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * This API enables the customer to Create an Incident
+     * Enables the customer to create an support ticket.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -49,7 +49,7 @@ public interface Incident extends AutoCloseable {
     CreateIncidentResponse createIncident(CreateIncidentRequest request);
 
     /**
-     * This API fetches the details of a requested Incident
+     * Gets the details of the support ticket.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -57,7 +57,7 @@ public interface Incident extends AutoCloseable {
     GetIncidentResponse getIncident(GetIncidentRequest request);
 
     /**
-     * GetStatus of the Service
+     * Gets the status of the service.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -65,7 +65,7 @@ public interface Incident extends AutoCloseable {
     GetStatusResponse getStatus(GetStatusRequest request);
 
     /**
-     * This API returns the list of all possible product that OCI supports, while creating an incident
+     * During support ticket creation, returns the list of all possible products that Oracle Cloud Infrastructure supports.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -74,7 +74,7 @@ public interface Incident extends AutoCloseable {
             ListIncidentResourceTypesRequest request);
 
     /**
-     * This API returns the list of incidents raised by the tenant
+     * Returns the list of support tickets raised by the tenancy.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -82,7 +82,7 @@ public interface Incident extends AutoCloseable {
     ListIncidentsResponse listIncidents(ListIncidentsRequest request);
 
     /**
-     * This API updates an existing incident
+     * Updates the specified support ticket's information.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -90,7 +90,7 @@ public interface Incident extends AutoCloseable {
     UpdateIncidentResponse updateIncident(UpdateIncidentRequest request);
 
     /**
-     * ValidateUser
+     * Checks whether the requested user is valid.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/IncidentAsync.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/IncidentAsync.java
@@ -41,7 +41,7 @@ public interface IncidentAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * This API enables the customer to Create an Incident
+     * Enables the customer to create an support ticket.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -56,7 +56,7 @@ public interface IncidentAsync extends AutoCloseable {
                     handler);
 
     /**
-     * This API fetches the details of a requested Incident
+     * Gets the details of the support ticket.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -70,7 +70,7 @@ public interface IncidentAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetIncidentRequest, GetIncidentResponse> handler);
 
     /**
-     * GetStatus of the Service
+     * Gets the status of the service.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -84,7 +84,7 @@ public interface IncidentAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetStatusRequest, GetStatusResponse> handler);
 
     /**
-     * This API returns the list of all possible product that OCI supports, while creating an incident
+     * During support ticket creation, returns the list of all possible products that Oracle Cloud Infrastructure supports.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -100,7 +100,7 @@ public interface IncidentAsync extends AutoCloseable {
                     handler);
 
     /**
-     * This API returns the list of incidents raised by the tenant
+     * Returns the list of support tickets raised by the tenancy.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -115,7 +115,7 @@ public interface IncidentAsync extends AutoCloseable {
                     handler);
 
     /**
-     * This API updates an existing incident
+     * Updates the specified support ticket's information.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -130,7 +130,7 @@ public interface IncidentAsync extends AutoCloseable {
                     handler);
 
     /**
-     * ValidateUser
+     * Checks whether the requested user is valid.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/User.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/User.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims;
+
+import com.oracle.bmc.cims.requests.*;
+import com.oracle.bmc.cims.responses.*;
+
+/**
+ * Use the Support Management API to manage support requests. For more information, see [Getting Help and Contacting Support](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/contactingsupport.htm). **Note**: Before you can create service requests with this API, you need to have an Oracle Single Sign On (SSO) account, and you need to register your Customer Support Identifier (CSI) with My Oracle Support.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+public interface User extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create user to request Customer Support Identifier(CSI) to Customer User Administrator(CUA).
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateUserResponse createUser(CreateUserRequest request);
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/UserAsync.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/UserAsync.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims;
+
+import com.oracle.bmc.cims.requests.*;
+import com.oracle.bmc.cims.responses.*;
+
+/**
+ * Use the Support Management API to manage support requests. For more information, see [Getting Help and Contacting Support](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/contactingsupport.htm). **Note**: Before you can create service requests with this API, you need to have an Oracle Single Sign On (SSO) account, and you need to register your Customer Support Identifier (CSI) with My Oracle Support.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+public interface UserAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Create user to request Customer Support Identifier(CSI) to Customer User Administrator(CUA).
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateUserResponse> createUser(
+            CreateUserRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateUserRequest, CreateUserResponse> handler);
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/UserAsyncClient.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/UserAsyncClient.java
@@ -1,0 +1,393 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims;
+
+import java.util.Locale;
+import com.oracle.bmc.cims.internal.http.*;
+import com.oracle.bmc.cims.requests.*;
+import com.oracle.bmc.cims.responses.*;
+
+/**
+ * Async client implementation for User service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.extern.slf4j.Slf4j
+public class UserAsyncClient implements UserAsync {
+    /**
+     * Service instance for User.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("USER")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate(
+                            "https://incidentmanagement.{region}.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public UserAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, UserAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public UserAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new UserAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateUserResponse> createUser(
+            final CreateUserRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateUserRequest, CreateUserResponse>
+                    handler) {
+        LOG.trace("Called async createUser");
+        final CreateUserRequest interceptedRequest = CreateUserConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateUserConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateUserResponse>
+                transformer = CreateUserConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreateUserRequest, CreateUserResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateUserRequest, CreateUserResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateUserDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateUserDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateUserResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateUserDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/UserClient.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/UserClient.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims;
+
+import java.util.Locale;
+import com.oracle.bmc.cims.internal.http.*;
+import com.oracle.bmc.cims.requests.*;
+import com.oracle.bmc.cims.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.extern.slf4j.Slf4j
+public class UserClient implements User {
+    /**
+     * Service instance for User.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("USER")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate(
+                            "https://incidentmanagement.{region}.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public UserClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public UserClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public UserClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public UserClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public UserClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public UserClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public UserClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected UserClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(additionalClientConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, UserClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public UserClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new UserClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public CreateUserResponse createUser(CreateUserRequest request) {
+        LOG.trace("Called createUser");
+        final CreateUserRequest interceptedRequest = CreateUserConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateUserConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateUserResponse> transformer =
+                CreateUserConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateUserDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/CreateIncidentConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/CreateIncidentConverter.java
@@ -37,15 +37,15 @@ public class CreateIncidentConverter {
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
 
-        if (request.getOpcRetryToken() != null) {
-            ib.header("opc-retry-token", request.getOpcRetryToken());
-        }
-
         if (request.getOpcRequestId() != null) {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
         ib.header("ocid", request.getOcid());
+
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
 
         return ib;
     }
@@ -93,15 +93,6 @@ public class CreateIncidentConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.CreateIncidentResponse

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/CreateUserConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/CreateUserConverter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cims.model.*;
+import com.oracle.bmc.cims.requests.*;
+import com.oracle.bmc.cims.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.extern.slf4j.Slf4j
+public class CreateUserConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cims.requests.CreateUserRequest interceptRequest(
+            com.oracle.bmc.cims.requests.CreateUserRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cims.requests.CreateUserRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateUserDetails(), "createUserDetails is required");
+        Validate.notNull(request.getOcid(), "ocid is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20181231").path("v2").path("users");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        ib.header("ocid", request.getOcid());
+
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.cims.responses.CreateUserResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.cims.responses.CreateUserResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cims.responses.CreateUserResponse>() {
+                            @Override
+                            public com.oracle.bmc.cims.responses.CreateUserResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cims.responses.CreateUserResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<User>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(User.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<User> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cims.responses.CreateUserResponse.Builder builder =
+                                        com.oracle.bmc.cims.responses.CreateUserResponse.builder();
+
+                                builder.user(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cims.responses.CreateUserResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/GetIncidentConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/GetIncidentConverter.java
@@ -52,6 +52,14 @@ public class GetIncidentConverter {
 
         ib.header("ocid", request.getOcid());
 
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
+
+        if (request.getProblemType() != null) {
+            ib.header("problem-type", request.getProblemType());
+        }
+
         return ib;
     }
 
@@ -96,15 +104,6 @@ public class GetIncidentConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.GetIncidentResponse responseWrapper =

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/GetStatusConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/GetStatusConverter.java
@@ -50,6 +50,10 @@ public class GetStatusConverter {
 
         ib.header("ocid", request.getOcid());
 
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
+
         return ib;
     }
 
@@ -93,15 +97,6 @@ public class GetStatusConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.GetStatusResponse responseWrapper =

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ListIncidentResourceTypesConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ListIncidentResourceTypesConverter.java
@@ -103,6 +103,10 @@ public class ListIncidentResourceTypesConverter {
 
         ib.header("ocid", request.getOcid());
 
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
+
         return ib;
     }
 
@@ -169,15 +173,6 @@ public class ListIncidentResourceTypesConverter {
                                                     "opc-next-page",
                                                     opcNextPageHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.ListIncidentResourceTypesResponse

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ListIncidentsConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ListIncidentsConverter.java
@@ -80,6 +80,14 @@ public class ListIncidentsConverter {
                                     request.getPage()));
         }
 
+        if (request.getProblemType() != null) {
+            target =
+                    target.queryParam(
+                            "problemType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getProblemType()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -91,6 +99,10 @@ public class ListIncidentsConverter {
         }
 
         ib.header("ocid", request.getOcid());
+
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
 
         return ib;
     }
@@ -155,15 +167,6 @@ public class ListIncidentsConverter {
                                                     "opc-next-page",
                                                     opcNextPageHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.ListIncidentsResponse

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/UpdateIncidentConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/UpdateIncidentConverter.java
@@ -47,10 +47,6 @@ public class UpdateIncidentConverter {
 
         ib.header("csi", request.getCsi());
 
-        if (request.getOpcRetryToken() != null) {
-            ib.header("opc-retry-token", request.getOpcRetryToken());
-        }
-
         if (request.getOpcRequestId() != null) {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
@@ -60,6 +56,10 @@ public class UpdateIncidentConverter {
         }
 
         ib.header("ocid", request.getOcid());
+
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
 
         return ib;
     }
@@ -107,15 +107,6 @@ public class UpdateIncidentConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.UpdateIncidentResponse

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ValidateUserConverter.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/internal/http/ValidateUserConverter.java
@@ -52,15 +52,15 @@ public class ValidateUserConverter {
 
         ib.header("csi", request.getCsi());
 
-        if (request.getOpcRetryToken() != null) {
-            ib.header("opc-retry-token", request.getOpcRetryToken());
-        }
-
         if (request.getOpcRequestId() != null) {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
         ib.header("ocid", request.getOcid());
+
+        if (request.getHomeregion() != null) {
+            ib.header("homeregion", request.getHomeregion());
+        }
 
         return ib;
     }
@@ -109,15 +109,6 @@ public class ValidateUserConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "etag");
-                                if (etagHeader.isPresent()) {
-                                    builder.etag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "etag", etagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.cims.responses.ValidateUserResponse responseWrapper =

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ActivityItem.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ActivityItem.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Activity Item
+ * Details about the ActivityItem object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -187,24 +187,24 @@ public class ActivityItem extends Item {
     }
 
     /**
-     * Comments to update as part of Activity
+     * Comments added with the activity on the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("comments")
     String comments;
 
     /**
-     * Epoch time when activity was created
+     * The time when the activity was created, in milliseconds since epoch time.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     Integer timeCreated;
 
     /**
-     * Epoch time when activity was updated
+     * The time when the activity was updated, in milliseconds since epoch time.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     Integer timeUpdated;
     /**
-     * Type of activity. eg: NOTES, UPDATE
+     * The type of activity occuring on the support ticket.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum ActivityType {
@@ -252,12 +252,12 @@ public class ActivityItem extends Item {
         }
     };
     /**
-     * Type of activity. eg: NOTES, UPDATE
+     * The type of activity occuring on the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("activityType")
     ActivityType activityType;
     /**
-     * Person who updates the activity
+     * The person who updates the activity on the support ticket.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum ActivityAuthor {
@@ -303,7 +303,7 @@ public class ActivityItem extends Item {
         }
     };
     /**
-     * Person who updates the activity
+     * The person who updates the activity on the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("activityAuthor")
     ActivityAuthor activityAuthor;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/AvailabilityDomain.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/AvailabilityDomain.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Availability Domain supported by CIMS. eg: PHX_AD_1, PHX_AD_1
+ * The list of availability domains supported by the Support Management API.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j
@@ -36,8 +36,6 @@ public enum AvailabilityDomain {
     ApSeoul1Ad1("AP_SEOUL_1_AD_1"),
     ApMumbai1Ad1("AP_MUMBAI_1_AD_1"),
     SaSaopaulo1Ad1("SA_SAOPAULO_1_AD_1"),
-    UsLuke1Ad1("US_LUKE_1_AD_1"),
-    UsLangley1Ad1("US_LANGLEY_1_AD_1"),
     MeJeddah1Ad1("ME_JEDDAH_1_AD_1"),
     ApOsaka1Ad1("AP_OSAKA_1_AD_1"),
     ApSydney1Ad1("AP_SYDNEY_1_AD_1"),
@@ -47,7 +45,6 @@ public enum AvailabilityDomain {
     CaMontreal1Ad1("CA_MONTREAL_1_AD_1"),
     ApHyderabad1Ad1("AP_HYDERABAD_1_AD_1"),
     ApChuncheon1Ad1("AP_CHUNCHEON_1_AD_1"),
-    UsTacoma1Ad1("US_TACOMA_1_AD_1"),
     NoAd("NO_AD"),
 
     /**

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Category.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Category.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Category of the incident
+ * Details about the category associated with the support ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class Category {
     }
 
     /**
-     * Unique ID that identifies a Category
+     * Unique identifier for the category.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("categoryKey")
     String categoryKey;
 
     /**
-     * Name of category. eg: Compute, Identity
+     * The name of the category. For example, `Compute` or `Identity`.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Classifier.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Classifier.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Incident Classifier details
+ * Details about the incident classifier object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -121,36 +121,36 @@ public class Classifier {
     }
 
     /**
-     * Unique ID that identifies a classifier
+     * Unique identifier of the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Name of classifier. eg: LIMIT Increase
+     * The display name of the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Label of classifier
+     * The label associated with the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("label")
     String label;
 
     /**
-     * Description of classifier
+     * The description of the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * List of Issues
+     * The list of issues.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("issueTypeList")
     java.util.List<IssueType> issueTypeList;
     /**
-     * Scope of Service category/resource
+     * The scope of the service category or resource.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Scope {
@@ -198,12 +198,12 @@ public class Classifier {
         }
     };
     /**
-     * Scope of Service category/resource
+     * The scope of the service category or resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scope")
     Scope scope;
     /**
-     * Unit to measure Service category/ resource
+     * The unit to use to measure the service category or resource.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Unit {
@@ -249,7 +249,7 @@ public class Classifier {
         }
     };
     /**
-     * Unit to measure Service category/ resource
+     * The unit to use to measure the service category or resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("unit")
     Unit unit;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Contact.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Contact.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Contact Details of the Customer
+ * Contact details for the customer.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -91,24 +91,24 @@ public class Contact {
     }
 
     /**
-     * Contact person name
+     * The name of the contact person.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contactName")
     String contactName;
 
     /**
-     * Contact person email
+     * The email of the contact person.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contactEmail")
     String contactEmail;
 
     /**
-     * Contact person phone number
+     * The phone number of the contact person.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contactPhone")
     String contactPhone;
     /**
-     * ContactType enum. eg: MANAGER, PRIMARY
+     * The type of contact, such as primary or alternate.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum ContactType {
@@ -157,7 +157,7 @@ public class Contact {
         }
     };
     /**
-     * ContactType enum. eg: MANAGER, PRIMARY
+     * The type of contact, such as primary or alternate.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contactType")
     ContactType contactType;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ContactList.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ContactList.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * List of contacts
+ * The list of contacts for the ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -59,7 +59,7 @@ public class ContactList {
     }
 
     /**
-     * List of contacts
+     * The list of contacts.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contactList")
     java.util.List<Contact> contactList;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ContextualData.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ContextualData.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ContextualData.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContextualData {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("clientId")
+        private String clientId;
+
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            this.__explicitlySet__.add("clientId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaName")
+        private String schemaName;
+
+        public Builder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            this.__explicitlySet__.add("schemaName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaVersion")
+        private String schemaVersion;
+
+        public Builder schemaVersion(String schemaVersion) {
+            this.schemaVersion = schemaVersion;
+            this.__explicitlySet__.add("schemaVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("payload")
+        private String payload;
+
+        public Builder payload(String payload) {
+            this.payload = payload;
+            this.__explicitlySet__.add("payload");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContextualData build() {
+            ContextualData __instance__ =
+                    new ContextualData(clientId, schemaName, schemaVersion, payload);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContextualData o) {
+            Builder copiedBuilder =
+                    clientId(o.getClientId())
+                            .schemaName(o.getSchemaName())
+                            .schemaVersion(o.getSchemaVersion())
+                            .payload(o.getPayload());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique client identifier
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientId")
+    String clientId;
+
+    /**
+     * The schema name
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaName")
+    String schemaName;
+
+    /**
+     * The schema version
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaVersion")
+    String schemaVersion;
+
+    /**
+     * The context data payload
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("payload")
+    String payload;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateCategoryDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateCategoryDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Category of the incident
+ * Details for creating the category of the support ticket.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +64,7 @@ public class CreateCategoryDetails {
     }
 
     /**
-     * Unique ID that identifies a Category
+     * Unique identifier for the category.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("categoryKey")
     String categoryKey;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateIncident.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateIncident.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Incident
+ * Details gathered during the creation of the support ticket.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -111,7 +114,7 @@ public class CreateIncident {
     }
 
     /**
-     * Tenancy Ocid
+     * The OCID of the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -120,25 +123,25 @@ public class CreateIncident {
     CreateTicketDetails ticket;
 
     /**
-     * Customer Support Identifier of the support account
+     * The Customer Support Identifier number for the support account.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("csi")
     String csi;
 
     /**
-     * States type of incident. eg: LIMIT, TECH
+     * The kind of support ticket, such as a technical issue request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("problemType")
     ProblemType problemType;
 
     /**
-     * List of contacts
+     * The list of contacts.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("contacts")
     java.util.List<Contact> contacts;
 
     /**
-     * Referrer of the incident., its usually the URL for where the customer logged the incident
+     * The incident referrer. This value is often the URL that the customer used when creating the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("referrer")
     String referrer;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateIssueTypeDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateIssueTypeDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details Issue Type of the incident
+ * Details for creating the issue type of the support ticket.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +64,7 @@ public class CreateIssueTypeDetails {
     }
 
     /**
-     * Unique ID that identifies an Issue Type
+     * Unique identifier for the issue type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("issueTypeKey")
     String issueTypeKey;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateItemDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateItemDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Item
+ * Details gathered during item creation.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -50,7 +53,7 @@ public class CreateItemDetails {
     CreateIssueTypeDetails issueType;
 
     /**
-     * Name of the item
+     * The display name of the item.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateLimitItemDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateLimitItemDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Limit Item
+ * Reserved for future use.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -164,24 +164,24 @@ public class CreateLimitItemDetails extends CreateItemDetails {
     }
 
     /**
-     * Current available limit of the resource
+     * The limit of the resource currently available.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("currentLimit")
     Integer currentLimit;
 
     /**
-     * Current used limit of the resource
+     * The current usage of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("currentUsage")
     Integer currentUsage;
 
     /**
-     * Requested limit for the resource
+     * Reserved for future use.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("requestedLimit")
     Integer requestedLimit;
     /**
-     * Status of the Limit
+     * The current status of the request.
      **/
     public enum LimitStatus {
         Approved("APPROVED"),
@@ -217,7 +217,7 @@ public class CreateLimitItemDetails extends CreateItemDetails {
         }
     };
     /**
-     * Status of the Limit
+     * The current status of the request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("limitStatus")
     LimitStatus limitStatus;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateResourceDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateResourceDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket Item
+ * Details about the resource that the support ticket relates to.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -86,13 +89,13 @@ public class CreateResourceDetails {
     CreateItemDetails item;
 
     /**
-     * List of OCI regions
+     * The list of available Oracle Cloud Infrastructure regions.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")
     Region region;
 
     /**
-     * List of OCI ADs
+     * The list of available Oracle Cloud Infrastructure availability domains.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
     AvailabilityDomain availabilityDomain;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateSubCategoryDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateSubCategoryDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Sub Category of the incident
+ * Details for creating the subcategory of the support ticket.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +64,7 @@ public class CreateSubCategoryDetails {
     }
 
     /**
-     * Unique ID that identifies a Sub Category
+     * Unique identifier for the subcategory.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subCategoryKey")
     String subCategoryKey;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateTechSupportItemDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateTechSupportItemDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of TechSupport Item
+ * Details about the issue that the technical support request relates to.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateTicketDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateTicketDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket created
+ * Details relevant to the support ticket.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,12 +65,22 @@ public class CreateTicketDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("contextualData")
+        private ContextualData contextualData;
+
+        public Builder contextualData(ContextualData contextualData) {
+            this.contextualData = contextualData;
+            this.__explicitlySet__.add("contextualData");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateTicketDetails build() {
             CreateTicketDetails __instance__ =
-                    new CreateTicketDetails(severity, resourceList, title, description);
+                    new CreateTicketDetails(
+                            severity, resourceList, title, description, contextualData);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,7 +91,8 @@ public class CreateTicketDetails {
                     severity(o.getSeverity())
                             .resourceList(o.getResourceList())
                             .title(o.getTitle())
-                            .description(o.getDescription());
+                            .description(o.getDescription())
+                            .contextualData(o.getContextualData());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -93,7 +107,7 @@ public class CreateTicketDetails {
     }
 
     /**
-     * Severity of the ticket. eg: HIGH, MEDIUM
+     * The severity of the support ticket.
      **/
     public enum Severity {
         Highest("HIGHEST"),
@@ -129,28 +143,34 @@ public class CreateTicketDetails {
         }
     };
     /**
-     * Severity of the ticket. eg: HIGH, MEDIUM
+     * The severity of the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("severity")
     Severity severity;
 
     /**
-     * List of resources
+     * The list of resources.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceList")
     java.util.List<CreateResourceDetails> resourceList;
 
     /**
-     * Title of ticket
+     * The title of the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("title")
     String title;
 
     /**
-     * Details of ticket
+     * The description of the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    /**
+     * The context from where the ticket is getting created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("contextualData")
+    ContextualData contextualData;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateUserDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/CreateUserDetails.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.model;
+
+/**
+ * Details about creation of user.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateUserDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateUserDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+        private String firstName;
+
+        public Builder firstName(String firstName) {
+            this.firstName = firstName;
+            this.__explicitlySet__.add("firstName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+        private String lastName;
+
+        public Builder lastName(String lastName) {
+            this.lastName = lastName;
+            this.__explicitlySet__.add("lastName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("country")
+        private String country;
+
+        public Builder country(String country) {
+            this.country = country;
+            this.__explicitlySet__.add("country");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("csi")
+        private String csi;
+
+        public Builder csi(String csi) {
+            this.csi = csi;
+            this.__explicitlySet__.add("csi");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("phone")
+        private String phone;
+
+        public Builder phone(String phone) {
+            this.phone = phone;
+            this.__explicitlySet__.add("phone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+        private String timezone;
+
+        public Builder timezone(String timezone) {
+            this.timezone = timezone;
+            this.__explicitlySet__.add("timezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("organizationName")
+        private String organizationName;
+
+        public Builder organizationName(String organizationName) {
+            this.organizationName = organizationName;
+            this.__explicitlySet__.add("organizationName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateUserDetails build() {
+            CreateUserDetails __instance__ =
+                    new CreateUserDetails(
+                            compartmentId,
+                            firstName,
+                            lastName,
+                            country,
+                            csi,
+                            phone,
+                            timezone,
+                            organizationName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateUserDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .firstName(o.getFirstName())
+                            .lastName(o.getLastName())
+                            .country(o.getCountry())
+                            .csi(o.getCsi())
+                            .phone(o.getPhone())
+                            .timezone(o.getTimezone())
+                            .organizationName(o.getOrganizationName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * First name of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+    String firstName;
+
+    /**
+     * Last name of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+    String lastName;
+
+    /**
+     * Country of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("country")
+    String country;
+
+    /**
+     * CSI to be associated to the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("csi")
+    String csi;
+
+    /**
+     * Contact number of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("phone")
+    String phone;
+
+    /**
+     * Timezone of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+    String timezone;
+
+    /**
+     * Organization of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("organizationName")
+    String organizationName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ErrorCode.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ErrorCode.java
@@ -25,6 +25,11 @@ public enum ErrorCode {
     ExternalServiceProviderUnavailable("EXTERNAL_SERVICE_PROVIDER_UNAVAILABLE"),
     ExternalServiceProviderTimeout("EXTERNAL_SERVICE_PROVIDER_TIMEOUT"),
     TooManyRequests("TOO_MANY_REQUESTS"),
+    IdpScimNotSetup("IDP_SCIM_NOT_SETUP"),
+    IncidentNotFound("INCIDENT_NOT_FOUND"),
+    InvalidUserCsi("INVALID_USER_CSI"),
+    DataAlreadyExists("DATA_ALREADY_EXISTS"),
+    AuthUserNotMatching("AUTH_USER_NOT_MATCHING"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Incident.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Incident.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Incident
+ * Details of about the incident object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -139,13 +139,13 @@ public class Incident {
     }
 
     /**
-     * Unique ID that identifies an Incident
+     * Unique identifier for the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("key")
     String key;
 
     /**
-     * Tenancy Ocid
+     * The OCID of the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -163,13 +163,13 @@ public class Incident {
     IncidentType incidentType;
 
     /**
-     * States type of incident. eg: LIMIT, TECH
+     * The kind of support ticket, such as a technical support request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("problemType")
     ProblemType problemType;
 
     /**
-     * Referrer of the incident., its usually the URL for where the customer logged the incident
+     * The incident referrer. This value is often the URL that the customer used when creating the support ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("referrer")
     String referrer;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentResourceType.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentResourceType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of incident type
+ * Details about the resource associated with the support request.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -104,31 +104,31 @@ public class IncidentResourceType {
     }
 
     /**
-     * Unique ID that identifies an Incident Type
+     * Unique identifier of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceTypeKey")
     String resourceTypeKey;
 
     /**
-     * Name of Incident type
+     * The display name of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Label associated with Incident Type
+     * The label associated with the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("label")
     String label;
 
     /**
-     * Details of Incident Type
+     * The description of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Service Category List
+     * The service category list.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceCategoryList")
     java.util.List<ServiceCategory> serviceCategoryList;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentSummary.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Incident
+ * Details about the support ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -128,13 +128,13 @@ public class IncidentSummary {
     }
 
     /**
-     * Unique ID that identifies an Incident
+     * Unique identifier of the incident.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("key")
     String key;
 
     /**
-     * Tenancy Ocid
+     * The OCID of the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -152,7 +152,7 @@ public class IncidentSummary {
     IncidentResourceType incidentType;
 
     /**
-     * States type of incident. eg: LIMIT, TECH
+     * The kind of support ticket, such as a technical support request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("problemType")
     ProblemType problemType;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentType.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IncidentType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of incident type
+ * Details about the incident type object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -101,31 +101,31 @@ public class IncidentType {
     }
 
     /**
-     * Unique ID that identifies an Incident Type
+     * Unique identifier for the incident type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Name of Incident type
+     * The name of the incident type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Label associated with Incident Type
+     * The label associated with the incident type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("label")
     String label;
 
     /**
-     * Details of Incident Type
+     * The description of the incident type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * List of classifiers
+     * The list of classifiers.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("classifierList")
     java.util.List<Classifier> classifierList;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IssueType.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/IssueType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details Issue Type of the incident
+ * Details about the issue type associated with the support ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class IssueType {
     }
 
     /**
-     * Unique ID that identifies an Issue Type
+     * Unique identifier for the issue type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("issueTypeKey")
     String issueTypeKey;
 
     /**
-     * Label of issue type. eg: Instance Performance
+     * The label for the issue type. For example, `Instance Performance`.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("label")
     String label;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Item.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Item.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Item
+ * Details about the item object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -42,13 +42,13 @@ package com.oracle.bmc.cims.model;
 public class Item {
 
     /**
-     * Unique ID that identifies an Item
+     * Unique identifier for the item.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("itemKey")
     String itemKey;
 
     /**
-     * Name of item
+     * The display name of the item.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LifecycleDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LifecycleDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Provides the current status of the ticket
+ * Information about the current status of the ticket.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LifecycleState.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LifecycleState.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Provides the current status of the ticket
+ * The current state of the ticket.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LimitItem.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/LimitItem.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Limit Item
+ * Reserved for future use.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -174,24 +174,24 @@ public class LimitItem extends Item {
     }
 
     /**
-     * Current available limit of the resource
+     * The currently available limit of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("currentLimit")
     Integer currentLimit;
 
     /**
-     * Current used limit of the resource
+     * The current usage of the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("currentUsage")
     Integer currentUsage;
 
     /**
-     * Requested limit for the resource
+     * The requested limit for the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("requestedLimit")
     Integer requestedLimit;
     /**
-     * Status of the Limit
+     * The status of the request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LimitStatus {
@@ -238,7 +238,7 @@ public class LimitItem extends Item {
         }
     };
     /**
-     * Status of the Limit
+     * The status of the request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("limitStatus")
     LimitStatus limitStatus;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ProblemType.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ProblemType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Problem Type of an Incident
+ * The kind of support ticket, such as a technical support request.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Region.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Region.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Available OCI Regions supported by CIMS. eg: PHX, IAD
+ * The available Oracle Cloud Infrastructure regions supported by the Support Management API.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j
@@ -21,14 +21,9 @@ public enum Region {
     Lhr("LHR"),
     Yyz("YYZ"),
     Nrt("NRT"),
-    UsLangley1("US_LANGLEY_1"),
-    UsLuke1("US_LUKE_1"),
     Icn("ICN"),
     Bom("BOM"),
     Gru("GRU"),
-    UsGovAshburn1("US_GOV_ASHBURN_1"),
-    UsGovPhoenix1("US_GOV_PHOENIX_1"),
-    UsGovChicago1("US_GOV_CHICAGO_1"),
     Syd("SYD"),
     Zrh("ZRH"),
     Jed("JED"),
@@ -38,7 +33,6 @@ public enum Region {
     Yul("YUL"),
     Hyd("HYD"),
     Yny("YNY"),
-    Tiw("TIW"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Resource.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Resource.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket Item
+ * Details about the ticket item object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -83,13 +83,13 @@ public class Resource {
     Item item;
 
     /**
-     * List of OCI regions
+     * The list of available Oracle Cloud Infrastructure regions.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")
     Region region;
 
     /**
-     * List of OCI ADs
+     * The list of available Oracle Cloud Infrastructure availability domains.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
     AvailabilityDomain availabilityDomain;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Scope.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Scope.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Scope of Service category/resource
+ * The scope of the service category or resource.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ServiceCategory.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ServiceCategory.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Incident Classifier details
+ * Information about the incident classifier.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -132,49 +132,49 @@ public class ServiceCategory {
     }
 
     /**
-     * Unique ID that identifies a classifier
+     * The unique ID that identifies a classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("key")
     String key;
 
     /**
-     * Name of classifier. eg: LIMIT Increase
+     * The name of the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Label of classifier
+     * The label for the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("label")
     String label;
 
     /**
-     * Description of classifier
+     * The text describing the classifier.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * List of Issues
+     * The list of issues.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("issueTypeList")
     java.util.List<IssueType> issueTypeList;
 
     /**
-     * List of Scope
+     * The scope of the incident.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scope")
     Scope scope;
 
     /**
-     * List of Units
+     * The unit to use to measure the service category or resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("unit")
     Unit unit;
 
     /**
-     * Limit's unique id
+     * The unique ID for the limit.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("limitId")
     String limitId;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SortBy.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SortBy.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * The field to sort by. Only one sort order may be provided. If no value is specified dateUpdated is default.
+ * The field to sort by. You can only provide one sort order. The default value is dateUpdated.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 public enum SortBy {

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SortOrder.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SortOrder.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * SortOrder query for Incident Lists
+ * The sort order to use to query support ticket lists, either ascending (`ASC`) or descending (`DESC`).
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 public enum SortOrder {

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Status.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Status.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket Status
+ * Details about the status of the support ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class Status {
     }
 
     /**
-     * Unique code
+     * The code unique to this ticket status.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("code")
     String code;
 
     /**
-     * Status message
+     * The status message for this ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     String message;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SubCategory.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/SubCategory.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Sub Category of the incident
+ * Details about the subcategory associated with the support ticket.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class SubCategory {
     }
 
     /**
-     * Unique ID that identifies a Sub Category
+     * Unique identifier for the subcategory.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subCategoryKey")
     String subCategoryKey;
 
     /**
-     * Name of sub category. eg: Backup Count, Custom Image Count
+     * The name of the subcategory. For example, `Backup Count` or `Custom Image Count`.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TechSupportItem.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TechSupportItem.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of TechSupport Item
+ * Details about the TechSupportItem object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TenancyInformation.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TenancyInformation.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Customer Tenant
+ * Details about the customer's tenancy.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -71,13 +71,13 @@ public class TenancyInformation {
     }
 
     /**
-     * Tenant customer support identifier
+     * The Customer Support Identifier number associated with the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("customerSupportKey")
     String customerSupportKey;
 
     /**
-     * Tenant OCID
+     * The OCID of the tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("tenancyId")
     String tenancyId;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Ticket.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Ticket.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket created
+ * Details about the ticket created.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -150,12 +150,12 @@ public class Ticket {
     }
 
     /**
-     * Unique ID that identifies a Ticket
+     * Unique identifier for the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ticketNumber")
     String ticketNumber;
     /**
-     * Severity of the ticket. eg: HIGH, MEDIUM
+     * The severity assigned to the ticket.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Severity {
@@ -202,49 +202,49 @@ public class Ticket {
         }
     };
     /**
-     * Severity of the ticket. eg: HIGH, MEDIUM
+     * The severity assigned to the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("severity")
     Severity severity;
 
     /**
-     * List of resources
+     * The list of resources associated with the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceList")
     java.util.List<Resource> resourceList;
 
     /**
-     * Title of ticket
+     * The title of the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("title")
     String title;
 
     /**
-     * Details of ticket
+     * The description of the issue addressed in the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Epoch time of ticket creation
+     * The time when the ticket was created, in milliseconds since epoch time.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     Integer timeCreated;
 
     /**
-     * Epoch time of ticket updated
+     * The time when the ticket was updated, in milliseconds since epoch time.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     Integer timeUpdated;
 
     /**
-     * Describes the lifecycles of a ticket
+     * The current state of the ticket.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
 
     /**
-     * Describes the lifecycle details of a ticket
+     * Additional information about the current `lifecycleState`.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     LifecycleDetails lifecycleDetails;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TimeZone.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/TimeZone.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.model;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+public enum TimeZone {
+    GreenwichMeanTime("GREENWICH_MEAN_TIME"),
+    EuropeanCentralTime("EUROPEAN_CENTRAL_TIME"),
+    EasternEuropeanTime("EASTERN_EUROPEAN_TIME"),
+    EasternAfricanTime("EASTERN_AFRICAN_TIME"),
+    MiddleEastTime("MIDDLE_EAST_TIME"),
+    NearEastTime("NEAR_EAST_TIME"),
+    PakistanLahoreTime("PAKISTAN_LAHORE_TIME"),
+    IndiaStandardTime("INDIA_STANDARD_TIME"),
+    BangladeshStandardTime("BANGLADESH_STANDARD_TIME"),
+    VietnamStandardTime("VIETNAM_STANDARD_TIME"),
+    ChinaTaiwanTime("CHINA_TAIWAN_TIME"),
+    JapanStandardTime("JAPAN_STANDARD_TIME"),
+    AustraliaCentralTime("AUSTRALIA_CENTRAL_TIME"),
+    AustraliaEasternTime("AUSTRALIA_EASTERN_TIME"),
+    SolomonStandardTime("SOLOMON_STANDARD_TIME"),
+    NewZealandStandardTime("NEW_ZEALAND_STANDARD_TIME"),
+    MidwayIslandsTime("MIDWAY_ISLANDS_TIME"),
+    HawaiiStandardTime("HAWAII_STANDARD_TIME"),
+    AlaskaStandardTime("ALASKA_STANDARD_TIME"),
+    PacificStandardTime("PACIFIC_STANDARD_TIME"),
+    MountainStandardTime("MOUNTAIN_STANDARD_TIME"),
+    CentralStandardTime("CENTRAL_STANDARD_TIME"),
+    EasternStandardTime("EASTERN_STANDARD_TIME"),
+    PuertoRicoAndUsVirginIslandsTime("PUERTO_RICO_AND_US_VIRGIN_ISLANDS_TIME"),
+    CanadaNewfoundlandTime("CANADA_NEWFOUNDLAND_TIME"),
+    ArgentinaStandardTime("ARGENTINA_STANDARD_TIME"),
+    MidAtlanticTime("MID_ATLANTIC_TIME"),
+    CentralAfricanTime("CENTRAL_AFRICAN_TIME"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, TimeZone> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (TimeZone v : TimeZone.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    TimeZone(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TimeZone create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid TimeZone: " + key);
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Unit.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/Unit.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Unit to measure Service category/resource
+ * The unit to use to measure the service category or resource.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateActivityItemDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateActivityItemDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Activity Item
+ * Details for udpating the support ticket activity.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -84,12 +87,12 @@ public class UpdateActivityItemDetails extends UpdateItemDetails {
     }
 
     /**
-     * Comments to update as part of Activity
+     * Comments updated at the time that the activity occurs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("comments")
     String comments;
     /**
-     * Type of activity. eg: NOTES, UPDATE
+     * The type of activity occurring.
      **/
     public enum ActivityType {
         Notes("NOTES"),
@@ -126,7 +129,7 @@ public class UpdateActivityItemDetails extends UpdateItemDetails {
         }
     };
     /**
-     * Type of activity. eg: NOTES, UPDATE
+     * The type of activity occurring.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("activityType")
     ActivityType activityType;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateIncident.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateIncident.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Resource Item to be updated
+ * Details about the support ticket being updated.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateItemDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateItemDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Item
+ * Details for udpating an item.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateResourceDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateResourceDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Update Resource details
+ * Details about updates to the resource.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateTicketDetails.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/UpdateTicketDetails.java
@@ -5,7 +5,10 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Details of Ticket updated
+ * Details about the ticket updated.
+ * <p>
+ **Caution:** Avoid using any confidential information when you supply string values using the API.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +64,7 @@ public class UpdateTicketDetails {
     }
 
     /**
-     * List of resources
+     * The list of resources.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resource")
     Object resource;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/User.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/User.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.model;
+
+/**
+ * Details about the user object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = User.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class User {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+        private String firstName;
+
+        public Builder firstName(String firstName) {
+            this.firstName = firstName;
+            this.__explicitlySet__.add("firstName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+        private String lastName;
+
+        public Builder lastName(String lastName) {
+            this.lastName = lastName;
+            this.__explicitlySet__.add("lastName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("country")
+        private String country;
+
+        public Builder country(String country) {
+            this.country = country;
+            this.__explicitlySet__.add("country");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("csi")
+        private String csi;
+
+        public Builder csi(String csi) {
+            this.csi = csi;
+            this.__explicitlySet__.add("csi");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("phone")
+        private String phone;
+
+        public Builder phone(String phone) {
+            this.phone = phone;
+            this.__explicitlySet__.add("phone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+        private String timezone;
+
+        public Builder timezone(String timezone) {
+            this.timezone = timezone;
+            this.__explicitlySet__.add("timezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("organizationName")
+        private String organizationName;
+
+        public Builder organizationName(String organizationName) {
+            this.organizationName = organizationName;
+            this.__explicitlySet__.add("organizationName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("contactEmail")
+        private String contactEmail;
+
+        public Builder contactEmail(String contactEmail) {
+            this.contactEmail = contactEmail;
+            this.__explicitlySet__.add("contactEmail");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public User build() {
+            User __instance__ =
+                    new User(
+                            key,
+                            firstName,
+                            lastName,
+                            country,
+                            csi,
+                            phone,
+                            timezone,
+                            organizationName,
+                            compartmentId,
+                            contactEmail);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(User o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .firstName(o.getFirstName())
+                            .lastName(o.getLastName())
+                            .country(o.getCountry())
+                            .csi(o.getCsi())
+                            .phone(o.getPhone())
+                            .timezone(o.getTimezone())
+                            .organizationName(o.getOrganizationName())
+                            .compartmentId(o.getCompartmentId())
+                            .contactEmail(o.getContactEmail());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier for the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * First name of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+    String firstName;
+
+    /**
+     * Last name of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+    String lastName;
+
+    /**
+     * Country of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("country")
+    String country;
+
+    /**
+     * CSI to be associated to the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("csi")
+    String csi;
+
+    /**
+     * Contact number of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("phone")
+    String phone;
+
+    /**
+     * Timezone of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+    String timezone;
+
+    /**
+     * Organization of the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("organizationName")
+    String organizationName;
+
+    /**
+     * The OCID of the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The email of the contact person.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("contactEmail")
+    String contactEmail;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ValidationResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/model/ValidationResponse.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.cims.model;
 
 /**
- * Validation Response
+ * The validation response returned when checking whether the requested user is valid.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +61,7 @@ public class ValidationResponse {
     }
 
     /**
-     * Boolean value to check whether requested user is valid or not
+     * Boolean value that indicates whether the requested user is valid.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isValidUser")
     Boolean isValidUser;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/CreateIncidentRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/CreateIncidentRequest.java
@@ -17,19 +17,19 @@ public class CreateIncidentRequest extends com.oracle.bmc.requests.BmcRequest<Cr
     private CreateIncident createIncidentDetails;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Retry token
-     */
-    private String opcRetryToken;
-
-    /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
 
     /**
      * Alternative accessor for the body parameter.
@@ -78,8 +78,8 @@ public class CreateIncidentRequest extends com.oracle.bmc.requests.BmcRequest<Cr
         public Builder copy(CreateIncidentRequest o) {
             createIncidentDetails(o.getCreateIncidentDetails());
             ocid(o.getOcid());
-            opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            homeregion(o.getHomeregion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/CreateUserRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/CreateUserRequest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.requests;
+
+import com.oracle.bmc.cims.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateUserRequest extends com.oracle.bmc.requests.BmcRequest<CreateUserDetails> {
+
+    /**
+     * User information
+     */
+    private CreateUserDetails createUserDetails;
+
+    /**
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
+     */
+    private String ocid;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     */
+    private String opcRequestId;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateUserDetails getBody$() {
+        return createUserDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateUserRequest, CreateUserDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateUserRequest o) {
+            createUserDetails(o.getCreateUserDetails());
+            ocid(o.getOcid());
+            opcRequestId(o.getOpcRequestId());
+            homeregion(o.getHomeregion());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateUserRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateUserRequest
+         */
+        public CreateUserRequest build() {
+            CreateUserRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateUserDetails body) {
+            createUserDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/GetIncidentRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/GetIncidentRequest.java
@@ -12,24 +12,34 @@ import com.oracle.bmc.cims.model.*;
 public class GetIncidentRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Unique ID that identifies an incident
+     * Unique identifier for the support ticket.
      */
     private String incidentKey;
 
     /**
-     * Customer Support Identifier of the support account
+     * The Customer Support Identifier associated with the support account.
      */
     private String csi;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
+
+    /**
+     * The kind of support request.
+     */
+    private String problemType;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -70,6 +80,8 @@ public class GetIncidentRequest extends com.oracle.bmc.requests.BmcRequest<java.
             csi(o.getCsi());
             ocid(o.getOcid());
             opcRequestId(o.getOpcRequestId());
+            homeregion(o.getHomeregion());
+            problemType(o.getProblemType());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/GetStatusRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/GetStatusRequest.java
@@ -12,19 +12,24 @@ import com.oracle.bmc.cims.model.*;
 public class GetStatusRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Source is a downstream system. Eg: JIRA or MOS or any other source in future.
+     * The system that generated the support ticket, such as My Oracle Support.
      */
     private String source;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -64,6 +69,7 @@ public class GetStatusRequest extends com.oracle.bmc.requests.BmcRequest<java.la
             source(o.getSource());
             ocid(o.getOcid());
             opcRequestId(o.getOpcRequestId());
+            homeregion(o.getHomeregion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ListIncidentResourceTypesRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ListIncidentResourceTypesRequest.java
@@ -13,54 +13,61 @@ public class ListIncidentResourceTypesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Problem Type of Taxonomy - tech/limit
+     * The kind of support request.
      */
     private String problemType;
 
     /**
-     * Tenancy Ocid
+     * The OCID of the tenancy.
      */
     private String compartmentId;
 
     /**
-     * Customer Support Identifier of the support account
+     * The Customer Support Identifier associated with the support account.
      */
     private String csi;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
 
     /**
-     * Limit query for number of returned results
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
      */
     private Integer limit;
 
     /**
-     * Pagination for Incident list
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
      */
     private String page;
 
     /**
-     * The key to sort the returned items by
+     * The key to use to sort the returned items.
      */
     private com.oracle.bmc.cims.model.SortBy sortBy;
 
     /**
-     * The order in which to sort the results
+     * The order to sort the results in.
      */
     private com.oracle.bmc.cims.model.SortOrder sortOrder;
 
     /**
-     * Name of Incident Type. eg: Limit Increase
+     * The user-friendly name of the incident type.
      */
     private String name;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -107,6 +114,7 @@ public class ListIncidentResourceTypesRequest
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             name(o.getName());
+            homeregion(o.getHomeregion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ListIncidentsRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ListIncidentsRequest.java
@@ -12,49 +12,61 @@ import com.oracle.bmc.cims.model.*;
 public class ListIncidentsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Customer Support Identifier of the support account
+     * The Customer Support Identifier associated with the support account.
      */
     private String csi;
 
     /**
-     * Tenancy Ocid
+     * The OCID of the tenancy.
      */
     private String compartmentId;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Limit query for number of returned results
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
      */
     private Integer limit;
 
     /**
-     * The key to sort the returned items by
+     * The key to use to sort the returned items.
      */
     private com.oracle.bmc.cims.model.SortBy sortBy;
 
     /**
-     * The order in which to sort the results
+     * The order to sort the results in.
      */
     private com.oracle.bmc.cims.model.SortOrder sortOrder;
 
     /**
-     * The order in which to sort the results
+     * The current state of the ticket.
      */
     private com.oracle.bmc.cims.model.LifecycleState lifecycleState;
 
     /**
-     * Pagination for Incident list
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
      */
     private String page;
 
     /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
+
+    /**
+     * The kind of support request.
+     */
+    private String problemType;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -100,6 +112,8 @@ public class ListIncidentsRequest extends com.oracle.bmc.requests.BmcRequest<jav
             lifecycleState(o.getLifecycleState());
             page(o.getPage());
             opcRequestId(o.getOpcRequestId());
+            homeregion(o.getHomeregion());
+            problemType(o.getProblemType());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/UpdateIncidentRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/UpdateIncidentRequest.java
@@ -12,39 +12,39 @@ import com.oracle.bmc.cims.model.*;
 public class UpdateIncidentRequest extends com.oracle.bmc.requests.BmcRequest<UpdateIncident> {
 
     /**
-     * Unique ID that identifies an incident
+     * Unique identifier for the support ticket.
      */
     private String incidentKey;
 
     /**
-     * Customer Support Identifier of the support account
+     * The Customer Support Identifier associated with the support account.
      */
     private String csi;
 
     /**
-     * Details of Resource to be updated
+     * Details about the support ticket being updated.
      */
     private UpdateIncident updateIncidentDetails;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Retry token
-     */
-    private String opcRetryToken;
-
-    /**
-     * Unique Header for request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
 
     /**
-     * if-match check
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the etag from a previous GET or POST response for that resource. The resource will be updated or deleted only if the etag you provide matches the resource's current etag value.
      */
     private String ifMatch;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
 
     /**
      * Alternative accessor for the body parameter.
@@ -95,9 +95,9 @@ public class UpdateIncidentRequest extends com.oracle.bmc.requests.BmcRequest<Up
             csi(o.getCsi());
             updateIncidentDetails(o.getUpdateIncidentDetails());
             ocid(o.getOcid());
-            opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
             ifMatch(o.getIfMatch());
+            homeregion(o.getHomeregion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ValidateUserRequest.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/requests/ValidateUserRequest.java
@@ -12,29 +12,29 @@ import com.oracle.bmc.cims.model.*;
 public class ValidateUserRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Customer support identifier of the support account
+     * The Customer Support Identifier number for the support account.
      */
     private String csi;
 
     /**
-     * User OCID for IDCS users that have a shadow in OCI
+     * User OCID for Oracle Identity Cloud Service (IDCS) users who also have a federated Oracle Cloud Infrastructure account.
      */
     private String ocid;
 
     /**
-     * Retry-token header
-     */
-    private String opcRetryToken;
-
-    /**
-     * Unique request id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
 
     /**
-     * Problem Type of Taxonomy - tech/limit
+     * The kind of support request.
      */
     private String problemType;
+
+    /**
+     * The region of the tenancy.
+     */
+    private String homeregion;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -73,9 +73,9 @@ public class ValidateUserRequest extends com.oracle.bmc.requests.BmcRequest<java
         public Builder copy(ValidateUserRequest o) {
             csi(o.getCsi());
             ocid(o.getOcid());
-            opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
             problemType(o.getProblemType());
+            homeregion(o.getHomeregion());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/CreateIncidentResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/CreateIncidentResponse.java
@@ -12,14 +12,9 @@ import com.oracle.bmc.cims.model.*;
 public class CreateIncidentResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * The returned Incident instance.
@@ -33,7 +28,6 @@ public class CreateIncidentResponse {
          */
         public Builder copy(CreateIncidentResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             incident(o.getIncident());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/CreateUserResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/CreateUserResponse.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cims.responses;
+
+import com.oracle.bmc.cims.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181231")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateUserResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned User instance.
+     */
+    private User user;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateUserResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            user(o.getUser());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/GetIncidentResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/GetIncidentResponse.java
@@ -12,14 +12,9 @@ import com.oracle.bmc.cims.model.*;
 public class GetIncidentResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * The returned Incident instance.
@@ -33,7 +28,6 @@ public class GetIncidentResponse {
          */
         public Builder copy(GetIncidentResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             incident(o.getIncident());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/GetStatusResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/GetStatusResponse.java
@@ -12,14 +12,9 @@ import com.oracle.bmc.cims.model.*;
 public class GetStatusResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * The returned Status instance.
@@ -33,7 +28,6 @@ public class GetStatusResponse {
          */
         public Builder copy(GetStatusResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             status(o.getStatus());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ListIncidentResourceTypesResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ListIncidentResourceTypesResponse.java
@@ -12,19 +12,14 @@ import com.oracle.bmc.cims.model.*;
 public class ListIncidentResourceTypesResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
 
     /**
-     * OPC next page
+     * For list pagination. When this header appears in the response, additional pages of results remain. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
      */
     private String opcNextPage;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * A list of IncidentResourceType instances.
@@ -39,7 +34,6 @@ public class ListIncidentResourceTypesResponse {
         public Builder copy(ListIncidentResourceTypesResponse o) {
             opcRequestId(o.getOpcRequestId());
             opcNextPage(o.getOpcNextPage());
-            etag(o.getEtag());
             items(o.getItems());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ListIncidentsResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ListIncidentsResponse.java
@@ -12,19 +12,14 @@ import com.oracle.bmc.cims.model.*;
 public class ListIncidentsResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
 
     /**
-     * OPC next page
+     * For list pagination. When this header appears in the response, additional pages of results remain. For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
      */
     private String opcNextPage;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * A list of IncidentSummary instances.
@@ -39,7 +34,6 @@ public class ListIncidentsResponse {
         public Builder copy(ListIncidentsResponse o) {
             opcRequestId(o.getOpcRequestId());
             opcNextPage(o.getOpcNextPage());
-            etag(o.getEtag());
             items(o.getItems());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/UpdateIncidentResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/UpdateIncidentResponse.java
@@ -12,14 +12,9 @@ import com.oracle.bmc.cims.model.*;
 public class UpdateIncidentResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * The returned Incident instance.
@@ -33,7 +28,6 @@ public class UpdateIncidentResponse {
          */
         public Builder copy(UpdateIncidentResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             incident(o.getIncident());
 
             return this;

--- a/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ValidateUserResponse.java
+++ b/bmc-cims/src/main/java/com/oracle/bmc/cims/responses/ValidateUserResponse.java
@@ -12,14 +12,9 @@ import com.oracle.bmc.cims.model.*;
 public class ValidateUserResponse {
 
     /**
-     * OPC Request Id
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
      */
     private String opcRequestId;
-
-    /**
-     * e-Tag
-     */
-    private String etag;
 
     /**
      * The returned ValidationResponse instance.
@@ -33,7 +28,6 @@ public class ValidateUserResponse {
          */
         public Builder copy(ValidateUserResponse o) {
             opcRequestId(o.getOpcRequestId());
-            etag(o.getEtag());
             validationResponse(o.getValidationResponse());
 
             return this;

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -882,12 +882,14 @@ public class AutonomousDatabase {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum DbWorkload {
         Oltp("OLTP"),
         Dw("DW"),
+        Ajd("AJD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -932,6 +934,7 @@ public class AutonomousDatabase {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -884,12 +884,14 @@ public class AutonomousDatabaseSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum DbWorkload {
         Oltp("OLTP"),
         Dw("DW"),
+        Ajd("AJD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -934,6 +936,7 @@ public class AutonomousDatabaseSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbPreviewVersionSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbPreviewVersionSummary.java
@@ -126,12 +126,14 @@ public class AutonomousDbPreviewVersionSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum DbWorkload {
         Oltp("OLTP"),
         Dw("DW"),
+        Ajd("AJD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -176,6 +178,7 @@ public class AutonomousDbPreviewVersionSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbVersionSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbVersionSummary.java
@@ -114,12 +114,14 @@ public class AutonomousDbVersionSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum DbWorkload {
         Oltp("OLTP"),
         Dw("DW"),
+        Ajd("AJD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -164,6 +166,7 @@ public class AutonomousDbVersionSummary {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -73,11 +73,13 @@ public class CreateAutonomousDatabaseBase {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     public enum DbWorkload {
         Oltp("OLTP"),
         Dw("DW"),
+        Ajd("AJD"),
         ;
 
         private final String value;
@@ -112,6 +114,7 @@ public class CreateAutonomousDatabaseBase {
      * <p>
      * - OLTP - indicates an Autonomous Transaction Processing database
      * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -102,6 +102,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")
+        private DbWorkload dbWorkload;
+
+        public Builder dbWorkload(DbWorkload dbWorkload) {
+            this.dbWorkload = dbWorkload;
+            this.__explicitlySet__.add("dbWorkload");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
         private LicenseModel licenseModel;
 
@@ -188,6 +197,7 @@ public class UpdateAutonomousDatabaseDetails {
                             dbName,
                             freeformTags,
                             definedTags,
+                            dbWorkload,
                             licenseModel,
                             whitelistedIps,
                             isAutoScalingEnabled,
@@ -211,6 +221,7 @@ public class UpdateAutonomousDatabaseDetails {
                             .dbName(o.getDbName())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .dbWorkload(o.getDbWorkload())
                             .licenseModel(o.getLicenseModel())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
@@ -292,6 +303,57 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+    /**
+     * The Autonomous Database workload type. The following values are valid:
+     * <p>
+     * - OLTP - indicates an Autonomous Transaction Processing database
+     * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
+     *
+     **/
+    public enum DbWorkload {
+        Oltp("OLTP"),
+        Dw("DW"),
+        Ajd("AJD"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DbWorkload> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DbWorkload v : DbWorkload.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DbWorkload(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DbWorkload create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid DbWorkload: " + key);
+        }
+    };
+    /**
+     * The Autonomous Database workload type. The following values are valid:
+     * <p>
+     * - OLTP - indicates an Autonomous Transaction Processing database
+     * - DW - indicates an Autonomous Data Warehouse database
+     * - AJD - indicates an Autonomous JSON Database
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbWorkload")
+    DbWorkload dbWorkload;
     /**
      * The Oracle license model that applies to the Oracle Autonomous Database. Note that when provisioning an Autonomous Database on [dedicated Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adbddoverview.htm), this attribute must be null because the attribute is already set at the
      * Autonomous Exadata Infrastructure level. When using [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), if a value is not specified, the system will supply the value of `BRING_YOUR_OWN_LICENSE`.

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAttributesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAttributesConverter.java
@@ -56,6 +56,14 @@ public class ListAttributesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListConnectionsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListConnectionsConverter.java
@@ -51,6 +51,14 @@ public class ListConnectionsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListDataAssetsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListDataAssetsConverter.java
@@ -46,6 +46,14 @@ public class ListDataAssetsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
@@ -51,6 +51,14 @@ public class ListEntitiesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListFoldersConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListFoldersConverter.java
@@ -51,6 +51,14 @@ public class ListFoldersConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListGlossariesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListGlossariesConverter.java
@@ -46,6 +46,14 @@ public class ListGlossariesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobDefinitionsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobDefinitionsConverter.java
@@ -46,6 +46,22 @@ public class ListJobDefinitionsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
+        if (request.getJobExecutionState() != null) {
+            target =
+                    target.queryParam(
+                            "jobExecutionState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getJobExecutionState().getValue()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobMetricsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobMetricsConverter.java
@@ -56,6 +56,14 @@ public class ListJobMetricsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getCategory() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobsConverter.java
@@ -46,6 +46,14 @@ public class ListJobsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTagsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTagsConverter.java
@@ -46,6 +46,14 @@ public class ListTagsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTermRelationshipsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTermRelationshipsConverter.java
@@ -56,6 +56,14 @@ public class ListTermRelationshipsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTermsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListTermsConverter.java
@@ -51,6 +51,14 @@ public class ListTermsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
@@ -143,6 +143,60 @@ public class Attribute {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+        private Integer minCollectionCount;
+
+        public Builder minCollectionCount(Integer minCollectionCount) {
+            this.minCollectionCount = minCollectionCount;
+            this.__explicitlySet__.add("minCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+        private Integer maxCollectionCount;
+
+        public Builder maxCollectionCount(Integer maxCollectionCount) {
+            this.maxCollectionCount = maxCollectionCount;
+            this.__explicitlySet__.add("maxCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("datatypeEntityKey")
+        private String datatypeEntityKey;
+
+        public Builder datatypeEntityKey(String datatypeEntityKey) {
+            this.datatypeEntityKey = datatypeEntityKey;
+            this.__explicitlySet__.add("datatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+        private String externalDatatypeEntityKey;
+
+        public Builder externalDatatypeEntityKey(String externalDatatypeEntityKey) {
+            this.externalDatatypeEntityKey = externalDatatypeEntityKey;
+            this.__explicitlySet__.add("externalDatatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentAttributeKey")
+        private String parentAttributeKey;
+
+        public Builder parentAttributeKey(String parentAttributeKey) {
+            this.parentAttributeKey = parentAttributeKey;
+            this.__explicitlySet__.add("parentAttributeKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+        private String externalParentAttributeKey;
+
+        public Builder externalParentAttributeKey(String externalParentAttributeKey) {
+            this.externalParentAttributeKey = externalParentAttributeKey;
+            this.__explicitlySet__.add("externalParentAttributeKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("length")
         private Long length;
 
@@ -197,6 +251,15 @@ public class Attribute {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("path")
+        private String path;
+
+        public Builder path(String path) {
+            this.path = path;
+            this.__explicitlySet__.add("path");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -225,12 +288,19 @@ public class Attribute {
                             externalKey,
                             isIncrementalData,
                             isNullable,
+                            minCollectionCount,
+                            maxCollectionCount,
+                            datatypeEntityKey,
+                            externalDatatypeEntityKey,
+                            parentAttributeKey,
+                            externalParentAttributeKey,
                             length,
                             position,
                             precision,
                             scale,
                             timeExternal,
                             uri,
+                            path,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -252,12 +322,19 @@ public class Attribute {
                             .externalKey(o.getExternalKey())
                             .isIncrementalData(o.getIsIncrementalData())
                             .isNullable(o.getIsNullable())
+                            .minCollectionCount(o.getMinCollectionCount())
+                            .maxCollectionCount(o.getMaxCollectionCount())
+                            .datatypeEntityKey(o.getDatatypeEntityKey())
+                            .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
+                            .parentAttributeKey(o.getParentAttributeKey())
+                            .externalParentAttributeKey(o.getExternalParentAttributeKey())
                             .length(o.getLength())
                             .position(o.getPosition())
                             .precision(o.getPrecision())
                             .scale(o.getScale())
                             .timeExternal(o.getTimeExternal())
                             .uri(o.getUri())
+                            .path(o.getPath())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -360,6 +437,45 @@ public class Attribute {
     Boolean isNullable;
 
     /**
+     * The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+    Integer minCollectionCount;
+
+    /**
+     * The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     * For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+     * Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+    Integer maxCollectionCount;
+
+    /**
+     * Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("datatypeEntityKey")
+    String datatypeEntityKey;
+
+    /**
+     * External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+    String externalDatatypeEntityKey;
+
+    /**
+     * Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parentAttributeKey")
+    String parentAttributeKey;
+
+    /**
+     * External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+    String externalParentAttributeKey;
+
+    /**
      * Max allowed length of the attribute value.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("length")
@@ -394,6 +510,12 @@ public class Attribute {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * Full path of the attribute.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    String path;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeCollection.java
@@ -27,6 +27,15 @@ public class AttributeCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<AttributeSummary> items;
 
@@ -40,14 +49,14 @@ public class AttributeCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AttributeCollection build() {
-            AttributeCollection __instance__ = new AttributeCollection(items);
+            AttributeCollection __instance__ = new AttributeCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AttributeCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class AttributeCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of attributes.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeSummary.java
@@ -123,6 +123,69 @@ public class AttributeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+        private Integer minCollectionCount;
+
+        public Builder minCollectionCount(Integer minCollectionCount) {
+            this.minCollectionCount = minCollectionCount;
+            this.__explicitlySet__.add("minCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+        private Integer maxCollectionCount;
+
+        public Builder maxCollectionCount(Integer maxCollectionCount) {
+            this.maxCollectionCount = maxCollectionCount;
+            this.__explicitlySet__.add("maxCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("datatypeEntityKey")
+        private String datatypeEntityKey;
+
+        public Builder datatypeEntityKey(String datatypeEntityKey) {
+            this.datatypeEntityKey = datatypeEntityKey;
+            this.__explicitlySet__.add("datatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+        private String externalDatatypeEntityKey;
+
+        public Builder externalDatatypeEntityKey(String externalDatatypeEntityKey) {
+            this.externalDatatypeEntityKey = externalDatatypeEntityKey;
+            this.__explicitlySet__.add("externalDatatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentAttributeKey")
+        private String parentAttributeKey;
+
+        public Builder parentAttributeKey(String parentAttributeKey) {
+            this.parentAttributeKey = parentAttributeKey;
+            this.__explicitlySet__.add("parentAttributeKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+        private String externalParentAttributeKey;
+
+        public Builder externalParentAttributeKey(String externalParentAttributeKey) {
+            this.externalParentAttributeKey = externalParentAttributeKey;
+            this.__explicitlySet__.add("externalParentAttributeKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("path")
+        private String path;
+
+        public Builder path(String path) {
+            this.path = path;
+            this.__explicitlySet__.add("path");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -139,7 +202,14 @@ public class AttributeSummary {
                             uri,
                             lifecycleState,
                             timeCreated,
-                            externalDataType);
+                            externalDataType,
+                            minCollectionCount,
+                            maxCollectionCount,
+                            datatypeEntityKey,
+                            externalDatatypeEntityKey,
+                            parentAttributeKey,
+                            externalParentAttributeKey,
+                            path);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -157,7 +227,14 @@ public class AttributeSummary {
                             .uri(o.getUri())
                             .lifecycleState(o.getLifecycleState())
                             .timeCreated(o.getTimeCreated())
-                            .externalDataType(o.getExternalDataType());
+                            .externalDataType(o.getExternalDataType())
+                            .minCollectionCount(o.getMinCollectionCount())
+                            .maxCollectionCount(o.getMaxCollectionCount())
+                            .datatypeEntityKey(o.getDatatypeEntityKey())
+                            .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
+                            .parentAttributeKey(o.getParentAttributeKey())
+                            .externalParentAttributeKey(o.getExternalParentAttributeKey())
+                            .path(o.getPath());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,6 +317,51 @@ public class AttributeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalDataType")
     String externalDataType;
+
+    /**
+     * The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+    Integer minCollectionCount;
+
+    /**
+     * The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     * For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+     * Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+    Integer maxCollectionCount;
+
+    /**
+     * Entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("datatypeEntityKey")
+    String datatypeEntityKey;
+
+    /**
+     * External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+    String externalDatatypeEntityKey;
+
+    /**
+     * Attribute key that represents the parent attribute of this attribute , applicable if the parent attribute is of complex datatype.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parentAttributeKey")
+    String parentAttributeKey;
+
+    /**
+     * External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+    String externalParentAttributeKey;
+
+    /**
+     * Full path of the attribute.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    String path;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeTagCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeTagCollection.java
@@ -27,6 +27,15 @@ public class AttributeTagCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<AttributeTagSummary> items;
 
@@ -40,14 +49,14 @@ public class AttributeTagCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AttributeTagCollection build() {
-            AttributeTagCollection __instance__ = new AttributeTagCollection(items);
+            AttributeTagCollection __instance__ = new AttributeTagCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(AttributeTagCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class AttributeTagCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of attribute tags.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ConnectionCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ConnectionCollection.java
@@ -27,6 +27,15 @@ public class ConnectionCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<ConnectionSummary> items;
 
@@ -40,14 +49,14 @@ public class ConnectionCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ConnectionCollection build() {
-            ConnectionCollection __instance__ = new ConnectionCollection(items);
+            ConnectionCollection __instance__ = new ConnectionCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ConnectionCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class ConnectionCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of connection summaries.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
@@ -116,6 +116,42 @@ public class CreateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+        private Integer minCollectionCount;
+
+        public Builder minCollectionCount(Integer minCollectionCount) {
+            this.minCollectionCount = minCollectionCount;
+            this.__explicitlySet__.add("minCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+        private Integer maxCollectionCount;
+
+        public Builder maxCollectionCount(Integer maxCollectionCount) {
+            this.maxCollectionCount = maxCollectionCount;
+            this.__explicitlySet__.add("maxCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+        private String externalDatatypeEntityKey;
+
+        public Builder externalDatatypeEntityKey(String externalDatatypeEntityKey) {
+            this.externalDatatypeEntityKey = externalDatatypeEntityKey;
+            this.__explicitlySet__.add("externalDatatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+        private String externalParentAttributeKey;
+
+        public Builder externalParentAttributeKey(String externalParentAttributeKey) {
+            this.externalParentAttributeKey = externalParentAttributeKey;
+            this.__explicitlySet__.add("externalParentAttributeKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -141,6 +177,10 @@ public class CreateAttributeDetails {
                             precision,
                             scale,
                             timeExternal,
+                            minCollectionCount,
+                            maxCollectionCount,
+                            externalDatatypeEntityKey,
+                            externalParentAttributeKey,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -159,6 +199,10 @@ public class CreateAttributeDetails {
                             .precision(o.getPrecision())
                             .scale(o.getScale())
                             .timeExternal(o.getTimeExternal())
+                            .minCollectionCount(o.getMinCollectionCount())
+                            .maxCollectionCount(o.getMaxCollectionCount())
+                            .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
+                            .externalParentAttributeKey(o.getExternalParentAttributeKey())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -234,6 +278,33 @@ public class CreateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeExternal")
     java.util.Date timeExternal;
+
+    /**
+     * The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+    Integer minCollectionCount;
+
+    /**
+     * The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     * For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+     * Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+    Integer maxCollectionCount;
+
+    /**
+     * External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+    String externalDatatypeEntityKey;
+
+    /**
+     * External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+    String externalParentAttributeKey;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAssetCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAssetCollection.java
@@ -27,6 +27,15 @@ public class DataAssetCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<DataAssetSummary> items;
 
@@ -40,14 +49,14 @@ public class DataAssetCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DataAssetCollection build() {
-            DataAssetCollection __instance__ = new DataAssetCollection(items);
+            DataAssetCollection __instance__ = new DataAssetCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DataAssetCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class DataAssetCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of data asset summaries.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAssetTagCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAssetTagCollection.java
@@ -27,6 +27,15 @@ public class DataAssetTagCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<DataAssetTagSummary> items;
 
@@ -40,14 +49,14 @@ public class DataAssetTagCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DataAssetTagCollection build() {
-            DataAssetTagCollection __instance__ = new DataAssetTagCollection(items);
+            DataAssetTagCollection __instance__ = new DataAssetTagCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DataAssetTagCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class DataAssetTagCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of data asset tags.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
@@ -162,6 +162,15 @@ public class Entity {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("folderName")
+        private String folderName;
+
+        public Builder folderName(String folderName) {
+            this.folderName = folderName;
+            this.__explicitlySet__.add("folderName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("path")
         private String path;
 
@@ -237,6 +246,7 @@ public class Entity {
                             isPartition,
                             dataAssetKey,
                             folderKey,
+                            folderName,
                             path,
                             harvestStatus,
                             lastJobKey,
@@ -265,6 +275,7 @@ public class Entity {
                             .isPartition(o.getIsPartition())
                             .dataAssetKey(o.getDataAssetKey())
                             .folderKey(o.getFolderKey())
+                            .folderName(o.getFolderName())
                             .path(o.getPath())
                             .harvestStatus(o.getHarvestStatus())
                             .lastJobKey(o.getLastJobKey())
@@ -380,6 +391,12 @@ public class Entity {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("folderKey")
     String folderKey;
+
+    /**
+     * Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("folderName")
+    String folderName;
 
     /**
      * Full path of the data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntityCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntityCollection.java
@@ -25,6 +25,15 @@ public class EntityCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<EntitySummary> items;
 
@@ -38,14 +47,14 @@ public class EntityCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public EntityCollection build() {
-            EntityCollection __instance__ = new EntityCollection(items);
+            EntityCollection __instance__ = new EntityCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(EntityCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class EntityCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of data entities.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
@@ -72,6 +72,15 @@ public class EntitySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("folderName")
+        private String folderName;
+
+        public Builder folderName(String folderName) {
+            this.folderName = folderName;
+            this.__explicitlySet__.add("folderName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("externalKey")
         private String externalKey;
 
@@ -146,6 +155,7 @@ public class EntitySummary {
                             description,
                             dataAssetKey,
                             folderKey,
+                            folderName,
                             externalKey,
                             path,
                             timeCreated,
@@ -165,6 +175,7 @@ public class EntitySummary {
                             .description(o.getDescription())
                             .dataAssetKey(o.getDataAssetKey())
                             .folderKey(o.getFolderKey())
+                            .folderName(o.getFolderName())
                             .externalKey(o.getExternalKey())
                             .path(o.getPath())
                             .timeCreated(o.getTimeCreated())
@@ -216,6 +227,12 @@ public class EntitySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("folderKey")
     String folderKey;
+
+    /**
+     * Name of the associated folder. This name is harvested from the source data asset when the parent folder for the entiy is harvested.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("folderName")
+    String folderName;
 
     /**
      * Unique external key of this object in the source system.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntityTagCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntityTagCollection.java
@@ -27,6 +27,15 @@ public class EntityTagCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<EntityTagSummary> items;
 
@@ -40,14 +49,14 @@ public class EntityTagCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public EntityTagCollection build() {
-            EntityTagCollection __instance__ = new EntityTagCollection(items);
+            EntityTagCollection __instance__ = new EntityTagCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(EntityTagCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class EntityTagCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of entity tags.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderCollection.java
@@ -25,6 +25,15 @@ public class FolderCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<FolderSummary> items;
 
@@ -38,14 +47,14 @@ public class FolderCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public FolderCollection build() {
-            FolderCollection __instance__ = new FolderCollection(items);
+            FolderCollection __instance__ = new FolderCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(FolderCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class FolderCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of folders.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderTagCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderTagCollection.java
@@ -27,6 +27,15 @@ public class FolderTagCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<FolderTagSummary> items;
 
@@ -40,14 +49,14 @@ public class FolderTagCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public FolderTagCollection build() {
-            FolderTagCollection __instance__ = new FolderTagCollection(items);
+            FolderTagCollection __instance__ = new FolderTagCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(FolderTagCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class FolderTagCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of folder tags.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/GlossaryCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/GlossaryCollection.java
@@ -27,6 +27,15 @@ public class GlossaryCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<GlossarySummary> items;
 
@@ -40,14 +49,14 @@ public class GlossaryCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public GlossaryCollection build() {
-            GlossaryCollection __instance__ = new GlossaryCollection(items);
+            GlossaryCollection __instance__ = new GlossaryCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(GlossaryCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class GlossaryCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of glossaries.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
@@ -195,6 +195,33 @@ public class Job {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
+        private String jobDefinitionName;
+
+        public Builder jobDefinitionName(String jobDefinitionName) {
+            this.jobDefinitionName = jobDefinitionName;
+            this.__explicitlySet__.add("jobDefinitionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+        private String errorCode;
+
+        public Builder errorCode(String errorCode) {
+            this.errorCode = errorCode;
+            this.__explicitlySet__.add("errorCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+        private String errorMessage;
+
+        public Builder errorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+            this.__explicitlySet__.add("errorMessage");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("uri")
         private String uri;
 
@@ -229,6 +256,9 @@ public class Job {
                             timeOfLatestExecution,
                             createdById,
                             updatedById,
+                            jobDefinitionName,
+                            errorCode,
+                            errorMessage,
                             uri);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -256,6 +286,9 @@ public class Job {
                             .timeOfLatestExecution(o.getTimeOfLatestExecution())
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
+                            .jobDefinitionName(o.getJobDefinitionName())
+                            .errorCode(o.getErrorCode())
+                            .errorMessage(o.getErrorMessage())
                             .uri(o.getUri());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -395,6 +428,26 @@ public class Job {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
     String updatedById;
+
+    /**
+     * The display name of the job definition resource that defined the scope of this job.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
+    String jobDefinitionName;
+
+    /**
+     * Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+    String errorCode;
+
+    /**
+     * Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+    String errorMessage;
 
     /**
      * URI to the job instance in the API.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobCollection.java
@@ -25,6 +25,15 @@ public class JobCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<JobSummary> items;
 
@@ -38,14 +47,14 @@ public class JobCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public JobCollection build() {
-            JobCollection __instance__ = new JobCollection(items);
+            JobCollection __instance__ = new JobCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(JobCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class JobCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of jobs.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinition.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinition.java
@@ -180,6 +180,42 @@ public class JobDefinition {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionStarted")
+        private java.util.Date timeLatestExecutionStarted;
+
+        public Builder timeLatestExecutionStarted(java.util.Date timeLatestExecutionStarted) {
+            this.timeLatestExecutionStarted = timeLatestExecutionStarted;
+            this.__explicitlySet__.add("timeLatestExecutionStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionEnded")
+        private java.util.Date timeLatestExecutionEnded;
+
+        public Builder timeLatestExecutionEnded(java.util.Date timeLatestExecutionEnded) {
+            this.timeLatestExecutionEnded = timeLatestExecutionEnded;
+            this.__explicitlySet__.add("timeLatestExecutionEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jobExecutionState")
+        private JobExecutionState jobExecutionState;
+
+        public Builder jobExecutionState(JobExecutionState jobExecutionState) {
+            this.jobExecutionState = jobExecutionState;
+            this.__explicitlySet__.add("jobExecutionState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")
+        private JobScheduleType scheduleType;
+
+        public Builder scheduleType(JobScheduleType scheduleType) {
+            this.scheduleType = scheduleType;
+            this.__explicitlySet__.add("scheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -212,6 +248,10 @@ public class JobDefinition {
                             uri,
                             isSampleDataExtracted,
                             sampleDataSizeInMBs,
+                            timeLatestExecutionStarted,
+                            timeLatestExecutionEnded,
+                            jobExecutionState,
+                            scheduleType,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -237,6 +277,10 @@ public class JobDefinition {
                             .uri(o.getUri())
                             .isSampleDataExtracted(o.getIsSampleDataExtracted())
                             .sampleDataSizeInMBs(o.getSampleDataSizeInMBs())
+                            .timeLatestExecutionStarted(o.getTimeLatestExecutionStarted())
+                            .timeLatestExecutionEnded(o.getTimeLatestExecutionEnded())
+                            .jobExecutionState(o.getJobExecutionState())
+                            .scheduleType(o.getScheduleType())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -358,6 +402,32 @@ public class JobDefinition {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sampleDataSizeInMBs")
     Integer sampleDataSizeInMBs;
+
+    /**
+     * Time that the latest job execution started. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionStarted")
+    java.util.Date timeLatestExecutionStarted;
+
+    /**
+     * Time that the latest job execution ended or null if it hasn't yet completed.
+     * An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionEnded")
+    java.util.Date timeLatestExecutionEnded;
+
+    /**
+     * Status of the latest job execution, such as running, paused, or completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobExecutionState")
+    JobExecutionState jobExecutionState;
+
+    /**
+     * Type of job schedule for the latest job executed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")
+    JobScheduleType scheduleType;
 
     /**
      * A map of maps that contains the properties which are specific to the job type. Each job type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionCollection.java
@@ -27,6 +27,15 @@ public class JobDefinitionCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<JobDefinitionSummary> items;
 
@@ -40,14 +49,14 @@ public class JobDefinitionCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public JobDefinitionCollection build() {
-            JobDefinitionCollection __instance__ = new JobDefinitionCollection(items);
+            JobDefinitionCollection __instance__ = new JobDefinitionCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(JobDefinitionCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class JobDefinitionCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of job definitions.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionSummary.java
@@ -110,6 +110,51 @@ public class JobDefinitionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("connectionKey")
+        private String connectionKey;
+
+        public Builder connectionKey(String connectionKey) {
+            this.connectionKey = connectionKey;
+            this.__explicitlySet__.add("connectionKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionStarted")
+        private java.util.Date timeLatestExecutionStarted;
+
+        public Builder timeLatestExecutionStarted(java.util.Date timeLatestExecutionStarted) {
+            this.timeLatestExecutionStarted = timeLatestExecutionStarted;
+            this.__explicitlySet__.add("timeLatestExecutionStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionEnded")
+        private java.util.Date timeLatestExecutionEnded;
+
+        public Builder timeLatestExecutionEnded(java.util.Date timeLatestExecutionEnded) {
+            this.timeLatestExecutionEnded = timeLatestExecutionEnded;
+            this.__explicitlySet__.add("timeLatestExecutionEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("jobExecutionState")
+        private JobExecutionState jobExecutionState;
+
+        public Builder jobExecutionState(JobExecutionState jobExecutionState) {
+            this.jobExecutionState = jobExecutionState;
+            this.__explicitlySet__.add("jobExecutionState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")
+        private JobScheduleType scheduleType;
+
+        public Builder scheduleType(JobScheduleType scheduleType) {
+            this.scheduleType = scheduleType;
+            this.__explicitlySet__.add("scheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -124,7 +169,12 @@ public class JobDefinitionSummary {
                             jobType,
                             lifecycleState,
                             isSampleDataExtracted,
-                            timeCreated);
+                            timeCreated,
+                            connectionKey,
+                            timeLatestExecutionStarted,
+                            timeLatestExecutionEnded,
+                            jobExecutionState,
+                            scheduleType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -140,7 +190,12 @@ public class JobDefinitionSummary {
                             .jobType(o.getJobType())
                             .lifecycleState(o.getLifecycleState())
                             .isSampleDataExtracted(o.getIsSampleDataExtracted())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .connectionKey(o.getConnectionKey())
+                            .timeLatestExecutionStarted(o.getTimeLatestExecutionStarted())
+                            .timeLatestExecutionEnded(o.getTimeLatestExecutionEnded())
+                            .jobExecutionState(o.getJobExecutionState())
+                            .scheduleType(o.getScheduleType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -211,6 +266,39 @@ public class JobDefinitionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * The key of the connection resource used in harvest, sampling, profiling jobs.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("connectionKey")
+    String connectionKey;
+
+    /**
+     * Time that the latest job execution started. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionStarted")
+    java.util.Date timeLatestExecutionStarted;
+
+    /**
+     * Time that the latest job execution ended or null if it hasn't yet completed.
+     * An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestExecutionEnded")
+    java.util.Date timeLatestExecutionEnded;
+
+    /**
+     * Status of the latest job execution, such as running, paused, or completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobExecutionState")
+    JobExecutionState jobExecutionState;
+
+    /**
+     * Type of job schedule for the latest job executed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")
+    JobScheduleType scheduleType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobExecutionCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobExecutionCollection.java
@@ -27,6 +27,15 @@ public class JobExecutionCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<JobExecutionSummary> items;
 
@@ -40,14 +49,14 @@ public class JobExecutionCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public JobExecutionCollection build() {
-            JobExecutionCollection __instance__ = new JobExecutionCollection(items);
+            JobExecutionCollection __instance__ = new JobExecutionCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(JobExecutionCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class JobExecutionCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of job executions.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobLogCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobLogCollection.java
@@ -25,6 +25,15 @@ public class JobLogCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<JobLogSummary> items;
 
@@ -38,14 +47,14 @@ public class JobLogCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public JobLogCollection build() {
-            JobLogCollection __instance__ = new JobLogCollection(items);
+            JobLogCollection __instance__ = new JobLogCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(JobLogCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class JobLogCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of Job logs.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobMetricCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobMetricCollection.java
@@ -27,6 +27,15 @@ public class JobMetricCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<JobMetricSummary> items;
 
@@ -40,14 +49,14 @@ public class JobMetricCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public JobMetricCollection build() {
-            JobMetricCollection __instance__ = new JobMetricCollection(items);
+            JobMetricCollection __instance__ = new JobMetricCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(JobMetricCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class JobMetricCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of job metrics.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
@@ -178,6 +178,33 @@ public class JobSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
+        private String jobDefinitionName;
+
+        public Builder jobDefinitionName(String jobDefinitionName) {
+            this.jobDefinitionName = jobDefinitionName;
+            this.__explicitlySet__.add("jobDefinitionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+        private String errorCode;
+
+        public Builder errorCode(String errorCode) {
+            this.errorCode = errorCode;
+            this.__explicitlySet__.add("errorCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+        private String errorMessage;
+
+        public Builder errorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+            this.__explicitlySet__.add("errorMessage");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("executions")
         private java.util.List<JobExecutionSummary> executions;
 
@@ -210,6 +237,9 @@ public class JobSummary {
                             timeScheduleBegin,
                             executionCount,
                             timeOfLatestExecution,
+                            jobDefinitionName,
+                            errorCode,
+                            errorMessage,
                             executions);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -235,6 +265,9 @@ public class JobSummary {
                             .timeScheduleBegin(o.getTimeScheduleBegin())
                             .executionCount(o.getExecutionCount())
                             .timeOfLatestExecution(o.getTimeOfLatestExecution())
+                            .jobDefinitionName(o.getJobDefinitionName())
+                            .errorCode(o.getErrorCode())
+                            .errorMessage(o.getErrorMessage())
                             .executions(o.getExecutions());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -360,6 +393,26 @@ public class JobSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeOfLatestExecution")
     java.util.Date timeOfLatestExecution;
+
+    /**
+     * The display name of the job definition resource that defined the scope of this job.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
+    String jobDefinitionName;
+
+    /**
+     * Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+    String errorCode;
+
+    /**
+     * Error message returned from the latest job execution for this job. Useful when the latest Job Execution is in a FAILED state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+    String errorMessage;
 
     /**
      * Array of the executions summary associated with this job.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobType.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobType.java
@@ -12,6 +12,8 @@ package com.oracle.bmc.datacatalog.model;
  * PREVIEW  - Preview jobs are metadata crawlers but allow users to filter and view metadata entities in data assets.
  * IMPORT - Import jobs import metadata in data catalog repository from a data catalog exported file.
  * EXPORT - Export jobs export data catalog metadata for imports into other data catalog repositories.
+ * IMPORT_GLOSSARY - Job type to import glossary metadata from a file.
+ * EXPORT_GLOSSARY - Job type to export glossary metadata to a file.
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
@@ -23,6 +25,8 @@ public enum JobType {
     Preview("PREVIEW"),
     Import("IMPORT"),
     Export("EXPORT"),
+    ImportGlossary("IMPORT_GLOSSARY"),
+    ExportGlossary("EXPORT_GLOSSARY"),
     Internal("INTERNAL"),
     Purge("PURGE"),
     Immediate("IMMEDIATE"),

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermCollection.java
@@ -25,6 +25,15 @@ public class TermCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<TermSummary> items;
 
@@ -38,14 +47,14 @@ public class TermCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public TermCollection build() {
-            TermCollection __instance__ = new TermCollection(items);
+            TermCollection __instance__ = new TermCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TermCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class TermCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of terms.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationship.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationship.java
@@ -79,6 +79,15 @@ public class TermRelationship {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("relatedTermPath")
+        private String relatedTermPath;
+
+        public Builder relatedTermPath(String relatedTermPath) {
+            this.relatedTermPath = relatedTermPath;
+            this.__explicitlySet__.add("relatedTermPath");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("uri")
         private String uri;
 
@@ -115,6 +124,15 @@ public class TermRelationship {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("parentTermPath")
+        private String parentTermPath;
+
+        public Builder parentTermPath(String parentTermPath) {
+            this.parentTermPath = parentTermPath;
+            this.__explicitlySet__.add("parentTermPath");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -145,10 +163,12 @@ public class TermRelationship {
                             relatedTermKey,
                             relatedTermDisplayName,
                             relatedTermDescription,
+                            relatedTermPath,
                             uri,
                             parentTermKey,
                             parentTermDisplayName,
                             parentTermDescription,
+                            parentTermPath,
                             timeCreated,
                             lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -164,10 +184,12 @@ public class TermRelationship {
                             .relatedTermKey(o.getRelatedTermKey())
                             .relatedTermDisplayName(o.getRelatedTermDisplayName())
                             .relatedTermDescription(o.getRelatedTermDescription())
+                            .relatedTermPath(o.getRelatedTermPath())
                             .uri(o.getUri())
                             .parentTermKey(o.getParentTermKey())
                             .parentTermDisplayName(o.getParentTermDisplayName())
                             .parentTermDescription(o.getParentTermDescription())
+                            .parentTermPath(o.getParentTermPath())
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState());
 
@@ -222,6 +244,12 @@ public class TermRelationship {
     String relatedTermDescription;
 
     /**
+     * Full path of the related term.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("relatedTermPath")
+    String relatedTermPath;
+
+    /**
      * URI to the term relationship instance in the API.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
@@ -244,6 +272,12 @@ public class TermRelationship {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parentTermDescription")
     String parentTermDescription;
+
+    /**
+     * Full path of the parent term.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parentTermPath")
+    String parentTermPath;
 
     /**
      * The date and time the term relationship was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationshipCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationshipCollection.java
@@ -27,6 +27,15 @@ public class TermRelationshipCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<TermRelationshipSummary> items;
 
@@ -40,14 +49,14 @@ public class TermRelationshipCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public TermRelationshipCollection build() {
-            TermRelationshipCollection __instance__ = new TermRelationshipCollection(items);
+            TermRelationshipCollection __instance__ = new TermRelationshipCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TermRelationshipCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -60,6 +69,12 @@ public class TermRelationshipCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of term relationships.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationshipSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TermRelationshipSummary.java
@@ -81,6 +81,15 @@ public class TermRelationshipSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("relatedTermPath")
+        private String relatedTermPath;
+
+        public Builder relatedTermPath(String relatedTermPath) {
+            this.relatedTermPath = relatedTermPath;
+            this.__explicitlySet__.add("relatedTermPath");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("uri")
         private String uri;
 
@@ -117,6 +126,15 @@ public class TermRelationshipSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("parentTermPath")
+        private String parentTermPath;
+
+        public Builder parentTermPath(String parentTermPath) {
+            this.parentTermPath = parentTermPath;
+            this.__explicitlySet__.add("parentTermPath");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -147,10 +165,12 @@ public class TermRelationshipSummary {
                             relatedTermKey,
                             relatedTermDisplayName,
                             relatedTermDescription,
+                            relatedTermPath,
                             uri,
                             parentTermKey,
                             parentTermDisplayName,
                             parentTermDescription,
+                            parentTermPath,
                             timeCreated,
                             lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -166,10 +186,12 @@ public class TermRelationshipSummary {
                             .relatedTermKey(o.getRelatedTermKey())
                             .relatedTermDisplayName(o.getRelatedTermDisplayName())
                             .relatedTermDescription(o.getRelatedTermDescription())
+                            .relatedTermPath(o.getRelatedTermPath())
                             .uri(o.getUri())
                             .parentTermKey(o.getParentTermKey())
                             .parentTermDisplayName(o.getParentTermDisplayName())
                             .parentTermDescription(o.getParentTermDescription())
+                            .parentTermPath(o.getParentTermPath())
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState());
 
@@ -224,6 +246,12 @@ public class TermRelationshipSummary {
     String relatedTermDescription;
 
     /**
+     * Full path of the related term.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("relatedTermPath")
+    String relatedTermPath;
+
+    /**
      * URI to the term relationship instance in the API.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
@@ -246,6 +274,12 @@ public class TermRelationshipSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parentTermDescription")
     String parentTermDescription;
+
+    /**
+     * Full path of the parent term.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parentTermPath")
+    String parentTermPath;
 
     /**
      * The date and time the term relationship was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TypeCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TypeCollection.java
@@ -25,6 +25,15 @@ public class TypeCollection {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("items")
         private java.util.List<TypeSummary> items;
 
@@ -38,14 +47,14 @@ public class TypeCollection {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public TypeCollection build() {
-            TypeCollection __instance__ = new TypeCollection(items);
+            TypeCollection __instance__ = new TypeCollection(count, items);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(TypeCollection o) {
-            Builder copiedBuilder = items(o.getItems());
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -58,6 +67,12 @@ public class TypeCollection {
     public static Builder builder() {
         return new Builder();
     }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
 
     /**
      * Collection of types.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
@@ -116,6 +116,42 @@ public class UpdateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+        private Integer minCollectionCount;
+
+        public Builder minCollectionCount(Integer minCollectionCount) {
+            this.minCollectionCount = minCollectionCount;
+            this.__explicitlySet__.add("minCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+        private Integer maxCollectionCount;
+
+        public Builder maxCollectionCount(Integer maxCollectionCount) {
+            this.maxCollectionCount = maxCollectionCount;
+            this.__explicitlySet__.add("maxCollectionCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+        private String externalDatatypeEntityKey;
+
+        public Builder externalDatatypeEntityKey(String externalDatatypeEntityKey) {
+            this.externalDatatypeEntityKey = externalDatatypeEntityKey;
+            this.__explicitlySet__.add("externalDatatypeEntityKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+        private String externalParentAttributeKey;
+
+        public Builder externalParentAttributeKey(String externalParentAttributeKey) {
+            this.externalParentAttributeKey = externalParentAttributeKey;
+            this.__explicitlySet__.add("externalParentAttributeKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -141,6 +177,10 @@ public class UpdateAttributeDetails {
                             precision,
                             scale,
                             timeExternal,
+                            minCollectionCount,
+                            maxCollectionCount,
+                            externalDatatypeEntityKey,
+                            externalParentAttributeKey,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -159,6 +199,10 @@ public class UpdateAttributeDetails {
                             .precision(o.getPrecision())
                             .scale(o.getScale())
                             .timeExternal(o.getTimeExternal())
+                            .minCollectionCount(o.getMinCollectionCount())
+                            .maxCollectionCount(o.getMaxCollectionCount())
+                            .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
+                            .externalParentAttributeKey(o.getExternalParentAttributeKey())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -234,6 +278,33 @@ public class UpdateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeExternal")
     java.util.Date timeExternal;
+
+    /**
+     * The minimum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minCollectionCount")
+    Integer minCollectionCount;
+
+    /**
+     * The maximum count for the number of instances of a given type stored in this collection type attribute,applicable if this attribute is a complex type.
+     * For type specifications in systems that specify only \"capacity\" without upper or lower bound , this property can also be used to just mean \"capacity\".
+     * Some examples are Varray size in Oracle , Occurs Clause in Cobol , capacity in XmlSchemaObjectCollection , maxOccurs in  Xml , maxItems in Json
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCollectionCount")
+    Integer maxCollectionCount;
+
+    /**
+     * External entity key that represents the datatype of this attribute , applicable if this attribute is a complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatatypeEntityKey")
+    String externalDatatypeEntityKey;
+
+    /**
+     * External attribute key that represents the parent attribute  of this attribute , applicable if the parent attribute is of complex type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
+    String externalParentAttributeKey;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetAttributeRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetAttributeRequest.java
@@ -62,6 +62,13 @@ public class GetAttributeRequest extends com.oracle.bmc.requests.BmcRequest<java
         TimeExternal("timeExternal"),
         Uri("uri"),
         Properties("properties"),
+        Path("path"),
+        MinCollectionCount("minCollectionCount"),
+        MaxCollectionCount("maxCollectionCount"),
+        DatatypeEntityKey("datatypeEntityKey"),
+        ExternalDatatypeEntityKey("externalDatatypeEntityKey"),
+        ParentAttributeKey("parentAttributeKey"),
+        ExternalParentAttributeKey("externalParentAttributeKey"),
         ;
 
         private final String value;

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetEntityRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetEntityRequest.java
@@ -52,6 +52,7 @@ public class GetEntityRequest extends com.oracle.bmc.requests.BmcRequest<java.la
         IsLogical("isLogical"),
         IsPartition("isPartition"),
         FolderKey("folderKey"),
+        FolderName("folderName"),
         TypeKey("typeKey"),
         Path("path"),
         HarvestStatus("harvestStatus"),

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetJobDefinitionRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetJobDefinitionRequest.java
@@ -49,6 +49,10 @@ public class GetJobDefinitionRequest extends com.oracle.bmc.requests.BmcRequest<
         Uri("uri"),
         IsSampleDataExtracted("isSampleDataExtracted"),
         SampleDataSizeInMBs("sampleDataSizeInMBs"),
+        TimeLatestExecutionStarted("timeLatestExecutionStarted"),
+        TimeLatestExecutionEnded("timeLatestExecutionEnded"),
+        JobExecutionState("jobExecutionState"),
+        ScheduleType("scheduleType"),
         Properties("properties"),
         ;
 

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetJobRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetJobRequest.java
@@ -53,6 +53,9 @@ public class GetJobRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.
         CreatedById("createdById"),
         UpdatedById("updatedById"),
         Uri("uri"),
+        JobDefinitionName("jobDefinitionName"),
+        ErrorCode("errorCode"),
+        ErrorMessage("errorMessage"),
         ;
 
         private final String value;

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAttributesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAttributesRequest.java
@@ -32,6 +32,14 @@ public class ListAttributesRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -123,6 +131,13 @@ public class ListAttributesRequest extends com.oracle.bmc.requests.BmcRequest<ja
         Length("length"),
         IsNullable("isNullable"),
         Uri("uri"),
+        Path("path"),
+        MinCollectionCount("minCollectionCount"),
+        MaxCollectionCount("maxCollectionCount"),
+        DatatypeEntityKey("datatypeEntityKey"),
+        ExternalDatatypeEntityKey("externalDatatypeEntityKey"),
+        ParentAttributeKey("parentAttributeKey"),
+        ExternalParentAttributeKey("externalParentAttributeKey"),
         ;
 
         private final String value;
@@ -288,6 +303,7 @@ public class ListAttributesRequest extends com.oracle.bmc.requests.BmcRequest<ja
             dataAssetKey(o.getDataAssetKey());
             entityKey(o.getEntityKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListConnectionsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListConnectionsRequest.java
@@ -27,6 +27,14 @@ public class ListConnectionsRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -251,6 +259,7 @@ public class ListConnectionsRequest extends com.oracle.bmc.requests.BmcRequest<j
             catalogId(o.getCatalogId());
             dataAssetKey(o.getDataAssetKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListDataAssetsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListDataAssetsRequest.java
@@ -22,6 +22,14 @@ public class ListDataAssetsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -239,6 +247,7 @@ public class ListDataAssetsRequest extends com.oracle.bmc.requests.BmcRequest<ja
         public Builder copy(ListDataAssetsRequest o) {
             catalogId(o.getCatalogId());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
@@ -27,6 +27,14 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -117,6 +125,7 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
         UpdatedById("updatedById"),
         LifecycleState("lifecycleState"),
         FolderKey("folderKey"),
+        FolderName("folderName"),
         ExternalKey("externalKey"),
         Path("path"),
         Uri("uri"),
@@ -284,6 +293,7 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
             catalogId(o.getCatalogId());
             dataAssetKey(o.getDataAssetKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListFoldersRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListFoldersRequest.java
@@ -27,6 +27,14 @@ public class ListFoldersRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -262,6 +270,7 @@ public class ListFoldersRequest extends com.oracle.bmc.requests.BmcRequest<java.
             catalogId(o.getCatalogId());
             dataAssetKey(o.getDataAssetKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             parentFolderKey(o.getParentFolderKey());
             path(o.getPath());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListGlossariesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListGlossariesRequest.java
@@ -22,6 +22,14 @@ public class ListGlossariesRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -228,6 +236,7 @@ public class ListGlossariesRequest extends com.oracle.bmc.requests.BmcRequest<ja
         public Builder copy(ListGlossariesRequest o) {
             catalogId(o.getCatalogId());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobDefinitionsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobDefinitionsRequest.java
@@ -22,6 +22,19 @@ public class ListJobDefinitionsRequest extends com.oracle.bmc.requests.BmcReques
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
+     * Job execution state.
+     */
+    private com.oracle.bmc.datacatalog.model.JobExecutionState jobExecutionState;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -87,10 +100,15 @@ public class ListJobDefinitionsRequest extends com.oracle.bmc.requests.BmcReques
         Description("description"),
         CatalogId("catalogId"),
         JobType("jobType"),
+        ConnectionKey("connectionKey"),
         LifecycleState("lifecycleState"),
         TimeCreated("timeCreated"),
         IsSampleDataExtracted("isSampleDataExtracted"),
         Uri("uri"),
+        TimeLatestExecutionStarted("timeLatestExecutionStarted"),
+        TimeLatestExecutionEnded("timeLatestExecutionEnded"),
+        JobExecutionState("jobExecutionState"),
+        ScheduleType("scheduleType"),
         ;
 
         private final String value;
@@ -121,18 +139,19 @@ public class ListJobDefinitionsRequest extends com.oracle.bmc.requests.BmcReques
         }
     };
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. Default order for TIMELATESTEXECUTIONSTARTED is descending. If no value is specified TIMECREATED is default.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. Default order for TIMELATESTEXECUTIONSTARTED is descending. If no value is specified TIMECREATED is default.
      *
      **/
     public enum SortBy {
         Timecreated("TIMECREATED"),
         Displayname("DISPLAYNAME"),
+        Timelatestexecutionstarted("TIMELATESTEXECUTIONSTARTED"),
         ;
 
         private final String value;
@@ -254,6 +273,8 @@ public class ListJobDefinitionsRequest extends com.oracle.bmc.requests.BmcReques
         public Builder copy(ListJobDefinitionsRequest o) {
             catalogId(o.getCatalogId());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
+            jobExecutionState(o.getJobExecutionState());
             lifecycleState(o.getLifecycleState());
             jobType(o.getJobType());
             isIncremental(o.getIsIncremental());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobMetricsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobMetricsRequest.java
@@ -32,6 +32,14 @@ public class ListJobMetricsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * Category of this metric.
      */
     private String category;
@@ -271,6 +279,7 @@ public class ListJobMetricsRequest extends com.oracle.bmc.requests.BmcRequest<ja
             jobKey(o.getJobKey());
             jobExecutionKey(o.getJobExecutionKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             category(o.getCategory());
             subCategory(o.getSubCategory());
             unit(o.getUnit());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
@@ -22,6 +22,14 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * Job lifecycle state.
      */
     private com.oracle.bmc.datacatalog.model.JobLifecycleState lifecycleState;
@@ -113,6 +121,9 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         TimeOfLatestExecution("timeOfLatestExecution"),
         Executions("executions"),
         Uri("uri"),
+        JobDefinitionName("jobDefinitionName"),
+        ErrorCode("errorCode"),
+        ErrorMessage("errorMessage"),
         ;
 
         private final String value;
@@ -288,6 +299,7 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         public Builder copy(ListJobsRequest o) {
             catalogId(o.getCatalogId());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());
             timeUpdated(o.getTimeUpdated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTagsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTagsRequest.java
@@ -22,6 +22,14 @@ public class ListTagsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -211,6 +219,7 @@ public class ListTagsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         public Builder copy(ListTagsRequest o) {
             catalogId(o.getCatalogId());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             fields(o.getFields());
             sortBy(o.getSortBy());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTermRelationshipsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTermRelationshipsRequest.java
@@ -33,6 +33,14 @@ public class ListTermRelationshipsRequest
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -223,6 +231,7 @@ public class ListTermRelationshipsRequest
             glossaryKey(o.getGlossaryKey());
             termKey(o.getTermKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             fields(o.getFields());
             sortBy(o.getSortBy());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTermsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListTermsRequest.java
@@ -27,6 +27,14 @@ public class ListTermsRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     private String displayName;
 
     /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
      * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
      */
     private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
@@ -238,6 +246,7 @@ public class ListTermsRequest extends com.oracle.bmc.requests.BmcRequest<java.la
             catalogId(o.getCatalogId());
             glossaryKey(o.getGlossaryKey());
             displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             parentTermKey(o.getParentTermKey());
             isAllowedToHaveChildTerms(o.getIsAllowedToHaveChildTerms());

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.21.0</version>
+        <version>1.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-full/src/main/assembly/assembly.xml
+++ b/bmc-full/src/main/assembly/assembly.xml
@@ -24,6 +24,7 @@
         <include>CONTRIBUTING.md</include>
         <include>LICENSE.txt</include>
         <include>THIRD_PARTY_LICENSES.txt</include>
+        <include>NOTICE.txt</include>
       </includes>
     </fileSet>
     <!-- Include all of the examples -->

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorage.java
@@ -432,6 +432,9 @@ public interface ObjectStorage extends AutoCloseable {
      * Creates a new object or overwrites an existing object with the same name. The maximum object size allowed by
      * PutObject is 50 GiB.
      * <p>
+     * See [Object Names](https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements)
+     * for object naming requirements.
+     * <p>
      * See [Special Instructions for Object Storage PUT](https://docs.cloud.oracle.com/Content/API/Concepts/signingrequests.htm#ObjectStoragePut)
      * for request signature requirements.
      *
@@ -520,6 +523,9 @@ public interface ObjectStorage extends AutoCloseable {
 
     /**
      * Rename an object in the given Object Storage namespace.
+     * <p>
+     * See [Object Names](https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements)
+     * for object naming requirements.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/ObjectStorageAsync.java
@@ -721,6 +721,9 @@ public interface ObjectStorageAsync extends AutoCloseable {
      * Creates a new object or overwrites an existing object with the same name. The maximum object size allowed by
      * PutObject is 50 GiB.
      * <p>
+     * See [Object Names](https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements)
+     * for object naming requirements.
+     * <p>
      * See [Special Instructions for Object Storage PUT](https://docs.cloud.oracle.com/Content/API/Concepts/signingrequests.htm#ObjectStoragePut)
      * for request signature requirements.
      *
@@ -809,6 +812,9 @@ public interface ObjectStorageAsync extends AutoCloseable {
 
     /**
      * Rename an object in the given Object Storage namespace.
+     * <p>
+     * See [Object Names](https://docs.cloud.oracle.com/Content/Object/Tasks/managingobjects.htm#namerequirements)
+     * for object naming requirements.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ObjectLifecycleRule.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ObjectLifecycleRule.java
@@ -38,6 +38,15 @@ public class ObjectLifecycleRule {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private String target;
+
+        public Builder target(String target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("action")
         private String action;
 
@@ -89,7 +98,13 @@ public class ObjectLifecycleRule {
         public ObjectLifecycleRule build() {
             ObjectLifecycleRule __instance__ =
                     new ObjectLifecycleRule(
-                            name, action, timeAmount, timeUnit, isEnabled, objectNameFilter);
+                            name,
+                            target,
+                            action,
+                            timeAmount,
+                            timeUnit,
+                            isEnabled,
+                            objectNameFilter);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -98,6 +113,7 @@ public class ObjectLifecycleRule {
         public Builder copy(ObjectLifecycleRule o) {
             Builder copiedBuilder =
                     name(o.getName())
+                            .target(o.getTarget())
                             .action(o.getAction())
                             .timeAmount(o.getTimeAmount())
                             .timeUnit(o.getTimeUnit())
@@ -123,9 +139,16 @@ public class ObjectLifecycleRule {
     String name;
 
     /**
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    String target;
+
+    /**
      * The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
      * [Archive Storage tier](https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm). Rules using the action
-     * 'DELETE' permanently delete objects from buckets. 'ARCHIVE' and 'DELETE' are the only two supported
+     * 'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
+     * and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
      * actions at this time.
      *
      **/

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.21.0</version>
+  <version>1.22.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for autonomous json databases in the Database service

- Support for cleaning up uncommitted multipart uploads in the Object Storage service

- Support for additional list API filters in the Data Catalog service





### Breaking Changes

- Some unusable region enums were removed from the Support Management service

- Parameter `opcRetryToken` was removed from the Support Management service