### PR TITLE
Releasing version 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.22.1 - 2020-08-18
+### Added
+- Support for custom boot volume size and other node pool updates in the Container Engine for Kubernetes service
+- Support for Data Guard on Exadata Cloud at Customer VM clusters in the Database service
+- Support for stopping VM instances after scheduled maintenance or hypervisor reboots in the Compute service
+- Support for creating and managing private endpoints in the Data Flow service
+
 ## 1.22.0 - 2020-08-11
 ### Added
 - Support for autonomous json databases in the Database service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,324 +19,324 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolDetails.java
@@ -220,7 +220,7 @@ public class CreateNodePoolDetails {
     String kubernetesVersion;
 
     /**
-     * A list of key/value pairs to add to each underlying OCI instance in the node pool.
+     * A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
     java.util.Map<String, String> nodeMetadata;
@@ -254,7 +254,7 @@ public class CreateNodePoolDetails {
     java.util.List<KeyValue> initialNodeLabels;
 
     /**
-     * The SSH public key to add to each node in the node pool.
+     * The SSH public key on each node in the node pool on launch.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKey")
     String sshPublicKey;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePool.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePool.java
@@ -105,6 +105,15 @@ public class NodePool {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+        private NodeSourceDetails nodeSourceDetails;
+
+        public Builder nodeSourceDetails(NodeSourceDetails nodeSourceDetails) {
+            this.nodeSourceDetails = nodeSourceDetails;
+            this.__explicitlySet__.add("nodeSourceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("nodeShape")
         private String nodeShape;
 
@@ -183,6 +192,7 @@ public class NodePool {
                             nodeImageId,
                             nodeImageName,
                             nodeSource,
+                            nodeSourceDetails,
                             nodeShape,
                             initialNodeLabels,
                             sshPublicKey,
@@ -206,6 +216,7 @@ public class NodePool {
                             .nodeImageId(o.getNodeImageId())
                             .nodeImageName(o.getNodeImageName())
                             .nodeSource(o.getNodeSource())
+                            .nodeSourceDetails(o.getNodeSourceDetails())
                             .nodeShape(o.getNodeShape())
                             .initialNodeLabels(o.getInitialNodeLabels())
                             .sshPublicKey(o.getSshPublicKey())
@@ -257,7 +268,7 @@ public class NodePool {
     String kubernetesVersion;
 
     /**
-     * A list of key/value pairs to add to each underlying OCI instance in the node pool.
+     * A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
     java.util.Map<String, String> nodeMetadata;
@@ -277,10 +288,16 @@ public class NodePool {
     String nodeImageName;
 
     /**
-     * Source running on the nodes in the node pool.
+     * Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodeSource")
     NodeSourceOption nodeSource;
+
+    /**
+     * Source running on the nodes in the node pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+    NodeSourceDetails nodeSourceDetails;
 
     /**
      * The name of the node shape of the nodes in the node pool.
@@ -295,7 +312,7 @@ public class NodePool {
     java.util.List<KeyValue> initialNodeLabels;
 
     /**
-     * The SSH public key on each node in the node pool.
+     * The SSH public key on each node in the node pool on launch.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKey")
     String sshPublicKey;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePoolSummary.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePoolSummary.java
@@ -96,6 +96,15 @@ public class NodePoolSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+        private NodeSourceDetails nodeSourceDetails;
+
+        public Builder nodeSourceDetails(NodeSourceDetails nodeSourceDetails) {
+            this.nodeSourceDetails = nodeSourceDetails;
+            this.__explicitlySet__.add("nodeSourceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("nodeShape")
         private String nodeShape;
 
@@ -164,6 +173,7 @@ public class NodePoolSummary {
                             nodeImageId,
                             nodeImageName,
                             nodeSource,
+                            nodeSourceDetails,
                             nodeShape,
                             initialNodeLabels,
                             sshPublicKey,
@@ -185,6 +195,7 @@ public class NodePoolSummary {
                             .nodeImageId(o.getNodeImageId())
                             .nodeImageName(o.getNodeImageName())
                             .nodeSource(o.getNodeSource())
+                            .nodeSourceDetails(o.getNodeSourceDetails())
                             .nodeShape(o.getNodeShape())
                             .initialNodeLabels(o.getInitialNodeLabels())
                             .sshPublicKey(o.getSshPublicKey())
@@ -249,10 +260,16 @@ public class NodePoolSummary {
     String nodeImageName;
 
     /**
-     * Source running on the nodes in the node pool.
+     * Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodeSource")
     NodeSourceOption nodeSource;
+
+    /**
+     * Source running on the nodes in the node pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+    NodeSourceDetails nodeSourceDetails;
 
     /**
      * The name of the node shape of the nodes in the node pool.
@@ -267,7 +284,7 @@ public class NodePoolSummary {
     java.util.List<KeyValue> initialNodeLabels;
 
     /**
-     * The SSH public key on each node in the node pool.
+     * The SSH public key on each node in the node pool on launch.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKey")
     String sshPublicKey;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodeSourceViaImageDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodeSourceViaImageDetails.java
@@ -41,18 +41,29 @@ public class NodeSourceViaImageDetails extends NodeSourceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeSizeInGBs")
+        private Long bootVolumeSizeInGBs;
+
+        public Builder bootVolumeSizeInGBs(Long bootVolumeSizeInGBs) {
+            this.bootVolumeSizeInGBs = bootVolumeSizeInGBs;
+            this.__explicitlySet__.add("bootVolumeSizeInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public NodeSourceViaImageDetails build() {
-            NodeSourceViaImageDetails __instance__ = new NodeSourceViaImageDetails(imageId);
+            NodeSourceViaImageDetails __instance__ =
+                    new NodeSourceViaImageDetails(imageId, bootVolumeSizeInGBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(NodeSourceViaImageDetails o) {
-            Builder copiedBuilder = imageId(o.getImageId());
+            Builder copiedBuilder =
+                    imageId(o.getImageId()).bootVolumeSizeInGBs(o.getBootVolumeSizeInGBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -67,9 +78,10 @@ public class NodeSourceViaImageDetails extends NodeSourceDetails {
     }
 
     @Deprecated
-    public NodeSourceViaImageDetails(String imageId) {
+    public NodeSourceViaImageDetails(String imageId, Long bootVolumeSizeInGBs) {
         super();
         this.imageId = imageId;
+        this.bootVolumeSizeInGBs = bootVolumeSizeInGBs;
     }
 
     /**
@@ -77,6 +89,12 @@ public class NodeSourceViaImageDetails extends NodeSourceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("imageId")
     String imageId;
+
+    /**
+     * The size of the boot volume in GBs. Minimum value is 50 GB. See [here](https://docs.cloud.oracle.com/en-us/iaas/Content/Block/Concepts/bootvolumes.htm) for max custom boot volume sizing and OS-specific requirements.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeSizeInGBs")
+    Long bootVolumeSizeInGBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateNodePoolDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateNodePoolDetails.java
@@ -80,6 +80,42 @@ public class UpdateNodePoolDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+        private java.util.Map<String, String> nodeMetadata;
+
+        public Builder nodeMetadata(java.util.Map<String, String> nodeMetadata) {
+            this.nodeMetadata = nodeMetadata;
+            this.__explicitlySet__.add("nodeMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+        private NodeSourceDetails nodeSourceDetails;
+
+        public Builder nodeSourceDetails(NodeSourceDetails nodeSourceDetails) {
+            this.nodeSourceDetails = nodeSourceDetails;
+            this.__explicitlySet__.add("nodeSourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKey")
+        private String sshPublicKey;
+
+        public Builder sshPublicKey(String sshPublicKey) {
+            this.sshPublicKey = sshPublicKey;
+            this.__explicitlySet__.add("sshPublicKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeShape")
+        private String nodeShape;
+
+        public Builder nodeShape(String nodeShape) {
+            this.nodeShape = nodeShape;
+            this.__explicitlySet__.add("nodeShape");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -91,7 +127,11 @@ public class UpdateNodePoolDetails {
                             initialNodeLabels,
                             quantityPerSubnet,
                             subnetIds,
-                            nodeConfigDetails);
+                            nodeConfigDetails,
+                            nodeMetadata,
+                            nodeSourceDetails,
+                            sshPublicKey,
+                            nodeShape);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -104,7 +144,11 @@ public class UpdateNodePoolDetails {
                             .initialNodeLabels(o.getInitialNodeLabels())
                             .quantityPerSubnet(o.getQuantityPerSubnet())
                             .subnetIds(o.getSubnetIds())
-                            .nodeConfigDetails(o.getNodeConfigDetails());
+                            .nodeConfigDetails(o.getNodeConfigDetails())
+                            .nodeMetadata(o.getNodeMetadata())
+                            .nodeSourceDetails(o.getNodeSourceDetails())
+                            .sshPublicKey(o.getSshPublicKey())
+                            .nodeShape(o.getNodeShape());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -165,6 +209,31 @@ public class UpdateNodePoolDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodeConfigDetails")
     UpdateNodePoolNodeConfigDetails nodeConfigDetails;
+
+    /**
+     * A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeMetadata")
+    java.util.Map<String, String> nodeMetadata;
+
+    /**
+     * Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeSourceDetails")
+    NodeSourceDetails nodeSourceDetails;
+
+    /**
+     * The SSH public key to add to each node in the node pool on launch.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshPublicKey")
+    String sshPublicKey;
+
+    /**
+     * The name of the node shape of the nodes in the node pool used on launch.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeShape")
+    String nodeShape;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
@@ -153,6 +153,15 @@ public class Instance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+        private InstanceAvailabilityConfig availabilityConfig;
+
+        public Builder availabilityConfig(InstanceAvailabilityConfig availabilityConfig) {
+            this.availabilityConfig = availabilityConfig;
+            this.__explicitlySet__.add("availabilityConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -262,6 +271,7 @@ public class Instance {
                             ipxeScript,
                             launchMode,
                             launchOptions,
+                            availabilityConfig,
                             lifecycleState,
                             metadata,
                             region,
@@ -292,6 +302,7 @@ public class Instance {
                             .ipxeScript(o.getIpxeScript())
                             .launchMode(o.getLaunchMode())
                             .launchOptions(o.getLaunchOptions())
+                            .availabilityConfig(o.getAvailabilityConfig())
                             .lifecycleState(o.getLifecycleState())
                             .metadata(o.getMetadata())
                             .region(o.getRegion())
@@ -505,6 +516,9 @@ public class Instance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
     LaunchOptions launchOptions;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+    InstanceAvailabilityConfig availabilityConfig;
     /**
      * The current state of the instance.
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceAvailabilityConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceAvailabilityConfig.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceAvailabilityConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstanceAvailabilityConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+        private RecoveryAction recoveryAction;
+
+        public Builder recoveryAction(RecoveryAction recoveryAction) {
+            this.recoveryAction = recoveryAction;
+            this.__explicitlySet__.add("recoveryAction");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceAvailabilityConfig build() {
+            InstanceAvailabilityConfig __instance__ =
+                    new InstanceAvailabilityConfig(recoveryAction);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceAvailabilityConfig o) {
+            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RecoveryAction {
+        RestoreInstance("RESTORE_INSTANCE"),
+        StopInstance("STOP_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RecoveryAction> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RecoveryAction v : RecoveryAction.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RecoveryAction(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RecoveryAction create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RecoveryAction', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+    RecoveryAction recoveryAction;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationAvailabilityConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationAvailabilityConfig.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceConfigurationAvailabilityConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstanceConfigurationAvailabilityConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+        private RecoveryAction recoveryAction;
+
+        public Builder recoveryAction(RecoveryAction recoveryAction) {
+            this.recoveryAction = recoveryAction;
+            this.__explicitlySet__.add("recoveryAction");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceConfigurationAvailabilityConfig build() {
+            InstanceConfigurationAvailabilityConfig __instance__ =
+                    new InstanceConfigurationAvailabilityConfig(recoveryAction);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceConfigurationAvailabilityConfig o) {
+            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RecoveryAction {
+        RestoreInstance("RESTORE_INSTANCE"),
+        StopInstance("STOP_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RecoveryAction> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RecoveryAction v : RecoveryAction.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RecoveryAction(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RecoveryAction create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RecoveryAction', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+    RecoveryAction recoveryAction;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
@@ -205,6 +205,16 @@ public class InstanceConfigurationLaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+        private InstanceConfigurationAvailabilityConfig availabilityConfig;
+
+        public Builder availabilityConfig(
+                InstanceConfigurationAvailabilityConfig availabilityConfig) {
+            this.availabilityConfig = availabilityConfig;
+            this.__explicitlySet__.add("availabilityConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -229,7 +239,8 @@ public class InstanceConfigurationLaunchInstanceDetails {
                             launchOptions,
                             agentConfig,
                             isPvEncryptionInTransitEnabled,
-                            preferredMaintenanceAction);
+                            preferredMaintenanceAction,
+                            availabilityConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -255,7 +266,8 @@ public class InstanceConfigurationLaunchInstanceDetails {
                             .launchOptions(o.getLaunchOptions())
                             .agentConfig(o.getAgentConfig())
                             .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled())
-                            .preferredMaintenanceAction(o.getPreferredMaintenanceAction());
+                            .preferredMaintenanceAction(o.getPreferredMaintenanceAction())
+                            .availabilityConfig(o.getAvailabilityConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -606,6 +618,9 @@ public class InstanceConfigurationLaunchInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("preferredMaintenanceAction")
     PreferredMaintenanceAction preferredMaintenanceAction;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+    InstanceConfigurationAvailabilityConfig availabilityConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceAvailabilityConfigDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceAvailabilityConfigDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LaunchInstanceAvailabilityConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LaunchInstanceAvailabilityConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+        private RecoveryAction recoveryAction;
+
+        public Builder recoveryAction(RecoveryAction recoveryAction) {
+            this.recoveryAction = recoveryAction;
+            this.__explicitlySet__.add("recoveryAction");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LaunchInstanceAvailabilityConfigDetails build() {
+            LaunchInstanceAvailabilityConfigDetails __instance__ =
+                    new LaunchInstanceAvailabilityConfigDetails(recoveryAction);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LaunchInstanceAvailabilityConfigDetails o) {
+            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    public enum RecoveryAction {
+        RestoreInstance("RESTORE_INSTANCE"),
+        StopInstance("STOP_INSTANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, RecoveryAction> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RecoveryAction v : RecoveryAction.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        RecoveryAction(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RecoveryAction create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid RecoveryAction: " + key);
+        }
+    };
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+    RecoveryAction recoveryAction;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -146,6 +146,16 @@ public class LaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+        private LaunchInstanceAvailabilityConfigDetails availabilityConfig;
+
+        public Builder availabilityConfig(
+                LaunchInstanceAvailabilityConfigDetails availabilityConfig) {
+            this.availabilityConfig = availabilityConfig;
+            this.__explicitlySet__.add("availabilityConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("metadata")
         private java.util.Map<String, String> metadata;
 
@@ -228,6 +238,7 @@ public class LaunchInstanceDetails {
                             imageId,
                             ipxeScript,
                             launchOptions,
+                            availabilityConfig,
                             metadata,
                             agentConfig,
                             shape,
@@ -255,6 +266,7 @@ public class LaunchInstanceDetails {
                             .imageId(o.getImageId())
                             .ipxeScript(o.getIpxeScript())
                             .launchOptions(o.getLaunchOptions())
+                            .availabilityConfig(o.getAvailabilityConfig())
                             .metadata(o.getMetadata())
                             .agentConfig(o.getAgentConfig())
                             .shape(o.getShape())
@@ -423,6 +435,9 @@ public class LaunchInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
     LaunchOptions launchOptions;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+    LaunchInstanceAvailabilityConfigDetails availabilityConfig;
 
     /**
      * Custom metadata key/value pairs that you provide, such as the SSH public key

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceAvailabilityConfigDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceAvailabilityConfigDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateInstanceAvailabilityConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateInstanceAvailabilityConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+        private RecoveryAction recoveryAction;
+
+        public Builder recoveryAction(RecoveryAction recoveryAction) {
+            this.recoveryAction = recoveryAction;
+            this.__explicitlySet__.add("recoveryAction");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateInstanceAvailabilityConfigDetails build() {
+            UpdateInstanceAvailabilityConfigDetails __instance__ =
+                    new UpdateInstanceAvailabilityConfigDetails(recoveryAction);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateInstanceAvailabilityConfigDetails o) {
+            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    public enum RecoveryAction {
+        RestoreInstance("RESTORE_INSTANCE"),
+        StopInstance("STOP_INSTANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, RecoveryAction> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RecoveryAction v : RecoveryAction.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        RecoveryAction(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RecoveryAction create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid RecoveryAction: " + key);
+        }
+    };
+    /**
+     * Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+     * * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+     * will be restored to the power state it was in before maintenance.
+     * * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
+    RecoveryAction recoveryAction;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceDetails.java
@@ -117,6 +117,16 @@ public class UpdateInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+        private UpdateInstanceAvailabilityConfigDetails availabilityConfig;
+
+        public Builder availabilityConfig(
+                UpdateInstanceAvailabilityConfigDetails availabilityConfig) {
+            this.availabilityConfig = availabilityConfig;
+            this.__explicitlySet__.add("availabilityConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -132,7 +142,8 @@ public class UpdateInstanceDetails {
                             shape,
                             shapeConfig,
                             faultDomain,
-                            launchOptions);
+                            launchOptions,
+                            availabilityConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -149,7 +160,8 @@ public class UpdateInstanceDetails {
                             .shape(o.getShape())
                             .shapeConfig(o.getShapeConfig())
                             .faultDomain(o.getFaultDomain())
-                            .launchOptions(o.getLaunchOptions());
+                            .launchOptions(o.getLaunchOptions())
+                            .availabilityConfig(o.getAvailabilityConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -283,6 +295,9 @@ public class UpdateInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("launchOptions")
     UpdateLaunchOptions launchOptions;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityConfig")
+    UpdateInstanceAvailabilityConfigDetails availabilityConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
@@ -36,6 +36,10 @@ package com.oracle.bmc.database.model;
         name = "NewDbSystem"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDataGuardAssociationToExistingVmClusterDetails.class,
+        name = "ExistingVmCluster"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateDataGuardAssociationToExistingDbSystemDetails.class,
         name = "ExistingDbSystem"
     )

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The configuration details for creating a Data Guard association for a ExaCC Vmcluster database. For these types of vm cluster databases, the `creationType` should be `ExistingVmCluster`. A standby database will be created in the VM cluster you specify.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDataGuardAssociationToExistingVmClusterDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "creationType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateDataGuardAssociationToExistingVmClusterDetails
+        extends CreateDataGuardAssociationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseAdminPassword")
+        private String databaseAdminPassword;
+
+        public Builder databaseAdminPassword(String databaseAdminPassword) {
+            this.databaseAdminPassword = databaseAdminPassword;
+            this.__explicitlySet__.add("databaseAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+        private ProtectionMode protectionMode;
+
+        public Builder protectionMode(ProtectionMode protectionMode) {
+            this.protectionMode = protectionMode;
+            this.__explicitlySet__.add("protectionMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("transportType")
+        private TransportType transportType;
+
+        public Builder transportType(TransportType transportType) {
+            this.transportType = transportType;
+            this.__explicitlySet__.add("transportType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerVmClusterId")
+        private String peerVmClusterId;
+
+        public Builder peerVmClusterId(String peerVmClusterId) {
+            this.peerVmClusterId = peerVmClusterId;
+            this.__explicitlySet__.add("peerVmClusterId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDataGuardAssociationToExistingVmClusterDetails build() {
+            CreateDataGuardAssociationToExistingVmClusterDetails __instance__ =
+                    new CreateDataGuardAssociationToExistingVmClusterDetails(
+                            databaseAdminPassword, protectionMode, transportType, peerVmClusterId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDataGuardAssociationToExistingVmClusterDetails o) {
+            Builder copiedBuilder =
+                    databaseAdminPassword(o.getDatabaseAdminPassword())
+                            .protectionMode(o.getProtectionMode())
+                            .transportType(o.getTransportType())
+                            .peerVmClusterId(o.getPeerVmClusterId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDataGuardAssociationToExistingVmClusterDetails(
+            String databaseAdminPassword,
+            ProtectionMode protectionMode,
+            TransportType transportType,
+            String peerVmClusterId) {
+        super(databaseAdminPassword, protectionMode, transportType);
+        this.peerVmClusterId = peerVmClusterId;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Cluster in which to create the standby database.
+     * You must supply this value if creationType is `ExistingVmCluster`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerVmClusterId")
+    String peerVmClusterId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.22.0</version>
+        <version>1.22.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.22.0</version>
+    <version>1.22.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.22.0</version>
+      <version>1.22.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.22.0</version>
+  <version>1.22.1</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for custom boot volume size and other node pool updates in the Container Engine for Kubernetes service

- Support for Data Guard on Exadata Cloud at Customer VM clusters in the Database service

- Support for stopping VM instances after scheduled maintenance or hypervisor reboots in the Compute service

- Support for creating and managing private endpoints in the Data Flow service