### PR TITLE
Pass RetryConfiguration to UploadManager

### DIFF
--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
@@ -90,7 +90,6 @@ public class UploadManager {
      * @param uploadDetails The upload request.
      * @return The response.
      * @throws BmcException if the upload fails for any reason.
-     * @throws IllegalArgumentException if UploadRequest
      */
     public UploadResponse upload(UploadRequest uploadDetails) {
         if (MultipartUtils.shouldUseMultipart(
@@ -172,7 +171,8 @@ public class UploadManager {
             shutdownExecutor = true;
         }
 
-        MultipartObjectAssembler assembler = createAssembler(uploadRequest, executorServiceToUse);
+        MultipartObjectAssembler assembler =
+                createAssembler(request, uploadRequest, executorServiceToUse);
         MultipartManifest manifest = null;
         try {
             manifest =
@@ -265,10 +265,15 @@ public class UploadManager {
     }
 
     @VisibleForTesting
-    protected MultipartObjectAssembler createAssembler(UploadRequest uploadRequest, ExecutorService executorService) {
+    protected MultipartObjectAssembler createAssembler(
+            PutObjectRequest request,
+            UploadRequest uploadRequest,
+            ExecutorService executorService) {
 
-        PutObjectRequest request = uploadRequest.putObjectRequest;
-        RetryConfiguration retryToUse = getRetryToUse(request.getRetryConfiguration());
+        // in case request != uploadRequest.putObjectRequest then choose the correct RetryConfiguration
+        RetryConfiguration retryToUse = getRetryToUse(
+                uploadRequest.putObjectRequest.getRetryConfiguration(),
+                request.getRetryConfiguration());
 
         return MultipartObjectAssembler.builder()
                 .allowOverwrite(uploadRequest.allowOverwrite)

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
@@ -90,6 +90,7 @@ public class UploadManager {
      * @param uploadDetails The upload request.
      * @return The response.
      * @throws BmcException if the upload fails for any reason.
+     * @throws IllegalArgumentException if UploadRequest
      */
     public UploadResponse upload(UploadRequest uploadDetails) {
         if (MultipartUtils.shouldUseMultipart(
@@ -171,8 +172,7 @@ public class UploadManager {
             shutdownExecutor = true;
         }
 
-        MultipartObjectAssembler assembler =
-                createAssembler(request, uploadRequest, executorServiceToUse);
+        MultipartObjectAssembler assembler = createAssembler(uploadRequest, executorServiceToUse);
         MultipartManifest manifest = null;
         try {
             manifest =
@@ -265,15 +265,10 @@ public class UploadManager {
     }
 
     @VisibleForTesting
-    protected MultipartObjectAssembler createAssembler(
-            PutObjectRequest request,
-            UploadRequest uploadRequest,
-            ExecutorService executorService) {
+    protected MultipartObjectAssembler createAssembler(UploadRequest uploadRequest, ExecutorService executorService) {
 
-        // in case request != uploadRequest.putObjectRequest then choose the correct RetryConfiguration
-        RetryConfiguration retryToUse = getRetryToUse(
-                uploadRequest.putObjectRequest.getRetryConfiguration(),
-                request.getRetryConfiguration());
+        PutObjectRequest request = uploadRequest.putObjectRequest;
+        RetryConfiguration retryToUse = getRetryToUse(request.getRetryConfiguration());
 
         return MultipartObjectAssembler.builder()
                 .allowOverwrite(uploadRequest.allowOverwrite)

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
@@ -249,13 +249,13 @@ public class UploadManager {
     }
 
     /**
-     * Determines the first non-null RetryCondition
+     * Determines the first non-null RetryConfiguration
      *    1 -> RetryConfiguration set on UploadConfiguration
      *    2 -> Default static RetryConfiguration for UploadManager
      *
-     * @return RetryConfiguration
+     * @return RetryConfiguration first non-null condition or UploadManager default
      */
-    private RetryConfiguration getRetryToUse(RetryConfiguration ...configs) {
+    private static RetryConfiguration getRetryToUse(RetryConfiguration ...configs) {
         for (RetryConfiguration cfg : configs) {
             if (cfg != null)
                 return cfg;

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
@@ -115,7 +115,7 @@ public class MultipartObjectAssemblerTest {
     }
 
     @Test
-    public void newRequest_andVerifyManifest() {
+    public void newRequest_andVerifyManifestWithRetryConfiguration() {
         String uploadId = "uploadId";
 
         initializeCreateMultipartUpload(uploadId);
@@ -143,7 +143,7 @@ public class MultipartObjectAssemblerTest {
     }
 
     @Test
-    public void newRequest_andVerifyManifestWithRetryConfiguration() {
+    public void newRequest_andVerifyManifest() {
         String uploadId = "uploadId";
 
         initializeCreateMultipartUpload(uploadId);

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssemblerTest.java
@@ -24,7 +24,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.oracle.bmc.retrier.DefaultRetryCondition;
+import com.oracle.bmc.retrier.RetryConfiguration;
 import com.oracle.bmc.util.internal.Consumer;
+import com.oracle.bmc.waiter.ExponentialBackoffDelayStrategy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,8 +68,14 @@ public class MultipartObjectAssemblerTest {
     private static final Map<String, String> OPC_META = new HashMap<>();
     private static final boolean ALLOW_OVERWRITE = false;
 
+    private static final RetryConfiguration RETRY_CONFIGURATION = RetryConfiguration.builder()
+            .delayStrategy(new ExponentialBackoffDelayStrategy(120000))
+            .retryCondition(new DefaultRetryCondition())
+            .build();
+
     private ExecutorService executorService;
     private MultipartObjectAssembler assembler;
+    private MultipartObjectAssembler assemblerWithRetryConfiguration;
 
     @Mock private Consumer<Invocation.Builder> mockInvocationCallback;
 
@@ -87,6 +96,17 @@ public class MultipartObjectAssemblerTest {
                         .objectName(OBJECT)
                         .service(service)
                         .build();
+        assemblerWithRetryConfiguration =
+                MultipartObjectAssembler.builder()
+                        .allowOverwrite(ALLOW_OVERWRITE)
+                        .bucketName(BUCKET)
+                        .executorService(executorService)
+                        .invocationCallback(mockInvocationCallback)
+                        .namespaceName(NAMESPACE)
+                        .objectName(OBJECT)
+                        .service(service)
+                        .retryConfiguration(RETRY_CONFIGURATION)
+                        .build();
     }
 
     @After
@@ -96,6 +116,34 @@ public class MultipartObjectAssemblerTest {
 
     @Test
     public void newRequest_andVerifyManifest() {
+        String uploadId = "uploadId";
+
+        initializeCreateMultipartUpload(uploadId);
+
+        MultipartManifest manifest =
+                assemblerWithRetryConfiguration.newRequest(CONTENT_TYPE, CONTENT_LANGUAGE, CONTENT_ENCODING, OPC_META);
+        assertNotNull(manifest);
+        assertEquals(uploadId, manifest.getUploadId());
+
+        ArgumentCaptor<CreateMultipartUploadRequest> captor =
+                ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        verify(service).createMultipartUpload(captor.capture());
+
+        CreateMultipartUploadRequest request = captor.getValue();
+        assertEquals(NAMESPACE, request.getNamespaceName());
+        assertEquals(BUCKET, request.getBucketName());
+        assertEquals(OBJECT, request.getCreateMultipartUploadDetails().getObject());
+        assertEquals(CONTENT_TYPE, request.getCreateMultipartUploadDetails().getContentType());
+        assertEquals(
+                CONTENT_LANGUAGE, request.getCreateMultipartUploadDetails().getContentLanguage());
+        assertEquals(
+                CONTENT_ENCODING, request.getCreateMultipartUploadDetails().getContentEncoding());
+        assertEquals(OPC_META, request.getCreateMultipartUploadDetails().getMetadata());
+        assertEquals(mockInvocationCallback, request.getInvocationCallback());
+    }
+
+    @Test
+    public void newRequest_andVerifyManifestWithRetryConfiguration() {
         String uploadId = "uploadId";
 
         initializeCreateMultipartUpload(uploadId);
@@ -298,6 +346,72 @@ public class MultipartObjectAssemblerTest {
         verify(service, times(2)).uploadPart(uploadCaptor.capture());
         verifyUploadPart(uploadCaptor.getAllValues().get(0), uploadId, 1, md5_1);
         verifyUploadPart(uploadCaptor.getAllValues().get(1), uploadId, 2, md5_2);
+
+        file.delete();
+    }
+
+    @Test
+    public void addParts_allSuccessful_withRetryConfiguration_commit() throws Exception {
+        String uploadId = "uploadId";
+        initializeCreateMultipartUpload(uploadId);
+        MultipartManifest manifest =
+                assemblerWithRetryConfiguration.newRequest(CONTENT_TYPE, CONTENT_LANGUAGE, CONTENT_ENCODING, OPC_META);
+
+        byte[] bytes = "abcd".getBytes();
+
+        File file = File.createTempFile("unitTest", ".txt");
+        file.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(bytes);
+        }
+
+        String etag1 = "etag1";
+        String etag2 = "etag2";
+        UploadPartResponse uploadPartResponse1 = UploadPartResponse.builder().eTag(etag1).build();
+        UploadPartResponse uploadPartResponse2 = UploadPartResponse.builder().eTag(etag2).build();
+        when(service.uploadPart(any(UploadPartRequest.class)))
+                .thenReturn(uploadPartResponse1)
+                .thenReturn(uploadPartResponse2);
+
+        CommitMultipartUploadResponse finalCommitResponse =
+                CommitMultipartUploadResponse.builder().build();
+        when(service.commitMultipartUpload(any(CommitMultipartUploadRequest.class)))
+                .thenReturn(finalCommitResponse);
+
+        String md5_1 = "md5_1";
+        String md5_2 = "md5_2";
+
+        assemblerWithRetryConfiguration.addPart(file, md5_1);
+        assemblerWithRetryConfiguration.addPart(StreamUtils.createByteArrayInputStream(bytes), bytes.length, md5_2);
+
+        CommitMultipartUploadResponse commitResponse = assemblerWithRetryConfiguration.commit();
+        assertSame(finalCommitResponse, commitResponse);
+
+        ArgumentCaptor<CommitMultipartUploadRequest> commitCaptor =
+                ArgumentCaptor.forClass(CommitMultipartUploadRequest.class);
+        verify(service).commitMultipartUpload(commitCaptor.capture());
+        CommitMultipartUploadRequest actualCommitRequest = commitCaptor.getValue();
+        assertEquals(NAMESPACE, actualCommitRequest.getNamespaceName());
+        assertEquals(BUCKET, actualCommitRequest.getBucketName());
+        assertEquals(OBJECT, actualCommitRequest.getObjectName());
+        assertEquals(uploadId, actualCommitRequest.getUploadId());
+        assertEquals(mockInvocationCallback, actualCommitRequest.getInvocationCallback());
+
+        assertTrue(manifest.isUploadComplete());
+        assertTrue(manifest.isUploadSuccessful());
+        assertEquals(2, manifest.listCompletedParts().size());
+        assertEquals(1, manifest.listCompletedParts().get(0).getPartNum().intValue());
+        assertEquals(etag1, manifest.listCompletedParts().get(0).getEtag());
+        assertEquals(2, manifest.listCompletedParts().get(1).getPartNum().intValue());
+        assertEquals(etag2, manifest.listCompletedParts().get(1).getEtag());
+
+        ArgumentCaptor<UploadPartRequest> uploadCaptor =
+                ArgumentCaptor.forClass(UploadPartRequest.class);
+        verify(service, times(2)).uploadPart(uploadCaptor.capture());
+        verifyUploadPart(uploadCaptor.getAllValues().get(0), uploadId, 1, md5_1);
+        verifyUploadPart(uploadCaptor.getAllValues().get(1), uploadId, 2, md5_2);
+
+        uploadCaptor.getAllValues().forEach(r -> assertSame(RETRY_CONFIGURATION, r.getRetryConfiguration()));
 
         file.delete();
     }

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/UploadManagerTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/UploadManagerTest.java
@@ -242,6 +242,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -279,6 +280,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -318,6 +320,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -354,6 +357,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -387,6 +391,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -444,6 +449,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, getMultipartUploadConfiguration()) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -640,6 +646,7 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
+                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/UploadManagerTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/UploadManagerTest.java
@@ -242,7 +242,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -280,7 +279,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -320,7 +318,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -357,7 +354,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -391,7 +387,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -449,7 +444,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, getMultipartUploadConfiguration()) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;
@@ -646,7 +640,6 @@ public class UploadManagerTest {
                 new UploadManager(objectStorage, uploadConfiguration) {
                     @Override
                     protected MultipartObjectAssembler createAssembler(
-                            PutObjectRequest request,
                             UploadRequest uploadRequest,
                             ExecutorService executorService) {
                         return assembler;


### PR DESCRIPTION
This is code allows for the ability to explicitly specify the RetryConfiguration for UploadManager.
This allows the RetryConfiguration that can already be set on an UploadRequest to be passed to the underlying MultipartObjectAssembler instance.