### PR TITLE
Releasing version 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.25.0 - 2020-10-13
+### Added
+- Support for API definitions in the API Gateway service
+- Support for pattern-based logical entities, namespace-bound custom properties, and faceted search in the Data Catalog service
+- Support for autonomous Data Guard on autonomous infrastructure in the Database service
+- Support for creating a Data Guard association on an existing standby database home in the Database service
+- Support for upgrading cloud VM cluster grid infrastructure in the Database service
+
+
+### Breaking Changes
+- Attribute `isQuickStart` & method `isQuickStart(Boolean isQuickStart)` in models `CreateLogSavedSearchDetails`, `LogSavedSearchSummary`,`UpdateLogSavedSearchDetails` and `LogSavedSearch` is removed from the Logging Management service
+- Lifecycle State `DELETED` is removed from the Logging Management service
+
 ## 1.24.0 - 2020-10-06
 ### Added
 - Support for calling Oracle Cloud Infrastructure services in the me-dubai-1 region

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGateway.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGateway.java
@@ -49,6 +49,14 @@ public interface ApiGateway extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Changes the API compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeApiCompartmentResponse changeApiCompartment(ChangeApiCompartmentRequest request);
+
+    /**
      * Changes the certificate compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -56,6 +64,15 @@ public interface ApiGateway extends AutoCloseable {
      */
     ChangeCertificateCompartmentResponse changeCertificateCompartment(
             ChangeCertificateCompartmentRequest request);
+
+    /**
+     * Creates a new API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateApiResponse createApi(CreateApiRequest request);
 
     /**
      * Creates a new Certificate.
@@ -67,12 +84,53 @@ public interface ApiGateway extends AutoCloseable {
     CreateCertificateResponse createCertificate(CreateCertificateRequest request);
 
     /**
+     * Deletes the API with the given identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteApiResponse deleteApi(DeleteApiRequest request);
+
+    /**
      * Deletes the certificate with the given identifier.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
      */
     DeleteCertificateResponse deleteCertificate(DeleteCertificateRequest request);
+
+    /**
+     * Gets an API by identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetApiResponse getApi(GetApiRequest request);
+
+    /**
+     * Get the raw API content.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetApiContentResponse getApiContent(GetApiContentRequest request);
+
+    /**
+     * Gets an API Deployment specification by identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetApiDeploymentSpecificationResponse getApiDeploymentSpecification(
+            GetApiDeploymentSpecificationRequest request);
+
+    /**
+     * Gets the API validation results.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetApiValidationsResponse getApiValidations(GetApiValidationsRequest request);
 
     /**
      * Gets a certificate by identifier.
@@ -83,6 +141,15 @@ public interface ApiGateway extends AutoCloseable {
     GetCertificateResponse getCertificate(GetCertificateRequest request);
 
     /**
+     * Returns a list of APIs.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListApisResponse listApis(ListApisRequest request);
+
+    /**
      * Returns a list of certificates.
      *
      * @param request The request object containing the details to send
@@ -90,6 +157,14 @@ public interface ApiGateway extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ListCertificatesResponse listCertificates(ListCertificatesRequest request);
+
+    /**
+     * Updates the API with the given identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateApiResponse updateApi(UpdateApiRequest request);
 
     /**
      * Updates a certificate with the given identifier

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayAsync.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayAsync.java
@@ -49,6 +49,22 @@ public interface ApiGatewayAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Changes the API compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeApiCompartmentResponse> changeApiCompartment(
+            ChangeApiCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeApiCompartmentRequest, ChangeApiCompartmentResponse>
+                    handler);
+
+    /**
      * Changes the certificate compartment.
      *
      * @param request The request object containing the details to send
@@ -64,6 +80,21 @@ public interface ApiGatewayAsync extends AutoCloseable {
                             ChangeCertificateCompartmentRequest,
                             ChangeCertificateCompartmentResponse>
                     handler);
+
+    /**
+     * Creates a new API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateApiResponse> createApi(
+            CreateApiRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateApiRequest, CreateApiResponse> handler);
 
     /**
      * Creates a new Certificate.
@@ -83,6 +114,20 @@ public interface ApiGatewayAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes the API with the given identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteApiResponse> deleteApi(
+            DeleteApiRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteApiRequest, DeleteApiResponse> handler);
+
+    /**
      * Deletes the certificate with the given identifier.
      *
      * @param request The request object containing the details to send
@@ -96,6 +141,69 @@ public interface ApiGatewayAsync extends AutoCloseable {
             DeleteCertificateRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             DeleteCertificateRequest, DeleteCertificateResponse>
+                    handler);
+
+    /**
+     * Gets an API by identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetApiResponse> getApi(
+            GetApiRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetApiRequest, GetApiResponse> handler);
+
+    /**
+     * Get the raw API content.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetApiContentResponse> getApiContent(
+            GetApiContentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetApiContentRequest, GetApiContentResponse>
+                    handler);
+
+    /**
+     * Gets an API Deployment specification by identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetApiDeploymentSpecificationResponse>
+            getApiDeploymentSpecification(
+                    GetApiDeploymentSpecificationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetApiDeploymentSpecificationRequest,
+                                    GetApiDeploymentSpecificationResponse>
+                            handler);
+
+    /**
+     * Gets the API validation results.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetApiValidationsResponse> getApiValidations(
+            GetApiValidationsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetApiValidationsRequest, GetApiValidationsResponse>
                     handler);
 
     /**
@@ -114,6 +222,21 @@ public interface ApiGatewayAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Returns a list of APIs.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListApisResponse> listApis(
+            ListApisRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListApisRequest, ListApisResponse> handler);
+
+    /**
      * Returns a list of certificates.
      *
      *
@@ -128,6 +251,20 @@ public interface ApiGatewayAsync extends AutoCloseable {
             ListCertificatesRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListCertificatesRequest, ListCertificatesResponse>
                     handler);
+
+    /**
+     * Updates the API with the given identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateApiResponse> updateApi(
+            UpdateApiRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateApiRequest, UpdateApiResponse> handler);
 
     /**
      * Updates a certificate with the given identifier

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayAsyncClient.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayAsyncClient.java
@@ -324,6 +324,97 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeApiCompartmentResponse> changeApiCompartment(
+            final ChangeApiCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeApiCompartmentRequest, ChangeApiCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeApiCompartment");
+        final ChangeApiCompartmentRequest interceptedRequest =
+                ChangeApiCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeApiCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeApiCompartmentResponse>
+                transformer = ChangeApiCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeApiCompartmentRequest, ChangeApiCompartmentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ChangeApiCompartmentRequest, ChangeApiCompartmentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getChangeApiCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getChangeApiCompartmentDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ChangeApiCompartmentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getChangeApiCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeCertificateCompartmentResponse>
             changeCertificateCompartment(
                     final ChangeCertificateCompartmentRequest request,
@@ -406,6 +497,93 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getChangeCertificateCompartmentDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateApiResponse> createApi(
+            final CreateApiRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateApiRequest, CreateApiResponse>
+                    handler) {
+        LOG.trace("Called async createApi");
+        final CreateApiRequest interceptedRequest = CreateApiConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateApiConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateApiResponse>
+                transformer = CreateApiConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreateApiRequest, CreateApiResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateApiRequest, CreateApiResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateApiDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateApiDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateApiResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateApiDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -507,6 +685,78 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteApiResponse> deleteApi(
+            final DeleteApiRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteApiRequest, DeleteApiResponse>
+                    handler) {
+        LOG.trace("Called async deleteApi");
+        final DeleteApiRequest interceptedRequest = DeleteApiConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteApiConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteApiResponse>
+                transformer = DeleteApiConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteApiRequest, DeleteApiResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteApiRequest, DeleteApiResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteApiResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteCertificateResponse> deleteCertificate(
             final DeleteCertificateRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -572,6 +822,302 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
                             return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetApiResponse> getApi(
+            final GetApiRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetApiRequest, GetApiResponse> handler) {
+        LOG.trace("Called async getApi");
+        final GetApiRequest interceptedRequest = GetApiConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetApiResponse>
+                transformer = GetApiConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetApiRequest, GetApiResponse> handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetApiRequest, GetApiResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetApiResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetApiContentResponse> getApiContent(
+            final GetApiContentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetApiContentRequest, GetApiContentResponse>
+                    handler) {
+        LOG.trace("Called async getApiContent");
+        final GetApiContentRequest interceptedRequest =
+                GetApiContentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiContentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetApiContentResponse>
+                transformer = GetApiContentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetApiContentRequest, GetApiContentResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetApiContentRequest, GetApiContentResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetApiContentResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetApiDeploymentSpecificationResponse>
+            getApiDeploymentSpecification(
+                    final GetApiDeploymentSpecificationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetApiDeploymentSpecificationRequest,
+                                    GetApiDeploymentSpecificationResponse>
+                            handler) {
+        LOG.trace("Called async getApiDeploymentSpecification");
+        final GetApiDeploymentSpecificationRequest interceptedRequest =
+                GetApiDeploymentSpecificationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiDeploymentSpecificationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetApiDeploymentSpecificationResponse>
+                transformer = GetApiDeploymentSpecificationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetApiDeploymentSpecificationRequest, GetApiDeploymentSpecificationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetApiDeploymentSpecificationRequest,
+                            GetApiDeploymentSpecificationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetApiDeploymentSpecificationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetApiValidationsResponse> getApiValidations(
+            final GetApiValidationsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetApiValidationsRequest, GetApiValidationsResponse>
+                    handler) {
+        LOG.trace("Called async getApiValidations");
+        final GetApiValidationsRequest interceptedRequest =
+                GetApiValidationsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiValidationsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetApiValidationsResponse>
+                transformer = GetApiValidationsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetApiValidationsRequest, GetApiValidationsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetApiValidationsRequest, GetApiValidationsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetApiValidationsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
                         }
                     });
         } else {
@@ -655,6 +1201,78 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListApisResponse> listApis(
+            final ListApisRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListApisRequest, ListApisResponse>
+                    handler) {
+        LOG.trace("Called async listApis");
+        final ListApisRequest interceptedRequest = ListApisConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListApisConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListApisResponse>
+                transformer = ListApisConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListApisRequest, ListApisResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListApisRequest, ListApisResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListApisResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListCertificatesResponse> listCertificates(
             final ListCertificatesRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -720,6 +1338,93 @@ public class ApiGatewayAsyncClient implements ApiGatewayAsync {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
                             return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateApiResponse> updateApi(
+            final UpdateApiRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateApiRequest, UpdateApiResponse>
+                    handler) {
+        LOG.trace("Called async updateApi");
+        final UpdateApiRequest interceptedRequest = UpdateApiConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateApiConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateApiResponse>
+                transformer = UpdateApiConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateApiRequest, UpdateApiResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateApiRequest, UpdateApiResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateApiDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateApiDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateApiResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateApiDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
                         }
                     });
         } else {

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayClient.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayClient.java
@@ -440,6 +440,38 @@ public class ApiGatewayClient implements ApiGateway {
     }
 
     @Override
+    public ChangeApiCompartmentResponse changeApiCompartment(ChangeApiCompartmentRequest request) {
+        LOG.trace("Called changeApiCompartment");
+        final ChangeApiCompartmentRequest interceptedRequest =
+                ChangeApiCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeApiCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ChangeApiCompartmentResponse>
+                transformer = ChangeApiCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeApiCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeCertificateCompartmentResponse changeCertificateCompartment(
             ChangeCertificateCompartmentRequest request) {
         LOG.trace("Called changeCertificateCompartment");
@@ -468,6 +500,37 @@ public class ApiGatewayClient implements ApiGateway {
                                                 ib,
                                                 retriedRequest
                                                         .getChangeCertificateCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateApiResponse createApi(CreateApiRequest request) {
+        LOG.trace("Called createApi");
+        final CreateApiRequest interceptedRequest = CreateApiConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateApiConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateApiResponse> transformer =
+                CreateApiConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateApiDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -507,6 +570,34 @@ public class ApiGatewayClient implements ApiGateway {
     }
 
     @Override
+    public DeleteApiResponse deleteApi(DeleteApiRequest request) {
+        LOG.trace("Called deleteApi");
+        final DeleteApiRequest interceptedRequest = DeleteApiConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteApiConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteApiResponse> transformer =
+                DeleteApiConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteCertificateResponse deleteCertificate(DeleteCertificateRequest request) {
         LOG.trace("Called deleteCertificate");
         final DeleteCertificateRequest interceptedRequest =
@@ -536,6 +627,119 @@ public class ApiGatewayClient implements ApiGateway {
     }
 
     @Override
+    public GetApiResponse getApi(GetApiRequest request) {
+        LOG.trace("Called getApi");
+        final GetApiRequest interceptedRequest = GetApiConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetApiResponse> transformer =
+                GetApiConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetApiContentResponse getApiContent(GetApiContentRequest request) {
+        LOG.trace("Called getApiContent");
+        final GetApiContentRequest interceptedRequest =
+                GetApiContentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiContentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetApiContentResponse>
+                transformer = GetApiContentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetApiDeploymentSpecificationResponse getApiDeploymentSpecification(
+            GetApiDeploymentSpecificationRequest request) {
+        LOG.trace("Called getApiDeploymentSpecification");
+        final GetApiDeploymentSpecificationRequest interceptedRequest =
+                GetApiDeploymentSpecificationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiDeploymentSpecificationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetApiDeploymentSpecificationResponse>
+                transformer = GetApiDeploymentSpecificationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetApiValidationsResponse getApiValidations(GetApiValidationsRequest request) {
+        LOG.trace("Called getApiValidations");
+        final GetApiValidationsRequest interceptedRequest =
+                GetApiValidationsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetApiValidationsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetApiValidationsResponse>
+                transformer = GetApiValidationsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetCertificateResponse getCertificate(GetCertificateRequest request) {
         LOG.trace("Called getCertificate");
         final GetCertificateRequest interceptedRequest =
@@ -544,6 +748,33 @@ public class ApiGatewayClient implements ApiGateway {
                 GetCertificateConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetCertificateResponse>
                 transformer = GetCertificateConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListApisResponse listApis(ListApisRequest request) {
+        LOG.trace("Called listApis");
+        final ListApisRequest interceptedRequest = ListApisConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListApisConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListApisResponse> transformer =
+                ListApisConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -586,6 +817,37 @@ public class ApiGatewayClient implements ApiGateway {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateApiResponse updateApi(UpdateApiRequest request) {
+        LOG.trace("Called updateApi");
+        final UpdateApiRequest interceptedRequest = UpdateApiConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateApiConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateApiResponse> transformer =
+                UpdateApiConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateApiDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayPaginators.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayPaginators.java
@@ -31,6 +31,115 @@ public class ApiGatewayPaginators {
     private final ApiGateway client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listApis operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListApisResponse> listApisResponseIterator(final ListApisRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListApisRequest.Builder, ListApisRequest, ListApisResponse>(
+                new com.google.common.base.Supplier<ListApisRequest.Builder>() {
+                    @Override
+                    public ListApisRequest.Builder get() {
+                        return ListApisRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListApisResponse, String>() {
+                    @Override
+                    public String apply(ListApisResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListApisRequest.Builder>,
+                        ListApisRequest>() {
+                    @Override
+                    public ListApisRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListApisRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListApisRequest, ListApisResponse>() {
+                    @Override
+                    public ListApisResponse apply(ListApisRequest request) {
+                        return client.listApis(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.apigateway.model.ApiSummary} objects
+     * contained in responses from the listApis operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.apigateway.model.ApiSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.apigateway.model.ApiSummary> listApisRecordIterator(
+            final ListApisRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListApisRequest.Builder, ListApisRequest, ListApisResponse,
+                com.oracle.bmc.apigateway.model.ApiSummary>(
+                new com.google.common.base.Supplier<ListApisRequest.Builder>() {
+                    @Override
+                    public ListApisRequest.Builder get() {
+                        return ListApisRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListApisResponse, String>() {
+                    @Override
+                    public String apply(ListApisResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListApisRequest.Builder>,
+                        ListApisRequest>() {
+                    @Override
+                    public ListApisRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListApisRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListApisRequest, ListApisResponse>() {
+                    @Override
+                    public ListApisResponse apply(ListApisRequest request) {
+                        return client.listApis(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListApisResponse,
+                        java.util.List<com.oracle.bmc.apigateway.model.ApiSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.apigateway.model.ApiSummary> apply(
+                            ListApisResponse response) {
+                        return response.getApiCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listCertificates operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayWaiters.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/ApiGatewayWaiters.java
@@ -26,6 +26,101 @@ public class ApiGatewayWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetApiRequest, GetApiResponse> forApi(
+            GetApiRequest request,
+            com.oracle.bmc.apigateway.model.Api.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forApi(com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetApiRequest, GetApiResponse> forApi(
+            GetApiRequest request,
+            com.oracle.bmc.apigateway.model.Api.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forApi(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetApiRequest, GetApiResponse> forApi(
+            GetApiRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.apigateway.model.Api.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forApi(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Api.
+    private com.oracle.bmc.waiter.Waiter<GetApiRequest, GetApiResponse> forApi(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetApiRequest request,
+            final com.oracle.bmc.apigateway.model.Api.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.apigateway.model.Api.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<GetApiRequest, GetApiResponse>() {
+                            @Override
+                            public GetApiResponse apply(GetApiRequest request) {
+                                return client.getApi(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetApiResponse>() {
+                            @Override
+                            public boolean apply(GetApiResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getApi().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.apigateway.model.Api.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetCertificateRequest, GetCertificateResponse>
             forCertificate(
                     GetCertificateRequest request,

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/ChangeApiCompartmentConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/ChangeApiCompartmentConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class ChangeApiCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.ChangeApiCompartmentRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.ChangeApiCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.ChangeApiCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+        Validate.notNull(
+                request.getChangeApiCompartmentDetails(),
+                "changeApiCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses
+                                        .ChangeApiCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .ChangeApiCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.ChangeApiCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/CreateApiConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/CreateApiConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class CreateApiConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.CreateApiRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.CreateApiRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.CreateApiRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateApiDetails(), "createApiDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190501").path("apis");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.CreateApiResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.CreateApiResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.CreateApiResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.CreateApiResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.CreateApiResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Api>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(Api.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Api> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.CreateApiResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .CreateApiResponse.builder();
+
+                                builder.api(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.CreateApiResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/DeleteApiConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/DeleteApiConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class DeleteApiConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.DeleteApiRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.DeleteApiRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.DeleteApiRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.DeleteApiResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.DeleteApiResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.DeleteApiResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.DeleteApiResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.DeleteApiResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.DeleteApiResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .DeleteApiResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.DeleteApiResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiContentConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiContentConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class GetApiContentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.GetApiContentRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.GetApiContentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.GetApiContentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()))
+                        .path("content");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.GetApiContentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.GetApiContentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.GetApiContentResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.GetApiContentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.GetApiContentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.GetApiContentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .GetApiContentResponse.builder();
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        xContentSha256Header =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "x-content-sha256");
+                                if (xContentSha256Header.isPresent()) {
+                                    builder.xContentSha256(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "x-content-sha256",
+                                                    xContentSha256Header.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.GetApiContentResponse
+                                        responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class GetApiConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.GetApiRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.GetApiRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.GetApiRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.apigateway.responses.GetApiResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.GetApiResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.GetApiResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.GetApiResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.GetApiResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Api>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(Api.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Api> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.GetApiResponse.Builder builder =
+                                        com.oracle.bmc.apigateway.responses.GetApiResponse
+                                                .builder();
+
+                                builder.api(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.GetApiResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiDeploymentSpecificationConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiDeploymentSpecificationConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class GetApiDeploymentSpecificationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.GetApiDeploymentSpecificationRequest
+            interceptRequest(
+                    com.oracle.bmc.apigateway.requests.GetApiDeploymentSpecificationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.GetApiDeploymentSpecificationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()))
+                        .path("deploymentSpecification");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.GetApiDeploymentSpecificationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.GetApiDeploymentSpecificationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses
+                                        .GetApiDeploymentSpecificationResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses
+                                            .GetApiDeploymentSpecificationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.GetApiDeploymentSpecificationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ApiSpecification>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ApiSpecification.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ApiSpecification>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses
+                                                .GetApiDeploymentSpecificationResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .GetApiDeploymentSpecificationResponse
+                                                        .builder();
+
+                                builder.apiSpecification(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses
+                                                .GetApiDeploymentSpecificationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiValidationsConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/GetApiValidationsConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class GetApiValidationsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.GetApiValidationsRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.GetApiValidationsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.GetApiValidationsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()))
+                        .path("validations");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.GetApiValidationsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.GetApiValidationsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.GetApiValidationsResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.GetApiValidationsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.GetApiValidationsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ApiValidations>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ApiValidations.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ApiValidations> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.GetApiValidationsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .GetApiValidationsResponse.builder();
+
+                                builder.apiValidations(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.GetApiValidationsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/ListApisConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/ListApisConverter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class ListApisConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.ListApisRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.ListApisRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.ListApisRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190501").path("apis");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.apigateway.responses.ListApisResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.ListApisResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.ListApisResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.ListApisResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.ListApisResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ApiCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ApiCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ApiCollection> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.ListApisResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses.ListApisResponse
+                                                        .builder();
+
+                                builder.apiCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.ListApisResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/UpdateApiConverter.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/internal/http/UpdateApiConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.apigateway.model.*;
+import com.oracle.bmc.apigateway.requests.*;
+import com.oracle.bmc.apigateway.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.extern.slf4j.Slf4j
+public class UpdateApiConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.apigateway.requests.UpdateApiRequest interceptRequest(
+            com.oracle.bmc.apigateway.requests.UpdateApiRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.apigateway.requests.UpdateApiRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getApiId(), "apiId must not be blank");
+        Validate.notNull(request.getUpdateApiDetails(), "updateApiDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190501")
+                        .path("apis")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getApiId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.apigateway.responses.UpdateApiResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.apigateway.responses.UpdateApiResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.apigateway.responses.UpdateApiResponse>() {
+                            @Override
+                            public com.oracle.bmc.apigateway.responses.UpdateApiResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.apigateway.responses.UpdateApiResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.apigateway.responses.UpdateApiResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.apigateway.responses
+                                                        .UpdateApiResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.apigateway.responses.UpdateApiResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/Api.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/Api.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * An API is simple container for an API Specification. For more information, see [API Gateway Concepts](https://docs.cloud.oracle.com/iaas/Content/APIGateway/Concepts/apigatewayconcepts.htm).
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Api.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Api {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("specificationType")
+        private String specificationType;
+
+        public Builder specificationType(String specificationType) {
+            this.specificationType = specificationType;
+            this.__explicitlySet__.add("specificationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("validationResults")
+        private java.util.List<ApiValidationResult> validationResults;
+
+        public Builder validationResults(java.util.List<ApiValidationResult> validationResults) {
+            this.validationResults = validationResults;
+            this.__explicitlySet__.add("validationResults");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Api build() {
+            Api __instance__ =
+                    new Api(
+                            id,
+                            displayName,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            specificationType,
+                            validationResults,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Api o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .specificationType(o.getSpecificationType())
+                            .validationResults(o.getValidationResults())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     * <p>
+     * Example: `My new resource`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+     * resource is created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The time this resource was created. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time this resource was last updated. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the API.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the API.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A message describing the current lifecycleState in more detail. For ACTIVE
+     * state it describes if the document has been validated and the possible values are:
+     * - 'New' for just updated API Specifications
+     * - 'Validating' for a document which is being validated.
+     * - 'Valid' the document has been validated without any errors or warnings
+     * - 'Warning' the document has been validated and contains warnings
+     * - 'Error' the document has been validated and contains errors
+     * - 'Failed' the document validation failed
+     * - 'Canceled' the document validation was canceled
+     * <p>
+     * For other states it may provide more details like actionable information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Type of API Specification file.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("specificationType")
+    String specificationType;
+
+    /**
+     * Status of each feature available from the API.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("validationResults")
+    java.util.List<ApiValidationResult> validationResults;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair
+     * with no predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiCollection.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiCollection.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * Collection of API summaries.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ApiCollection.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<ApiSummary> items;
+
+        public Builder items(java.util.List<ApiSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiCollection build() {
+            ApiCollection __instance__ = new ApiCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * API summaries.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<ApiSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiSummary.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiSummary.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * A summary of the API.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ApiSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("specificationType")
+        private String specificationType;
+
+        public Builder specificationType(String specificationType) {
+            this.specificationType = specificationType;
+            this.__explicitlySet__.add("specificationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("validationResults")
+        private java.util.List<ApiValidationResult> validationResults;
+
+        public Builder validationResults(java.util.List<ApiValidationResult> validationResults) {
+            this.validationResults = validationResults;
+            this.__explicitlySet__.add("validationResults");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiSummary build() {
+            ApiSummary __instance__ =
+                    new ApiSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            specificationType,
+                            validationResults,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .specificationType(o.getSpecificationType())
+                            .validationResults(o.getValidationResults())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the resource.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     * <p>
+     * Example: `My new resource`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+     * resource is created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The time this resource was created. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time this resource was last updated. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the API.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the API.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A message describing the current lifecycleState in more detail. For ACTIVE
+     * state it describes if the document has been validated and the possible values are:
+     * - 'New' for just updated API Specifications
+     * - 'Validating' for a document which is being validated.
+     * - 'Valid' the document has been validated without any errors or warnings
+     * - 'Warning' the document has been validated and contains warnings
+     * - 'Error' the document has been validated and contains errors
+     * - 'Failed' the document validation failed
+     * - 'Canceled' the document validation was canceled
+     * <p>
+     * For other states it may provide more details like actionable information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Type of API Specification file.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("specificationType")
+    String specificationType;
+
+    /**
+     * Status of each feature available from the API.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("validationResults")
+    java.util.List<ApiValidationResult> validationResults;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair
+     * with no predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationDetail.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationDetail.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * Detail of a single error or warning.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApiValidationDetail.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiValidationDetail {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("msg")
+        private String msg;
+
+        public Builder msg(String msg) {
+            this.msg = msg;
+            this.__explicitlySet__.add("msg");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("severity")
+        private Severity severity;
+
+        public Builder severity(Severity severity) {
+            this.severity = severity;
+            this.__explicitlySet__.add("severity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("src")
+        private java.util.List<java.util.List<java.math.BigDecimal>> src;
+
+        public Builder src(java.util.List<java.util.List<java.math.BigDecimal>> src) {
+            this.src = src;
+            this.__explicitlySet__.add("src");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiValidationDetail build() {
+            ApiValidationDetail __instance__ = new ApiValidationDetail(msg, severity, src);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiValidationDetail o) {
+            Builder copiedBuilder = msg(o.getMsg()).severity(o.getSeverity()).src(o.getSrc());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Description of the warning/error.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("msg")
+    String msg;
+    /**
+     * Severity of the issue.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Severity {
+        Info("INFO"),
+        Warning("WARNING"),
+        Error("ERROR"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Severity> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Severity v : Severity.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Severity(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Severity create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Severity', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Severity of the issue.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("severity")
+    Severity severity;
+
+    /**
+     * Position of the issue in the specification file (line, column).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("src")
+    java.util.List<java.util.List<java.math.BigDecimal>> src;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationDetails.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationDetails.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * Detail of an error or warning.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApiValidationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiValidationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("details")
+        private java.util.List<ApiValidationDetail> details;
+
+        public Builder details(java.util.List<ApiValidationDetail> details) {
+            this.details = details;
+            this.__explicitlySet__.add("details");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("result")
+        private Result result;
+
+        public Builder result(Result result) {
+            this.result = result;
+            this.__explicitlySet__.add("result");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiValidationDetails build() {
+            ApiValidationDetails __instance__ = new ApiValidationDetails(details, name, result);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiValidationDetails o) {
+            Builder copiedBuilder = details(o.getDetails()).name(o.getName()).result(o.getResult());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Details of validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("details")
+    java.util.List<ApiValidationDetail> details;
+
+    /**
+     * Name of the validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+    /**
+     * Result of the validation.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Result {
+        Error("ERROR"),
+        Warning("WARNING"),
+        Ok("OK"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Result> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Result v : Result.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Result(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Result create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Result', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Result of the validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("result")
+    Result result;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationResult.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidationResult.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * The result of single validation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApiValidationResult.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiValidationResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("result")
+        private Result result;
+
+        public Builder result(Result result) {
+            this.result = result;
+            this.__explicitlySet__.add("result");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiValidationResult build() {
+            ApiValidationResult __instance__ = new ApiValidationResult(name, result);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiValidationResult o) {
+            Builder copiedBuilder = name(o.getName()).result(o.getResult());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of the validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+    /**
+     * Result of the validation.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Result {
+        Error("ERROR"),
+        Warning("WARNING"),
+        Ok("OK"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Result> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Result v : Result.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Result(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Result create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Result', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Result of the validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("result")
+    Result result;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidations.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ApiValidations.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * The result of validations conducted on the API.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ApiValidations.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApiValidations {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("validations")
+        private java.util.List<ApiValidationDetails> validations;
+
+        public Builder validations(java.util.List<ApiValidationDetails> validations) {
+            this.validations = validations;
+            this.__explicitlySet__.add("validations");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApiValidations build() {
+            ApiValidations __instance__ = new ApiValidations(validations);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApiValidations o) {
+            Builder copiedBuilder = validations(o.getValidations());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * API validation results.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("validations")
+    java.util.List<ApiValidationDetails> validations;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ChangeApiCompartmentDetails.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/ChangeApiCompartmentDetails.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * The new compartment details for the API.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeApiCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeApiCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeApiCompartmentDetails build() {
+            ChangeApiCompartmentDetails __instance__ =
+                    new ChangeApiCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeApiCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+     * resource is created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/CreateApiDetails.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/CreateApiDetails.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * Information about the new API.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CreateApiDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateApiDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("content")
+        private String content;
+
+        public Builder content(String content) {
+            this.content = content;
+            this.__explicitlySet__.add("content");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateApiDetails build() {
+            CreateApiDetails __instance__ =
+                    new CreateApiDetails(
+                            displayName, compartmentId, freeformTags, definedTags, content);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateApiDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .content(o.getContent());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     * <p>
+     * Example: `My new resource`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which the
+     * resource is created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair
+     * with no predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * API Specification content in json or yaml format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("content")
+    String content;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/UpdateApiDetails.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/UpdateApiDetails.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.model;
+
+/**
+ * The information to be updated.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateApiDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateApiDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("content")
+        private String content;
+
+        public Builder content(String content) {
+            this.content = content;
+            this.__explicitlySet__.add("content");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateApiDetails build() {
+            UpdateApiDetails __instance__ =
+                    new UpdateApiDetails(displayName, freeformTags, definedTags, content);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateApiDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .content(o.getContent());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     * <p>
+     * Example: `My new resource`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair
+     * with no predefined name, type, or namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see
+     * [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * API Specification content in json or yaml format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("content")
+    String content;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/WorkRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/model/WorkRequest.java
@@ -169,6 +169,10 @@ public class WorkRequest {
         CreateCertificate("CREATE_CERTIFICATE"),
         UpdateCertificate("UPDATE_CERTIFICATE"),
         DeleteCertificate("DELETE_CERTIFICATE"),
+        CreateApi("CREATE_API"),
+        UpdateApi("UPDATE_API"),
+        DeleteApi("DELETE_API"),
+        ValidateApi("VALIDATE_API"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/ChangeApiCompartmentRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/ChangeApiCompartmentRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeApiCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeApiCompartmentDetails> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * Details of the target compartment.
+     */
+    private ChangeApiCompartmentDetails changeApiCompartmentDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeApiCompartmentDetails getBody$() {
+        return changeApiCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeApiCompartmentRequest, ChangeApiCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeApiCompartmentRequest o) {
+            apiId(o.getApiId());
+            changeApiCompartmentDetails(o.getChangeApiCompartmentDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeApiCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeApiCompartmentRequest
+         */
+        public ChangeApiCompartmentRequest build() {
+            ChangeApiCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeApiCompartmentDetails body) {
+            changeApiCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/CreateApiRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/CreateApiRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateApiRequest extends com.oracle.bmc.requests.BmcRequest<CreateApiDetails> {
+
+    /**
+     * Details for the new API.
+     */
+    private CreateApiDetails createApiDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateApiDetails getBody$() {
+        return createApiDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateApiRequest, CreateApiDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateApiRequest o) {
+            createApiDetails(o.getCreateApiDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateApiRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateApiRequest
+         */
+        public CreateApiRequest build() {
+            CreateApiRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateApiDetails body) {
+            createApiDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/DeleteApiRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/DeleteApiRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteApiRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteApiRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteApiRequest o) {
+            apiId(o.getApiId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteApiRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteApiRequest
+         */
+        public DeleteApiRequest build() {
+            DeleteApiRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiContentRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiContentRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetApiContentRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetApiContentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiContentRequest o) {
+            apiId(o.getApiId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetApiContentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetApiContentRequest
+         */
+        public GetApiContentRequest build() {
+            GetApiContentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiDeploymentSpecificationRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiDeploymentSpecificationRequest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetApiDeploymentSpecificationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetApiDeploymentSpecificationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiDeploymentSpecificationRequest o) {
+            apiId(o.getApiId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetApiDeploymentSpecificationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetApiDeploymentSpecificationRequest
+         */
+        public GetApiDeploymentSpecificationRequest build() {
+            GetApiDeploymentSpecificationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiRequest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetApiRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<GetApiRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiRequest o) {
+            apiId(o.getApiId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetApiRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetApiRequest
+         */
+        public GetApiRequest build() {
+            GetApiRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiValidationsRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/GetApiValidationsRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetApiValidationsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetApiValidationsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiValidationsRequest o) {
+            apiId(o.getApiId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetApiValidationsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetApiValidationsRequest
+         */
+        public GetApiValidationsRequest build() {
+            GetApiValidationsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/ListApisRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/ListApisRequest.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListApisRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ocid of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * <p>
+     * Example: `My new resource`
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only resources that match the given lifecycle state.
+     * <p>
+     * Example: `ACTIVE`
+     *
+     */
+    private ApiSummary.LifecycleState lifecycleState;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'. The default order depends on the sortBy value.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`).
+     * Default order for `timeCreated` is descending. Default order for
+     * `displayName` is ascending. The `displayName` sort order is case
+     * sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`).
+     * Default order for `timeCreated` is descending. Default order for
+     * `displayName` is ascending. The `displayName` sort order is case
+     * sensitive.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<ListApisRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListApisRequest o) {
+            compartmentId(o.getCompartmentId());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListApisRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListApisRequest
+         */
+        public ListApisRequest build() {
+            ListApisRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/UpdateApiRequest.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/requests/UpdateApiRequest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.requests;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateApiRequest extends com.oracle.bmc.requests.BmcRequest<UpdateApiDetails> {
+
+    /**
+     * The ocid of the API.
+     */
+    private String apiId;
+
+    /**
+     * The information to be updated.
+     */
+    private UpdateApiDetails updateApiDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request id for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateApiDetails getBody$() {
+        return updateApiDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateApiRequest, UpdateApiDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateApiRequest o) {
+            apiId(o.getApiId());
+            updateApiDetails(o.getUpdateApiDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateApiRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateApiRequest
+         */
+        public UpdateApiRequest build() {
+            UpdateApiRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateApiDetails body) {
+            updateApiDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/ChangeApiCompartmentResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/ChangeApiCompartmentResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeApiCompartmentResponse {
+
+    /**
+     * The OCID of the work request. Use
+     * {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with
+     * this id to track the status
+     * of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeApiCompartmentResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/CreateApiResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/CreateApiResponse.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateApiResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * The OCID of the work request. Use
+     * {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with
+     * this id to track the status
+     * of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Location of the resource.
+     *
+     */
+    private String location;
+
+    /**
+     * The returned Api instance.
+     */
+    private Api api;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateApiResponse o) {
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            api(o.getApi());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/DeleteApiResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/DeleteApiResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteApiResponse {
+
+    /**
+     * The OCID of the work request. Use
+     * {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with
+     * this id to track the status
+     * of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteApiResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiContentResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiContentResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetApiContentResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Base64 encoded Sha256 of the body.
+     */
+    private String xContentSha256;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiContentResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            xContentSha256(o.getXContentSha256());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiDeploymentSpecificationResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiDeploymentSpecificationResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetApiDeploymentSpecificationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ApiSpecification instance.
+     */
+    private ApiSpecification apiSpecification;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiDeploymentSpecificationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            apiSpecification(o.getApiSpecification());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetApiResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Api instance.
+     */
+    private Api api;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            api(o.getApi());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiValidationsResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/GetApiValidationsResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetApiValidationsResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ApiValidations instance.
+     */
+    private ApiValidations apiValidations;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetApiValidationsResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            apiValidations(o.getApiValidations());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/ListApisResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/ListApisResponse.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListApisResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response,
+     * additional pages of results remain. For important details about how
+     * pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response,
+     * additional pages of results were seen previously. For important details
+     * about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * The returned ApiCollection instance.
+     */
+    private ApiCollection apiCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListApisResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            apiCollection(o.getApiCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/UpdateApiResponse.java
+++ b/bmc-apigateway/src/main/java/com/oracle/bmc/apigateway/responses/UpdateApiResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.apigateway.responses;
+
+import com.oracle.bmc.apigateway.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateApiResponse {
+
+    /**
+     * The OCID of the work request. Use
+     * {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with
+     * this id to track the status
+     * of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * id.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateApiResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,372 +19,372 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -592,6 +592,19 @@ public interface Database extends AutoCloseable {
             FailOverAutonomousDatabaseRequest request);
 
     /**
+     * Fails over the standby Autonomous Container Database identified by the autonomousContainerDatabaseId parameter to the primary Autonomous Container Database after the existing primary Autonomous Container Database fails or becomes unreachable.
+     * <p>
+     * A failover can result in data loss, depending on the protection mode in effect at the time the primary Autonomous Container Database fails.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+            failoverAutonomousContainerDatabaseDataguardAssociation(
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest request);
+
+    /**
      * Performs a failover to transition the standby database identified by the `databaseId` parameter into the
      * specified Data Guard association's primary role after the existing primary database fails or becomes unreachable.
      * <p>
@@ -645,6 +658,17 @@ public interface Database extends AutoCloseable {
             GetAutonomousContainerDatabaseRequest request);
 
     /**
+     * Gets an Autonomous Container Database enabled with Autonomous Data Guard associated with the specified Autonomous Container Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetAutonomousContainerDatabaseDataguardAssociationResponse
+            getAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request);
+
+    /**
      * **Deprecated.** To get the details of an Autonomous Data Warehouse, use the {@link #getAutonomousDatabase(GetAutonomousDatabaseRequest) getAutonomousDatabase} operation.
      *
      * @param request The request object containing the details to send
@@ -681,6 +705,16 @@ public interface Database extends AutoCloseable {
      */
     GetAutonomousDatabaseBackupResponse getAutonomousDatabaseBackup(
             GetAutonomousDatabaseBackupRequest request);
+
+    /**
+     * Gets an Autonomous Data Guard-enabled database associated with the specified Autonomous Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetAutonomousDatabaseDataguardAssociationResponse getAutonomousDatabaseDataguardAssociation(
+            GetAutonomousDatabaseDataguardAssociationRequest request);
 
     /**
      * Gets the Autonomous Database regional wallet details.
@@ -997,6 +1031,17 @@ public interface Database extends AutoCloseable {
     LaunchDbSystemResponse launchDbSystem(LaunchDbSystemRequest request);
 
     /**
+     * Gets a list of the Autonomous Container Databases with Autonomous Data Guard enabled associated with the specified Autonomous Container Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListAutonomousContainerDatabaseDataguardAssociationsResponse
+            listAutonomousContainerDatabaseDataguardAssociations(
+                    ListAutonomousContainerDatabaseDataguardAssociationsRequest request);
+
+    /**
      * Gets a list of the Autonomous Container Databases in the specified compartment.
      *
      * @param request The request object containing the details to send
@@ -1045,6 +1090,16 @@ public interface Database extends AutoCloseable {
      */
     ListAutonomousDatabaseClonesResponse listAutonomousDatabaseClones(
             ListAutonomousDatabaseClonesRequest request);
+
+    /**
+     * Gets a list of the Autonomous Data Guard-enabled databases associated with the specified Autonomous Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListAutonomousDatabaseDataguardAssociationsResponse listAutonomousDatabaseDataguardAssociations(
+            ListAutonomousDatabaseDataguardAssociationsRequest request);
 
     /**
      * Gets a list of Autonomous Databases based on the query parameters specified.
@@ -1375,6 +1430,17 @@ public interface Database extends AutoCloseable {
             RegisterAutonomousDatabaseDataSafeRequest request);
 
     /**
+     * Reinstates a disabled standby Autonomous Container Database, identified by the autonomousContainerDatabaseId parameter, to an active standby Autonomous Container Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+            reinstateAutonomousContainerDatabaseDataguardAssociation(
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request);
+
+    /**
      * Reinstates the database identified by the `databaseId` parameter into the standby role in a Data Guard association.
      *
      * @param request The request object containing the details to send
@@ -1489,6 +1555,19 @@ public interface Database extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     StopAutonomousDatabaseResponse stopAutonomousDatabase(StopAutonomousDatabaseRequest request);
+
+    /**
+     * Switches over the primary Autonomous Container Database of an Autonomous Data Guard peer association into a standby role. The standby Autonomous Container Database associated with autonomousContainerDatabaseDataguardAssociationId assumes the primary Autonomous Container Database role.
+     * <p>
+     * A switchover incurs no data loss.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+            switchoverAutonomousContainerDatabaseDataguardAssociation(
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request);
 
     /**
      * Initiates a switchover of the specified Autonomous Database to the associated standby database. Applicable only to databases with Autonomous Data Guard enabled.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -1004,6 +1004,27 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Fails over the standby Autonomous Container Database identified by the autonomousContainerDatabaseId parameter to the primary Autonomous Container Database after the existing primary Autonomous Container Database fails or becomes unreachable.
+     * <p>
+     * A failover can result in data loss, depending on the protection mode in effect at the time the primary Autonomous Container Database fails.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            failoverAutonomousContainerDatabaseDataguardAssociation(
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler);
+
+    /**
      * Performs a failover to transition the standby database identified by the `databaseId` parameter into the
      * specified Data Guard association's primary role after the existing primary database fails or becomes unreachable.
      * <p>
@@ -1101,6 +1122,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Gets an Autonomous Container Database enabled with Autonomous Data Guard associated with the specified Autonomous Container Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            getAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler);
+
+    /**
      * **Deprecated.** To get the details of an Autonomous Data Warehouse, use the {@link #getAutonomousDatabase(GetAutonomousDatabaseRequest, Consumer, Consumer) getAutonomousDatabase} operation.
      *
      *
@@ -1168,6 +1208,25 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             GetAutonomousDatabaseBackupRequest, GetAutonomousDatabaseBackupResponse>
                     handler);
+
+    /**
+     * Gets an Autonomous Data Guard-enabled database associated with the specified Autonomous Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAutonomousDatabaseDataguardAssociationResponse>
+            getAutonomousDatabaseDataguardAssociation(
+                    GetAutonomousDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetAutonomousDatabaseDataguardAssociationRequest,
+                                    GetAutonomousDatabaseDataguardAssociationResponse>
+                            handler);
 
     /**
      * Gets the Autonomous Database regional wallet details.
@@ -1744,6 +1803,25 @@ public interface DatabaseAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets a list of the Autonomous Container Databases with Autonomous Data Guard enabled associated with the specified Autonomous Container Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+            listAutonomousContainerDatabaseDataguardAssociations(
+                    ListAutonomousContainerDatabaseDataguardAssociationsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                                    ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                            handler);
+
+    /**
      * Gets a list of the Autonomous Container Databases in the specified compartment.
      *
      *
@@ -1835,6 +1913,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             ListAutonomousDatabaseClonesRequest,
                             ListAutonomousDatabaseClonesResponse>
                     handler);
+
+    /**
+     * Gets a list of the Autonomous Data Guard-enabled databases associated with the specified Autonomous Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAutonomousDatabaseDataguardAssociationsResponse>
+            listAutonomousDatabaseDataguardAssociations(
+                    ListAutonomousDatabaseDataguardAssociationsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousDatabaseDataguardAssociationsRequest,
+                                    ListAutonomousDatabaseDataguardAssociationsResponse>
+                            handler);
 
     /**
      * Gets a list of Autonomous Databases based on the query parameters specified.
@@ -2438,6 +2535,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Reinstates a disabled standby Autonomous Container Database, identified by the autonomousContainerDatabaseId parameter, to an active standby Autonomous Container Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+            reinstateAutonomousContainerDatabaseDataguardAssociation(
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler);
+
+    /**
      * Reinstates the database identified by the `databaseId` parameter into the standby role in a Data Guard association.
      *
      *
@@ -2648,6 +2764,27 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             StopAutonomousDatabaseRequest, StopAutonomousDatabaseResponse>
                     handler);
+
+    /**
+     * Switches over the primary Autonomous Container Database of an Autonomous Data Guard peer association into a standby role. The standby Autonomous Container Database associated with autonomousContainerDatabaseDataguardAssociationId assumes the primary Autonomous Container Database role.
+     * <p>
+     * A switchover incurs no data loss.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            switchoverAutonomousContainerDatabaseDataguardAssociation(
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler);
 
     /**
      * Initiates a switchover of the specified Autonomous Database to the associated standby database. Applicable only to databases with Autonomous Data Guard enabled.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -4890,6 +4890,93 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<
+                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            failoverAutonomousContainerDatabaseDataguardAssociation(
+                    final FailoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async failoverAutonomousContainerDatabaseDataguardAssociation");
+        final FailoverAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                FailoverAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                FailoverAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        FailoverAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                        FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                            FailoverAutonomousContainerDatabaseDataguardAssociationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<FailoverDataGuardAssociationResponse>
             failoverDataGuardAssociation(
                     final FailoverDataGuardAssociationRequest request,
@@ -5353,6 +5440,91 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            getAutonomousContainerDatabaseDataguardAssociation(
+                    final GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async getAutonomousContainerDatabaseDataguardAssociation");
+        final GetAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                GetAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        GetAutonomousContainerDatabaseDataguardAssociationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                        GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                            GetAutonomousContainerDatabaseDataguardAssociationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    GetAutonomousContainerDatabaseDataguardAssociationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetAutonomousDataWarehouseResponse>
             getAutonomousDataWarehouse(
                     final GetAutonomousDataWarehouseRequest request,
@@ -5648,6 +5820,88 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetAutonomousDatabaseBackupResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetAutonomousDatabaseDataguardAssociationResponse>
+            getAutonomousDatabaseDataguardAssociation(
+                    final GetAutonomousDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetAutonomousDatabaseDataguardAssociationRequest,
+                                    GetAutonomousDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async getAutonomousDatabaseDataguardAssociation");
+        final GetAutonomousDatabaseDataguardAssociationRequest interceptedRequest =
+                GetAutonomousDatabaseDataguardAssociationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutonomousDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetAutonomousDatabaseDataguardAssociationResponse>
+                transformer = GetAutonomousDatabaseDataguardAssociationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetAutonomousDatabaseDataguardAssociationRequest,
+                        GetAutonomousDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetAutonomousDatabaseDataguardAssociationRequest,
+                            GetAutonomousDatabaseDataguardAssociationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetAutonomousDatabaseDataguardAssociationResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -8286,6 +8540,92 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+            listAutonomousContainerDatabaseDataguardAssociations(
+                    final ListAutonomousContainerDatabaseDataguardAssociationsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                                    ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                            handler) {
+        LOG.trace("Called async listAutonomousContainerDatabaseDataguardAssociations");
+        final ListAutonomousContainerDatabaseDataguardAssociationsRequest interceptedRequest =
+                ListAutonomousContainerDatabaseDataguardAssociationsConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousContainerDatabaseDataguardAssociationsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                transformer =
+                        ListAutonomousContainerDatabaseDataguardAssociationsConverter
+                                .fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                            ListAutonomousContainerDatabaseDataguardAssociationsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    ListAutonomousContainerDatabaseDataguardAssociationsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListAutonomousContainerDatabasesResponse>
             listAutonomousContainerDatabases(
                     final ListAutonomousContainerDatabasesRequest request,
@@ -8665,6 +9005,88 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, ListAutonomousDatabaseClonesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListAutonomousDatabaseDataguardAssociationsResponse>
+            listAutonomousDatabaseDataguardAssociations(
+                    final ListAutonomousDatabaseDataguardAssociationsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListAutonomousDatabaseDataguardAssociationsRequest,
+                                    ListAutonomousDatabaseDataguardAssociationsResponse>
+                            handler) {
+        LOG.trace("Called async listAutonomousDatabaseDataguardAssociations");
+        final ListAutonomousDatabaseDataguardAssociationsRequest interceptedRequest =
+                ListAutonomousDatabaseDataguardAssociationsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousDatabaseDataguardAssociationsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListAutonomousDatabaseDataguardAssociationsResponse>
+                transformer = ListAutonomousDatabaseDataguardAssociationsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListAutonomousDatabaseDataguardAssociationsRequest,
+                        ListAutonomousDatabaseDataguardAssociationsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListAutonomousDatabaseDataguardAssociationsRequest,
+                            ListAutonomousDatabaseDataguardAssociationsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListAutonomousDatabaseDataguardAssociationsResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -11386,6 +11808,93 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+            reinstateAutonomousContainerDatabaseDataguardAssociation(
+                    final ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async reinstateAutonomousContainerDatabaseDataguardAssociation");
+        final ReinstateAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                            ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ReinstateDataGuardAssociationResponse>
             reinstateDataGuardAssociation(
                     final ReinstateDataGuardAssociationRequest request,
@@ -12368,6 +12877,93 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, StopAutonomousDatabaseResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            switchoverAutonomousContainerDatabaseDataguardAssociation(
+                    final SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async switchoverAutonomousContainerDatabaseDataguardAssociation");
+        final SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                            SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response,
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -2162,6 +2162,43 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+            failoverAutonomousContainerDatabaseDataguardAssociation(
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called failoverAutonomousContainerDatabaseDataguardAssociation");
+        final FailoverAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                FailoverAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                FailoverAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        FailoverAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public FailoverDataGuardAssociationResponse failoverDataGuardAssociation(
             FailoverDataGuardAssociationRequest request) {
         LOG.trace("Called failoverDataGuardAssociation");
@@ -2334,6 +2371,41 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public GetAutonomousContainerDatabaseDataguardAssociationResponse
+            getAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called getAutonomousContainerDatabaseDataguardAssociation");
+        final GetAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                GetAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        GetAutonomousContainerDatabaseDataguardAssociationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetAutonomousDataWarehouseResponse getAutonomousDataWarehouse(
             GetAutonomousDataWarehouseRequest request) {
         LOG.trace("Called getAutonomousDataWarehouse");
@@ -2433,6 +2505,39 @@ public class DatabaseClient implements Database {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, GetAutonomousDatabaseBackupResponse>
                 transformer = GetAutonomousDatabaseBackupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetAutonomousDatabaseDataguardAssociationResponse
+            getAutonomousDatabaseDataguardAssociation(
+                    GetAutonomousDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called getAutonomousDatabaseDataguardAssociation");
+        final GetAutonomousDatabaseDataguardAssociationRequest interceptedRequest =
+                GetAutonomousDatabaseDataguardAssociationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutonomousDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        GetAutonomousDatabaseDataguardAssociationResponse>
+                transformer = GetAutonomousDatabaseDataguardAssociationConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -3441,6 +3546,42 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ListAutonomousContainerDatabaseDataguardAssociationsResponse
+            listAutonomousContainerDatabaseDataguardAssociations(
+                    ListAutonomousContainerDatabaseDataguardAssociationsRequest request) {
+        LOG.trace("Called listAutonomousContainerDatabaseDataguardAssociations");
+        final ListAutonomousContainerDatabaseDataguardAssociationsRequest interceptedRequest =
+                ListAutonomousContainerDatabaseDataguardAssociationsConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousContainerDatabaseDataguardAssociationsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                transformer =
+                        ListAutonomousContainerDatabaseDataguardAssociationsConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListAutonomousContainerDatabasesResponse listAutonomousContainerDatabases(
             ListAutonomousContainerDatabasesRequest request) {
         LOG.trace("Called listAutonomousContainerDatabases");
@@ -3571,6 +3712,39 @@ public class DatabaseClient implements Database {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, ListAutonomousDatabaseClonesResponse>
                 transformer = ListAutonomousDatabaseClonesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListAutonomousDatabaseDataguardAssociationsResponse
+            listAutonomousDatabaseDataguardAssociations(
+                    ListAutonomousDatabaseDataguardAssociationsRequest request) {
+        LOG.trace("Called listAutonomousDatabaseDataguardAssociations");
+        final ListAutonomousDatabaseDataguardAssociationsRequest interceptedRequest =
+                ListAutonomousDatabaseDataguardAssociationsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAutonomousDatabaseDataguardAssociationsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ListAutonomousDatabaseDataguardAssociationsResponse>
+                transformer = ListAutonomousDatabaseDataguardAssociationsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -4619,6 +4793,43 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+            reinstateAutonomousContainerDatabaseDataguardAssociation(
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called reinstateAutonomousContainerDatabaseDataguardAssociation");
+        final ReinstateAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ReinstateDataGuardAssociationResponse reinstateDataGuardAssociation(
             ReinstateDataGuardAssociationRequest request) {
         LOG.trace("Called reinstateDataGuardAssociation");
@@ -4986,6 +5197,43 @@ public class DatabaseClient implements Database {
                 StopAutonomousDatabaseConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, StopAutonomousDatabaseResponse>
                 transformer = StopAutonomousDatabaseConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+            switchoverAutonomousContainerDatabaseDataguardAssociation(
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called switchoverAutonomousContainerDatabaseDataguardAssociation");
+        final SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
@@ -31,6 +31,148 @@ public class DatabasePaginators {
     private final Database client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listAutonomousContainerDatabaseDataguardAssociations operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+            listAutonomousContainerDatabaseDataguardAssociationsResponseIterator(
+                    final ListAutonomousContainerDatabaseDataguardAssociationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder,
+                ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                ListAutonomousContainerDatabaseDataguardAssociationsResponse>(
+                new com.google.common.base.Supplier<
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder
+                            get() {
+                        return ListAutonomousContainerDatabaseDataguardAssociationsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListAutonomousContainerDatabaseDataguardAssociationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                                        .Builder>,
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsResponse apply(
+                            ListAutonomousContainerDatabaseDataguardAssociationsRequest request) {
+                        return client.listAutonomousContainerDatabaseDataguardAssociations(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation} objects
+     * contained in responses from the listAutonomousContainerDatabaseDataguardAssociations operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation>
+            listAutonomousContainerDatabaseDataguardAssociationsRecordIterator(
+                    final ListAutonomousContainerDatabaseDataguardAssociationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder,
+                ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                ListAutonomousContainerDatabaseDataguardAssociationsResponse,
+                com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation>(
+                new com.google.common.base.Supplier<
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsRequest.Builder
+                            get() {
+                        return ListAutonomousContainerDatabaseDataguardAssociationsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListAutonomousContainerDatabaseDataguardAssociationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                                        .Builder>,
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousContainerDatabaseDataguardAssociationsRequest,
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse>() {
+                    @Override
+                    public ListAutonomousContainerDatabaseDataguardAssociationsResponse apply(
+                            ListAutonomousContainerDatabaseDataguardAssociationsRequest request) {
+                        return client.listAutonomousContainerDatabaseDataguardAssociations(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousContainerDatabaseDataguardAssociationsResponse,
+                        java.util.List<
+                                com.oracle.bmc.database.model
+                                        .AutonomousContainerDatabaseDataguardAssociation>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.database.model
+                                            .AutonomousContainerDatabaseDataguardAssociation>
+                            apply(
+                                    ListAutonomousContainerDatabaseDataguardAssociationsResponse
+                                            response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listAutonomousContainerDatabases operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -655,6 +797,142 @@ public class DatabasePaginators {
                     @Override
                     public java.util.List<com.oracle.bmc.database.model.AutonomousDatabaseSummary>
                             apply(ListAutonomousDatabaseClonesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listAutonomousDatabaseDataguardAssociations operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListAutonomousDatabaseDataguardAssociationsResponse>
+            listAutonomousDatabaseDataguardAssociationsResponseIterator(
+                    final ListAutonomousDatabaseDataguardAssociationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListAutonomousDatabaseDataguardAssociationsRequest.Builder,
+                ListAutonomousDatabaseDataguardAssociationsRequest,
+                ListAutonomousDatabaseDataguardAssociationsResponse>(
+                new com.google.common.base.Supplier<
+                        ListAutonomousDatabaseDataguardAssociationsRequest.Builder>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsRequest.Builder get() {
+                        return ListAutonomousDatabaseDataguardAssociationsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousDatabaseDataguardAssociationsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListAutonomousDatabaseDataguardAssociationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAutonomousDatabaseDataguardAssociationsRequest.Builder>,
+                        ListAutonomousDatabaseDataguardAssociationsRequest>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAutonomousDatabaseDataguardAssociationsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousDatabaseDataguardAssociationsRequest,
+                        ListAutonomousDatabaseDataguardAssociationsResponse>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsResponse apply(
+                            ListAutonomousDatabaseDataguardAssociationsRequest request) {
+                        return client.listAutonomousDatabaseDataguardAssociations(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation} objects
+     * contained in responses from the listAutonomousDatabaseDataguardAssociations operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation>
+            listAutonomousDatabaseDataguardAssociationsRecordIterator(
+                    final ListAutonomousDatabaseDataguardAssociationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListAutonomousDatabaseDataguardAssociationsRequest.Builder,
+                ListAutonomousDatabaseDataguardAssociationsRequest,
+                ListAutonomousDatabaseDataguardAssociationsResponse,
+                com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation>(
+                new com.google.common.base.Supplier<
+                        ListAutonomousDatabaseDataguardAssociationsRequest.Builder>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsRequest.Builder get() {
+                        return ListAutonomousDatabaseDataguardAssociationsRequest.builder()
+                                .copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousDatabaseDataguardAssociationsResponse, String>() {
+                    @Override
+                    public String apply(
+                            ListAutonomousDatabaseDataguardAssociationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAutonomousDatabaseDataguardAssociationsRequest.Builder>,
+                        ListAutonomousDatabaseDataguardAssociationsRequest>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAutonomousDatabaseDataguardAssociationsRequest
+                                                    .Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousDatabaseDataguardAssociationsRequest,
+                        ListAutonomousDatabaseDataguardAssociationsResponse>() {
+                    @Override
+                    public ListAutonomousDatabaseDataguardAssociationsResponse apply(
+                            ListAutonomousDatabaseDataguardAssociationsRequest request) {
+                        return client.listAutonomousDatabaseDataguardAssociations(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAutonomousDatabaseDataguardAssociationsResponse,
+                        java.util.List<
+                                com.oracle.bmc.database.model
+                                        .AutonomousDatabaseDataguardAssociation>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.database.model
+                                            .AutonomousDatabaseDataguardAssociation>
+                            apply(ListAutonomousDatabaseDataguardAssociationsResponse response) {
                         return response.getItems();
                     }
                 });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -2584,6 +2584,73 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            forFailoverAutonomousContainerDatabaseDataguardAssociation(
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        return forFailoverAutonomousContainerDatabaseDataguardAssociation(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            forFailoverAutonomousContainerDatabaseDataguardAssociation(
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        FailoverAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                    @Override
+                    public FailoverAutonomousContainerDatabaseDataguardAssociationResponse call()
+                            throws Exception {
+                        final FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                response =
+                                        client
+                                                .failoverAutonomousContainerDatabaseDataguardAssociation(
+                                                        request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     FailoverDataGuardAssociationRequest, FailoverDataGuardAssociationResponse>
             forFailoverDataGuardAssociation(FailoverDataGuardAssociationRequest request) {
         return forFailoverDataGuardAssociation(
@@ -2748,6 +2815,136 @@ public class DatabaseWaiters {
                         },
                         targetStatesSet.contains(
                                 com.oracle.bmc.database.model.AutonomousContainerDatabase
+                                        .LifecycleState.Terminated)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            forAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forAutonomousContainerDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            forAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation
+                                    .LifecycleState
+                            targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forAutonomousContainerDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            forAutonomousContainerDatabaseDataguardAssociation(
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forAutonomousContainerDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for AutonomousContainerDatabaseDataguardAssociation.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                    GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            forAutonomousContainerDatabaseDataguardAssociation(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.database.model
+                                    .AutonomousContainerDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        final java.util.Set<
+                        com.oracle.bmc.database.model
+                                .AutonomousContainerDatabaseDataguardAssociation.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetAutonomousContainerDatabaseDataguardAssociationRequest,
+                                GetAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public GetAutonomousContainerDatabaseDataguardAssociationResponse apply(
+                                    GetAutonomousContainerDatabaseDataguardAssociationRequest
+                                            request) {
+                                return client.getAutonomousContainerDatabaseDataguardAssociation(
+                                        request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public boolean apply(
+                                    GetAutonomousContainerDatabaseDataguardAssociationResponse
+                                            response) {
+                                return targetStatesSet.contains(
+                                        response.getAutonomousContainerDatabaseDataguardAssociation()
+                                                .getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model
+                                        .AutonomousContainerDatabaseDataguardAssociation
                                         .LifecycleState.Terminated)),
                 request);
     }
@@ -3202,6 +3399,131 @@ public class DatabaseWaiters {
                         targetStatesSet.contains(
                                 com.oracle.bmc.database.model.AutonomousDatabaseBackup
                                         .LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousDatabaseDataguardAssociationRequest,
+                    GetAutonomousDatabaseDataguardAssociationResponse>
+            forAutonomousDatabaseDataguardAssociation(
+                    GetAutonomousDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forAutonomousDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousDatabaseDataguardAssociationRequest,
+                    GetAutonomousDatabaseDataguardAssociationResponse>
+            forAutonomousDatabaseDataguardAssociation(
+                    GetAutonomousDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                    .LifecycleState
+                            targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forAutonomousDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousDatabaseDataguardAssociationRequest,
+                    GetAutonomousDatabaseDataguardAssociationResponse>
+            forAutonomousDatabaseDataguardAssociation(
+                    GetAutonomousDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forAutonomousDatabaseDataguardAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for AutonomousDatabaseDataguardAssociation.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetAutonomousDatabaseDataguardAssociationRequest,
+                    GetAutonomousDatabaseDataguardAssociationResponse>
+            forAutonomousDatabaseDataguardAssociation(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetAutonomousDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                    .LifecycleState...
+                            targetStates) {
+        final java.util.Set<
+                        com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                .LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetAutonomousDatabaseDataguardAssociationRequest,
+                                GetAutonomousDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public GetAutonomousDatabaseDataguardAssociationResponse apply(
+                                    GetAutonomousDatabaseDataguardAssociationRequest request) {
+                                return client.getAutonomousDatabaseDataguardAssociation(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetAutonomousDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public boolean apply(
+                                    GetAutonomousDatabaseDataguardAssociationResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getAutonomousDatabaseDataguardAssociation()
+                                                .getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.AutonomousDatabaseDataguardAssociation
+                                        .LifecycleState.Terminated)),
                 request);
     }
 
@@ -5552,6 +5874,73 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+            forReinstateAutonomousContainerDatabaseDataguardAssociation(
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        return forReinstateAutonomousContainerDatabaseDataguardAssociation(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+            forReinstateAutonomousContainerDatabaseDataguardAssociation(
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                    @Override
+                    public ReinstateAutonomousContainerDatabaseDataguardAssociationResponse call()
+                            throws Exception {
+                        final ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+                                response =
+                                        client
+                                                .reinstateAutonomousContainerDatabaseDataguardAssociation(
+                                                        request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     ReinstateDataGuardAssociationRequest, ReinstateDataGuardAssociationResponse>
             forReinstateDataGuardAssociation(ReinstateDataGuardAssociationRequest request) {
         return forReinstateDataGuardAssociation(
@@ -6066,6 +6455,73 @@ public class DatabaseWaiters {
                     public StopAutonomousDatabaseResponse call() throws Exception {
                         final StopAutonomousDatabaseResponse response =
                                 client.stopAutonomousDatabase(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            forSwitchoverAutonomousContainerDatabaseDataguardAssociation(
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        return forSwitchoverAutonomousContainerDatabaseDataguardAssociation(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            forSwitchoverAutonomousContainerDatabaseDataguardAssociation(
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                    @Override
+                    public SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse call()
+                            throws Exception {
+                        final SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                response =
+                                        client
+                                                .switchoverAutonomousContainerDatabaseDataguardAssociation(
+                                                        request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/FailoverAutonomousContainerDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/FailoverAutonomousContainerDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class FailoverAutonomousContainerDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .FailoverAutonomousContainerDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .FailoverAutonomousContainerDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .FailoverAutonomousContainerDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseDataguardAssociationId(),
+                "autonomousContainerDatabaseDataguardAssociationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getAutonomousContainerDatabaseDataguardAssociationId()))
+                        .path("actions")
+                        .path("failover");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .FailoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .FailoverAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.FailoverAutonomousContainerDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AutonomousContainerDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AutonomousContainerDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AutonomousContainerDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                                        .builder();
+
+                                builder.autonomousContainerDatabaseDataguardAssociation(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .FailoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetAutonomousContainerDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetAutonomousContainerDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetAutonomousContainerDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .GetAutonomousContainerDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .GetAutonomousContainerDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .GetAutonomousContainerDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseDataguardAssociationId(),
+                "autonomousContainerDatabaseDataguardAssociationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getAutonomousContainerDatabaseDataguardAssociationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .GetAutonomousContainerDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .GetAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .GetAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .GetAutonomousContainerDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetAutonomousContainerDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AutonomousContainerDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AutonomousContainerDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AutonomousContainerDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .GetAutonomousContainerDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetAutonomousContainerDatabaseDataguardAssociationResponse
+                                                        .builder();
+
+                                builder.autonomousContainerDatabaseDataguardAssociation(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .GetAutonomousContainerDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetAutonomousDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetAutonomousDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetAutonomousDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.GetAutonomousDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .GetAutonomousDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.GetAutonomousDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousDatabaseId(), "autonomousDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousDatabaseDataguardAssociationId(),
+                "autonomousDatabaseDataguardAssociationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousDatabaseId()))
+                        .path("autonomousDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousDatabaseDataguardAssociationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .GetAutonomousDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .GetAutonomousDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .GetAutonomousDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .GetAutonomousDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetAutonomousDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AutonomousDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AutonomousDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AutonomousDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .GetAutonomousDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetAutonomousDatabaseDataguardAssociationResponse
+                                                        .builder();
+
+                                builder.autonomousDatabaseDataguardAssociation(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .GetAutonomousDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousContainerDatabaseDataguardAssociationsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousContainerDatabaseDataguardAssociationsConverter.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListAutonomousContainerDatabaseDataguardAssociationsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .ListAutonomousContainerDatabaseDataguardAssociationsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .ListAutonomousContainerDatabaseDataguardAssociationsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .ListAutonomousContainerDatabaseDataguardAssociationsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListAutonomousContainerDatabaseDataguardAssociationsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListAutonomousContainerDatabaseDataguardAssociationsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListAutonomousContainerDatabaseDataguardAssociationsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                AutonomousContainerDatabaseDataguardAssociation>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        AutonomousContainerDatabaseDataguardAssociation>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        AutonomousContainerDatabaseDataguardAssociation>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousContainerDatabaseDataguardAssociationsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListAutonomousContainerDatabaseDataguardAssociationsResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousContainerDatabaseDataguardAssociationsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousContainerDatabasesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousContainerDatabasesConverter.java
@@ -120,6 +120,14 @@ public class ListAutonomousContainerDatabasesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getServiceLevelAgreementType() != null) {
+            target =
+                    target.queryParam(
+                            "serviceLevelAgreementType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getServiceLevelAgreementType()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousDatabaseDataguardAssociationsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListAutonomousDatabaseDataguardAssociationsConverter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListAutonomousDatabaseDataguardAssociationsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .ListAutonomousDatabaseDataguardAssociationsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .ListAutonomousDatabaseDataguardAssociationsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListAutonomousDatabaseDataguardAssociationsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousDatabaseId(), "autonomousDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousDatabaseId()))
+                        .path("autonomousDatabaseDataguardAssociations");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .ListAutonomousDatabaseDataguardAssociationsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .ListAutonomousDatabaseDataguardAssociationsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListAutonomousDatabaseDataguardAssociationsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListAutonomousDatabaseDataguardAssociationsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListAutonomousDatabaseDataguardAssociationsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                AutonomousDatabaseDataguardAssociation>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        AutonomousDatabaseDataguardAssociation>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        AutonomousDatabaseDataguardAssociation>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousDatabaseDataguardAssociationsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListAutonomousDatabaseDataguardAssociationsResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListAutonomousDatabaseDataguardAssociationsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbHomesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbHomesConverter.java
@@ -62,6 +62,14 @@ public class ListDbHomesConverter {
                                     request.getBackupId()));
         }
 
+        if (request.getDbVersion() != null) {
+            target =
+                    target.queryParam(
+                            "dbVersion",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDbVersion()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ReinstateAutonomousContainerDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ReinstateAutonomousContainerDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .ReinstateAutonomousContainerDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .ReinstateAutonomousContainerDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .ReinstateAutonomousContainerDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseDataguardAssociationId(),
+                "autonomousContainerDatabaseDataguardAssociationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getAutonomousContainerDatabaseDataguardAssociationId()))
+                        .path("actions")
+                        .path("reinstate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ReinstateAutonomousContainerDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AutonomousContainerDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AutonomousContainerDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AutonomousContainerDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+                                                        .builder();
+
+                                builder.autonomousContainerDatabaseDataguardAssociation(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ReinstateAutonomousContainerDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class SwitchoverAutonomousContainerDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseDataguardAssociationId(),
+                "autonomousContainerDatabaseDataguardAssociationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getAutonomousContainerDatabaseDataguardAssociationId()))
+                        .path("actions")
+                        .path("switchover");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AutonomousContainerDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AutonomousContainerDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AutonomousContainerDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                                        .builder();
+
+                                builder.autonomousContainerDatabaseDataguardAssociation(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabase.java
@@ -189,6 +189,15 @@ public class AutonomousContainerDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+        private Integer standbyMaintenanceBufferInDays;
+
+        public Builder standbyMaintenanceBufferInDays(Integer standbyMaintenanceBufferInDays) {
+            this.standbyMaintenanceBufferInDays = standbyMaintenanceBufferInDays;
+            this.__explicitlySet__.add("standbyMaintenanceBufferInDays");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -205,6 +214,15 @@ public class AutonomousContainerDatabase {
                 java.util.Map<String, java.util.Map<String, Object>> definedTags) {
             this.definedTags = definedTags;
             this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
             return this;
         }
 
@@ -259,8 +277,10 @@ public class AutonomousContainerDatabase {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             maintenanceWindow,
+                            standbyMaintenanceBufferInDays,
                             freeformTags,
                             definedTags,
+                            role,
                             availabilityDomain,
                             dbVersion,
                             backupConfig);
@@ -290,8 +310,10 @@ public class AutonomousContainerDatabase {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .maintenanceWindow(o.getMaintenanceWindow())
+                            .standbyMaintenanceBufferInDays(o.getStandbyMaintenanceBufferInDays())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .role(o.getRole())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .dbVersion(o.getDbVersion())
                             .backupConfig(o.getBackupConfig());
@@ -338,6 +360,7 @@ public class AutonomousContainerDatabase {
     public enum ServiceLevelAgreementType {
         Standard("STANDARD"),
         MissionCritical("MISSION_CRITICAL"),
+        AutonomousDataguard("AUTONOMOUS_DATAGUARD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -473,6 +496,7 @@ public class AutonomousContainerDatabase {
         RestoreFailed("RESTORE_FAILED"),
         Restarting("RESTARTING"),
         MaintenanceInProgress("MAINTENANCE_IN_PROGRESS"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -603,6 +627,14 @@ public class AutonomousContainerDatabase {
     MaintenanceWindow maintenanceWindow;
 
     /**
+     * The scheduling detail for the quarterly maintenance window of standby Autonomous Container Database.
+     * This value represents the number of days before the primary database maintenance schedule.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+    Integer standbyMaintenanceBufferInDays;
+
+    /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
      * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
      * <p>
@@ -619,6 +651,57 @@ public class AutonomousContainerDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
 
     /**
      * The availability domain of the Autonomous Container Database.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
@@ -1,0 +1,552 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The properties that define Autonomous Data Guard association between two different Autonomous Container Databases.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AutonomousContainerDatabaseDataguardAssociation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AutonomousContainerDatabaseDataguardAssociation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousContainerDatabaseId")
+        private String autonomousContainerDatabaseId;
+
+        public Builder autonomousContainerDatabaseId(String autonomousContainerDatabaseId) {
+            this.autonomousContainerDatabaseId = autonomousContainerDatabaseId;
+            this.__explicitlySet__.add("autonomousContainerDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty(
+                "peerAutonomousContainerDatabaseDataguardAssociationId")
+        private String peerAutonomousContainerDatabaseDataguardAssociationId;
+
+        public Builder peerAutonomousContainerDatabaseDataguardAssociationId(
+                String peerAutonomousContainerDatabaseDataguardAssociationId) {
+            this.peerAutonomousContainerDatabaseDataguardAssociationId =
+                    peerAutonomousContainerDatabaseDataguardAssociationId;
+            this.__explicitlySet__.add("peerAutonomousContainerDatabaseDataguardAssociationId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousContainerDatabaseId")
+        private String peerAutonomousContainerDatabaseId;
+
+        public Builder peerAutonomousContainerDatabaseId(String peerAutonomousContainerDatabaseId) {
+            this.peerAutonomousContainerDatabaseId = peerAutonomousContainerDatabaseId;
+            this.__explicitlySet__.add("peerAutonomousContainerDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
+        private PeerRole peerRole;
+
+        public Builder peerRole(PeerRole peerRole) {
+            this.peerRole = peerRole;
+            this.__explicitlySet__.add("peerRole");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerLifecycleState")
+        private PeerLifecycleState peerLifecycleState;
+
+        public Builder peerLifecycleState(PeerLifecycleState peerLifecycleState) {
+            this.peerLifecycleState = peerLifecycleState;
+            this.__explicitlySet__.add("peerLifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+        private ProtectionMode protectionMode;
+
+        public Builder protectionMode(ProtectionMode protectionMode) {
+            this.protectionMode = protectionMode;
+            this.__explicitlySet__.add("protectionMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applyLag")
+        private String applyLag;
+
+        public Builder applyLag(String applyLag) {
+            this.applyLag = applyLag;
+            this.__explicitlySet__.add("applyLag");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
+        private String applyRate;
+
+        public Builder applyRate(String applyRate) {
+            this.applyRate = applyRate;
+            this.__explicitlySet__.add("applyRate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastRoleChanged")
+        private java.util.Date timeLastRoleChanged;
+
+        public Builder timeLastRoleChanged(java.util.Date timeLastRoleChanged) {
+            this.timeLastRoleChanged = timeLastRoleChanged;
+            this.__explicitlySet__.add("timeLastRoleChanged");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AutonomousContainerDatabaseDataguardAssociation build() {
+            AutonomousContainerDatabaseDataguardAssociation __instance__ =
+                    new AutonomousContainerDatabaseDataguardAssociation(
+                            id,
+                            autonomousContainerDatabaseId,
+                            role,
+                            lifecycleState,
+                            lifecycleDetails,
+                            peerAutonomousContainerDatabaseDataguardAssociationId,
+                            peerAutonomousContainerDatabaseId,
+                            peerRole,
+                            peerLifecycleState,
+                            protectionMode,
+                            applyLag,
+                            applyRate,
+                            timeCreated,
+                            timeLastRoleChanged);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AutonomousContainerDatabaseDataguardAssociation o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .role(o.getRole())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .peerAutonomousContainerDatabaseDataguardAssociationId(
+                                    o.getPeerAutonomousContainerDatabaseDataguardAssociationId())
+                            .peerAutonomousContainerDatabaseId(
+                                    o.getPeerAutonomousContainerDatabaseId())
+                            .peerRole(o.getPeerRole())
+                            .peerLifecycleState(o.getPeerLifecycleState())
+                            .protectionMode(o.getProtectionMode())
+                            .applyLag(o.getApplyLag())
+                            .applyRate(o.getApplyRate())
+                            .timeCreated(o.getTimeCreated())
+                            .timeLastRoleChanged(o.getTimeLastRoleChanged());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Autonomous Data Guard created for a given Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Autonomous Container Database that has a relationship with the peer Autonomous Container Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousContainerDatabaseId")
+    String autonomousContainerDatabaseId;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycleState, if available.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The OCID of the peer Autonomous Container Database-Autonomous Data Guard association.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty(
+            "peerAutonomousContainerDatabaseDataguardAssociationId")
+    String peerAutonomousContainerDatabaseDataguardAssociationId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the peer Autonomous Container Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousContainerDatabaseId")
+    String peerAutonomousContainerDatabaseId;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PeerRole {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PeerRole> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PeerRole v : PeerRole.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PeerRole(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PeerRole create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PeerRole', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
+    PeerRole peerRole;
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PeerLifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PeerLifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PeerLifecycleState v : PeerLifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PeerLifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PeerLifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PeerLifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerLifecycleState")
+    PeerLifecycleState peerLifecycleState;
+    /**
+     * The protection mode of this Autonomous Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ProtectionMode {
+        MaximumAvailability("MAXIMUM_AVAILABILITY"),
+        MaximumPerformance("MAXIMUM_PERFORMANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ProtectionMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ProtectionMode v : ProtectionMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ProtectionMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ProtectionMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ProtectionMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The protection mode of this Autonomous Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+    ProtectionMode protectionMode;
+
+    /**
+     * The lag time between updates to the primary Autonomous Container Database and application of the redo data on the standby Autonomous Container Database,
+     * as computed by the reporting database.
+     * <p>
+     * Example: `9 seconds`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applyLag")
+    String applyLag;
+
+    /**
+     * The rate at which redo logs are synchronized between the associated Autonomous Container Databases.
+     * <p>
+     * Example: `180 Mb per second`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
+    String applyRate;
+
+    /**
+     * The date and time the Autonomous DataGuard association was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time when the last role change action happened.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastRoleChanged")
+    java.util.Date timeLastRoleChanged;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseSummary.java
@@ -190,6 +190,15 @@ public class AutonomousContainerDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+        private Integer standbyMaintenanceBufferInDays;
+
+        public Builder standbyMaintenanceBufferInDays(Integer standbyMaintenanceBufferInDays) {
+            this.standbyMaintenanceBufferInDays = standbyMaintenanceBufferInDays;
+            this.__explicitlySet__.add("standbyMaintenanceBufferInDays");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -206,6 +215,15 @@ public class AutonomousContainerDatabaseSummary {
                 java.util.Map<String, java.util.Map<String, Object>> definedTags) {
             this.definedTags = definedTags;
             this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
             return this;
         }
 
@@ -260,8 +278,10 @@ public class AutonomousContainerDatabaseSummary {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             maintenanceWindow,
+                            standbyMaintenanceBufferInDays,
                             freeformTags,
                             definedTags,
+                            role,
                             availabilityDomain,
                             dbVersion,
                             backupConfig);
@@ -291,8 +311,10 @@ public class AutonomousContainerDatabaseSummary {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .maintenanceWindow(o.getMaintenanceWindow())
+                            .standbyMaintenanceBufferInDays(o.getStandbyMaintenanceBufferInDays())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .role(o.getRole())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .dbVersion(o.getDbVersion())
                             .backupConfig(o.getBackupConfig());
@@ -339,6 +361,7 @@ public class AutonomousContainerDatabaseSummary {
     public enum ServiceLevelAgreementType {
         Standard("STANDARD"),
         MissionCritical("MISSION_CRITICAL"),
+        AutonomousDataguard("AUTONOMOUS_DATAGUARD"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -474,6 +497,7 @@ public class AutonomousContainerDatabaseSummary {
         RestoreFailed("RESTORE_FAILED"),
         Restarting("RESTARTING"),
         MaintenanceInProgress("MAINTENANCE_IN_PROGRESS"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -604,6 +628,14 @@ public class AutonomousContainerDatabaseSummary {
     MaintenanceWindow maintenanceWindow;
 
     /**
+     * The scheduling detail for the quarterly maintenance window of standby Autonomous Container Database.
+     * This value represents the number of days before the primary database maintenance schedule.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+    Integer standbyMaintenanceBufferInDays;
+
+    /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
      * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
      * <p>
@@ -620,6 +652,57 @@ public class AutonomousContainerDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
 
     /**
      * The availability domain of the Autonomous Container Database.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -480,6 +480,15 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("availableUpgradeVersions")
         private java.util.List<String> availableUpgradeVersions;
 
@@ -545,6 +554,7 @@ public class AutonomousDatabase {
                             isDataGuardEnabled,
                             failedDataRecoveryInSeconds,
                             standbyDb,
+                            role,
                             availableUpgradeVersions);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -605,6 +615,7 @@ public class AutonomousDatabase {
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .failedDataRecoveryInSeconds(o.getFailedDataRecoveryInSeconds())
                             .standbyDb(o.getStandbyDb())
+                            .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -1384,6 +1395,57 @@ public class AutonomousDatabase {
 
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
 
     /**
      * List of Oracle Database versions available for a database upgrade. If there are no version upgrades available, this list is empty.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
@@ -1,0 +1,534 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The properties that define dataguard association between two different Autonomous Databases.
+ * Note that Autonomous Databases inherit DataGuard association from parent Autonomous Container Database.
+ * No actions can be taken on AutonomousDatabaseDataguardAssociation, usage is strictly informational.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AutonomousDatabaseDataguardAssociation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AutonomousDatabaseDataguardAssociation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
+        private String autonomousDatabaseId;
+
+        public Builder autonomousDatabaseId(String autonomousDatabaseId) {
+            this.autonomousDatabaseId = autonomousDatabaseId;
+            this.__explicitlySet__.add("autonomousDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
+        private PeerRole peerRole;
+
+        public Builder peerRole(PeerRole peerRole) {
+            this.peerRole = peerRole;
+            this.__explicitlySet__.add("peerRole");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousDatabaseId")
+        private String peerAutonomousDatabaseId;
+
+        public Builder peerAutonomousDatabaseId(String peerAutonomousDatabaseId) {
+            this.peerAutonomousDatabaseId = peerAutonomousDatabaseId;
+            this.__explicitlySet__.add("peerAutonomousDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousDatabaseLifeCycleState")
+        private PeerAutonomousDatabaseLifeCycleState peerAutonomousDatabaseLifeCycleState;
+
+        public Builder peerAutonomousDatabaseLifeCycleState(
+                PeerAutonomousDatabaseLifeCycleState peerAutonomousDatabaseLifeCycleState) {
+            this.peerAutonomousDatabaseLifeCycleState = peerAutonomousDatabaseLifeCycleState;
+            this.__explicitlySet__.add("peerAutonomousDatabaseLifeCycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+        private ProtectionMode protectionMode;
+
+        public Builder protectionMode(ProtectionMode protectionMode) {
+            this.protectionMode = protectionMode;
+            this.__explicitlySet__.add("protectionMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applyLag")
+        private String applyLag;
+
+        public Builder applyLag(String applyLag) {
+            this.applyLag = applyLag;
+            this.__explicitlySet__.add("applyLag");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
+        private String applyRate;
+
+        public Builder applyRate(String applyRate) {
+            this.applyRate = applyRate;
+            this.__explicitlySet__.add("applyRate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastRoleChanged")
+        private java.util.Date timeLastRoleChanged;
+
+        public Builder timeLastRoleChanged(java.util.Date timeLastRoleChanged) {
+            this.timeLastRoleChanged = timeLastRoleChanged;
+            this.__explicitlySet__.add("timeLastRoleChanged");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AutonomousDatabaseDataguardAssociation build() {
+            AutonomousDatabaseDataguardAssociation __instance__ =
+                    new AutonomousDatabaseDataguardAssociation(
+                            id,
+                            autonomousDatabaseId,
+                            role,
+                            lifecycleState,
+                            lifecycleDetails,
+                            peerRole,
+                            peerAutonomousDatabaseId,
+                            peerAutonomousDatabaseLifeCycleState,
+                            protectionMode,
+                            applyLag,
+                            applyRate,
+                            timeCreated,
+                            timeLastRoleChanged);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AutonomousDatabaseDataguardAssociation o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .autonomousDatabaseId(o.getAutonomousDatabaseId())
+                            .role(o.getRole())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .peerRole(o.getPeerRole())
+                            .peerAutonomousDatabaseId(o.getPeerAutonomousDatabaseId())
+                            .peerAutonomousDatabaseLifeCycleState(
+                                    o.getPeerAutonomousDatabaseLifeCycleState())
+                            .protectionMode(o.getProtectionMode())
+                            .applyLag(o.getApplyLag())
+                            .applyRate(o.getApplyRate())
+                            .timeCreated(o.getTimeCreated())
+                            .timeLastRoleChanged(o.getTimeLastRoleChanged());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Autonomous Dataguard created for Autonomous Container Database where given Autonomous Database resides in.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Autonomous Database that has a relationship with the peer Autonomous Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
+    String autonomousDatabaseId;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycleState, if available.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PeerRole {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PeerRole> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PeerRole v : PeerRole.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PeerRole(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PeerRole create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PeerRole', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
+    PeerRole peerRole;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the peer Autonomous Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousDatabaseId")
+    String peerAutonomousDatabaseId;
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PeerAutonomousDatabaseLifeCycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        RoleChangeInProgress("ROLE_CHANGE_IN_PROGRESS"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PeerAutonomousDatabaseLifeCycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PeerAutonomousDatabaseLifeCycleState v :
+                    PeerAutonomousDatabaseLifeCycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PeerAutonomousDatabaseLifeCycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PeerAutonomousDatabaseLifeCycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PeerAutonomousDatabaseLifeCycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Autonomous Data Guard.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousDatabaseLifeCycleState")
+    PeerAutonomousDatabaseLifeCycleState peerAutonomousDatabaseLifeCycleState;
+    /**
+     * The protection mode of this Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ProtectionMode {
+        MaximumAvailability("MAXIMUM_AVAILABILITY"),
+        MaximumPerformance("MAXIMUM_PERFORMANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ProtectionMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ProtectionMode v : ProtectionMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ProtectionMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ProtectionMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ProtectionMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The protection mode of this Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+    ProtectionMode protectionMode;
+
+    /**
+     * The lag time between updates to the primary database and application of the redo data on the standby database,
+     * as computed by the reporting database.
+     * <p>
+     * Example: `9 seconds`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applyLag")
+    String applyLag;
+
+    /**
+     * The rate at which redo logs are synced between the associated databases.
+     * <p>
+     * Example: `180 Mb per second`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
+    String applyRate;
+
+    /**
+     * The date and time the Data Guard association was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time when the last role change action happened.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastRoleChanged")
+    java.util.Date timeLastRoleChanged;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -482,6 +482,15 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("role")
+        private Role role;
+
+        public Builder role(Role role) {
+            this.role = role;
+            this.__explicitlySet__.add("role");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("availableUpgradeVersions")
         private java.util.List<String> availableUpgradeVersions;
 
@@ -547,6 +556,7 @@ public class AutonomousDatabaseSummary {
                             isDataGuardEnabled,
                             failedDataRecoveryInSeconds,
                             standbyDb,
+                            role,
                             availableUpgradeVersions);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -607,6 +617,7 @@ public class AutonomousDatabaseSummary {
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .failedDataRecoveryInSeconds(o.getFailedDataRecoveryInSeconds())
                             .standbyDb(o.getStandbyDb())
+                            .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -1386,6 +1397,57 @@ public class AutonomousDatabaseSummary {
 
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Role {
+        Primary("PRIMARY"),
+        Standby("STANDBY"),
+        DisabledStandby("DISABLED_STANDBY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Role> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Role v : Role.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Role(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Role create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Role', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("role")
+    Role role;
 
     /**
      * List of Oracle Database versions available for a database upgrade. If there are no version upgrades available, this list is empty.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousContainerDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousContainerDatabaseDetails.java
@@ -64,6 +64,36 @@ public class CreateAutonomousContainerDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousExadataInfrastructureId")
+        private String peerAutonomousExadataInfrastructureId;
+
+        public Builder peerAutonomousExadataInfrastructureId(
+                String peerAutonomousExadataInfrastructureId) {
+            this.peerAutonomousExadataInfrastructureId = peerAutonomousExadataInfrastructureId;
+            this.__explicitlySet__.add("peerAutonomousExadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousContainerDatabaseDisplayName")
+        private String peerAutonomousContainerDatabaseDisplayName;
+
+        public Builder peerAutonomousContainerDatabaseDisplayName(
+                String peerAutonomousContainerDatabaseDisplayName) {
+            this.peerAutonomousContainerDatabaseDisplayName =
+                    peerAutonomousContainerDatabaseDisplayName;
+            this.__explicitlySet__.add("peerAutonomousContainerDatabaseDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+        private ProtectionMode protectionMode;
+
+        public Builder protectionMode(ProtectionMode protectionMode) {
+            this.protectionMode = protectionMode;
+            this.__explicitlySet__.add("protectionMode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousVmClusterId")
         private String autonomousVmClusterId;
 
@@ -97,6 +127,15 @@ public class CreateAutonomousContainerDatabaseDetails {
         public Builder maintenanceWindowDetails(MaintenanceWindow maintenanceWindowDetails) {
             this.maintenanceWindowDetails = maintenanceWindowDetails;
             this.__explicitlySet__.add("maintenanceWindowDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+        private Integer standbyMaintenanceBufferInDays;
+
+        public Builder standbyMaintenanceBufferInDays(Integer standbyMaintenanceBufferInDays) {
+            this.standbyMaintenanceBufferInDays = standbyMaintenanceBufferInDays;
+            this.__explicitlySet__.add("standbyMaintenanceBufferInDays");
             return this;
         }
 
@@ -165,10 +204,14 @@ public class CreateAutonomousContainerDatabaseDetails {
                             dbUniqueName,
                             serviceLevelAgreementType,
                             autonomousExadataInfrastructureId,
+                            peerAutonomousExadataInfrastructureId,
+                            peerAutonomousContainerDatabaseDisplayName,
+                            protectionMode,
                             autonomousVmClusterId,
                             compartmentId,
                             patchModel,
                             maintenanceWindowDetails,
+                            standbyMaintenanceBufferInDays,
                             freeformTags,
                             definedTags,
                             backupConfig,
@@ -187,10 +230,16 @@ public class CreateAutonomousContainerDatabaseDetails {
                             .serviceLevelAgreementType(o.getServiceLevelAgreementType())
                             .autonomousExadataInfrastructureId(
                                     o.getAutonomousExadataInfrastructureId())
+                            .peerAutonomousExadataInfrastructureId(
+                                    o.getPeerAutonomousExadataInfrastructureId())
+                            .peerAutonomousContainerDatabaseDisplayName(
+                                    o.getPeerAutonomousContainerDatabaseDisplayName())
+                            .protectionMode(o.getProtectionMode())
                             .autonomousVmClusterId(o.getAutonomousVmClusterId())
                             .compartmentId(o.getCompartmentId())
                             .patchModel(o.getPatchModel())
                             .maintenanceWindowDetails(o.getMaintenanceWindowDetails())
+                            .standbyMaintenanceBufferInDays(o.getStandbyMaintenanceBufferInDays())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .backupConfig(o.getBackupConfig())
@@ -226,6 +275,7 @@ public class CreateAutonomousContainerDatabaseDetails {
      **/
     public enum ServiceLevelAgreementType {
         Standard("STANDARD"),
+        AutonomousDataguard("AUTONOMOUS_DATAGUARD"),
         ;
 
         private final String value;
@@ -266,6 +316,64 @@ public class CreateAutonomousContainerDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("autonomousExadataInfrastructureId")
     String autonomousExadataInfrastructureId;
+
+    /**
+     * The OCID of the peer Autonomous Exadata Infrastructure for Autonomous Data Guard.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousExadataInfrastructureId")
+    String peerAutonomousExadataInfrastructureId;
+
+    /**
+     * The display name for the peer Autonomous Container Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousContainerDatabaseDisplayName")
+    String peerAutonomousContainerDatabaseDisplayName;
+    /**
+     * The protection mode of this Autonomous Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    public enum ProtectionMode {
+        MaximumAvailability("MAXIMUM_AVAILABILITY"),
+        MaximumPerformance("MAXIMUM_PERFORMANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ProtectionMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ProtectionMode v : ProtectionMode.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ProtectionMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ProtectionMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ProtectionMode: " + key);
+        }
+    };
+    /**
+     * The protection mode of this Autonomous Data Guard association. For more information, see
+     * [Oracle Data Guard Protection Modes](http://docs.oracle.com/database/122/SBYDB/oracle-data-guard-protection-modes.htm#SBYDB02000)
+     * in the Oracle Data Guard documentation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
+    ProtectionMode protectionMode;
 
     /**
      * The OCID of the Autonomous VM Cluster.
@@ -321,6 +429,14 @@ public class CreateAutonomousContainerDatabaseDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceWindowDetails")
     MaintenanceWindow maintenanceWindowDetails;
+
+    /**
+     * The scheduling detail for the quarterly maintenance window of the standby Autonomous Container Database.
+     * This value represents the number of days before the primary database maintenance schedule.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+    Integer standbyMaintenanceBufferInDays;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
@@ -72,13 +72,26 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerDbHomeId")
+        private String peerDbHomeId;
+
+        public Builder peerDbHomeId(String peerDbHomeId) {
+            this.peerDbHomeId = peerDbHomeId;
+            this.__explicitlySet__.add("peerDbHomeId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDataGuardAssociationToExistingDbSystemDetails build() {
             CreateDataGuardAssociationToExistingDbSystemDetails __instance__ =
                     new CreateDataGuardAssociationToExistingDbSystemDetails(
-                            databaseAdminPassword, protectionMode, transportType, peerDbSystemId);
+                            databaseAdminPassword,
+                            protectionMode,
+                            transportType,
+                            peerDbSystemId,
+                            peerDbHomeId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,7 +102,8 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
                     databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
-                            .peerDbSystemId(o.getPeerDbSystemId());
+                            .peerDbSystemId(o.getPeerDbSystemId())
+                            .peerDbHomeId(o.getPeerDbHomeId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -108,9 +122,11 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
-            String peerDbSystemId) {
+            String peerDbSystemId,
+            String peerDbHomeId) {
         super(databaseAdminPassword, protectionMode, transportType);
         this.peerDbSystemId = peerDbSystemId;
+        this.peerDbHomeId = peerDbHomeId;
     }
 
     /**
@@ -120,6 +136,14 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerDbSystemId")
     String peerDbSystemId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB home in which to create the standby database.
+     * You must supply this value to create standby database with an existing DB home
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerDbHomeId")
+    String peerDbHomeId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
@@ -70,13 +70,26 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerDbHomeId")
+        private String peerDbHomeId;
+
+        public Builder peerDbHomeId(String peerDbHomeId) {
+            this.peerDbHomeId = peerDbHomeId;
+            this.__explicitlySet__.add("peerDbHomeId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDataGuardAssociationToExistingVmClusterDetails build() {
             CreateDataGuardAssociationToExistingVmClusterDetails __instance__ =
                     new CreateDataGuardAssociationToExistingVmClusterDetails(
-                            databaseAdminPassword, protectionMode, transportType, peerVmClusterId);
+                            databaseAdminPassword,
+                            protectionMode,
+                            transportType,
+                            peerVmClusterId,
+                            peerDbHomeId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -87,7 +100,8 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
                     databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
-                            .peerVmClusterId(o.getPeerVmClusterId());
+                            .peerVmClusterId(o.getPeerVmClusterId())
+                            .peerDbHomeId(o.getPeerDbHomeId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -106,9 +120,11 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
-            String peerVmClusterId) {
+            String peerVmClusterId,
+            String peerDbHomeId) {
         super(databaseAdminPassword, protectionMode, transportType);
         this.peerVmClusterId = peerVmClusterId;
+        this.peerDbHomeId = peerDbHomeId;
     }
 
     /**
@@ -118,6 +134,14 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerVmClusterId")
     String peerVmClusterId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the DB home in which to create the standby database.
+     * You must supply this value to create standby database with an existing DB home
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerDbHomeId")
+    String peerDbHomeId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRun.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRun.java
@@ -151,6 +151,15 @@ public class MaintenanceRun {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerMaintenanceRunId")
+        private String peerMaintenanceRunId;
+
+        public Builder peerMaintenanceRunId(String peerMaintenanceRunId) {
+            this.peerMaintenanceRunId = peerMaintenanceRunId;
+            this.__explicitlySet__.add("peerMaintenanceRunId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -170,7 +179,8 @@ public class MaintenanceRun {
                             targetResourceId,
                             maintenanceType,
                             patchId,
-                            maintenanceSubtype);
+                            maintenanceSubtype,
+                            peerMaintenanceRunId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -191,7 +201,8 @@ public class MaintenanceRun {
                             .targetResourceId(o.getTargetResourceId())
                             .maintenanceType(o.getMaintenanceType())
                             .patchId(o.getPatchId())
-                            .maintenanceSubtype(o.getMaintenanceSubtype());
+                            .maintenanceSubtype(o.getMaintenanceSubtype())
+                            .peerMaintenanceRunId(o.getPeerMaintenanceRunId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -477,6 +488,12 @@ public class MaintenanceRun {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceSubtype")
     MaintenanceSubtype maintenanceSubtype;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the maintenance run for the Autonomous Data Guard association's peer container database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerMaintenanceRunId")
+    String peerMaintenanceRunId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRunSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRunSummary.java
@@ -153,6 +153,15 @@ public class MaintenanceRunSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerMaintenanceRunId")
+        private String peerMaintenanceRunId;
+
+        public Builder peerMaintenanceRunId(String peerMaintenanceRunId) {
+            this.peerMaintenanceRunId = peerMaintenanceRunId;
+            this.__explicitlySet__.add("peerMaintenanceRunId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -172,7 +181,8 @@ public class MaintenanceRunSummary {
                             targetResourceId,
                             maintenanceType,
                             patchId,
-                            maintenanceSubtype);
+                            maintenanceSubtype,
+                            peerMaintenanceRunId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -193,7 +203,8 @@ public class MaintenanceRunSummary {
                             .targetResourceId(o.getTargetResourceId())
                             .maintenanceType(o.getMaintenanceType())
                             .patchId(o.getPatchId())
-                            .maintenanceSubtype(o.getMaintenanceSubtype());
+                            .maintenanceSubtype(o.getMaintenanceSubtype())
+                            .peerMaintenanceRunId(o.getPeerMaintenanceRunId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -479,6 +490,12 @@ public class MaintenanceRunSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceSubtype")
     MaintenanceSubtype maintenanceSubtype;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the maintenance run for the Autonomous Data Guard association's peer container database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerMaintenanceRunId")
+    String peerMaintenanceRunId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Update.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Update.java
@@ -269,6 +269,7 @@ public class Update {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
 
         /**

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousContainerDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousContainerDatabaseDetails.java
@@ -54,6 +54,15 @@ public class UpdateAutonomousContainerDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+        private Integer standbyMaintenanceBufferInDays;
+
+        public Builder standbyMaintenanceBufferInDays(Integer standbyMaintenanceBufferInDays) {
+            this.standbyMaintenanceBufferInDays = standbyMaintenanceBufferInDays;
+            this.__explicitlySet__.add("standbyMaintenanceBufferInDays");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -91,6 +100,7 @@ public class UpdateAutonomousContainerDatabaseDetails {
                             displayName,
                             patchModel,
                             maintenanceWindowDetails,
+                            standbyMaintenanceBufferInDays,
                             freeformTags,
                             definedTags,
                             backupConfig);
@@ -104,6 +114,7 @@ public class UpdateAutonomousContainerDatabaseDetails {
                     displayName(o.getDisplayName())
                             .patchModel(o.getPatchModel())
                             .maintenanceWindowDetails(o.getMaintenanceWindowDetails())
+                            .standbyMaintenanceBufferInDays(o.getStandbyMaintenanceBufferInDays())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .backupConfig(o.getBackupConfig());
@@ -168,6 +179,14 @@ public class UpdateAutonomousContainerDatabaseDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("maintenanceWindowDetails")
     MaintenanceWindow maintenanceWindowDetails;
+
+    /**
+     * The scheduling detail for the quarterly maintenance window of the standby Autonomous Container Database.
+     * This value represents the number of days before the primary database maintenance schedule.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("standbyMaintenanceBufferInDays")
+    Integer standbyMaintenanceBufferInDays;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateHistoryEntry.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateHistoryEntry.java
@@ -208,6 +208,7 @@ public class UpdateHistoryEntry {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
 
         /**

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateHistoryEntrySummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateHistoryEntrySummary.java
@@ -208,6 +208,7 @@ public class UpdateHistoryEntrySummary {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
 
         /**

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateSummary.java
@@ -274,6 +274,7 @@ public class UpdateSummary {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
 
         /**

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/FailoverAutonomousContainerDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/FailoverAutonomousContainerDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class FailoverAutonomousContainerDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseDataguardAssociationId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    FailoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(FailoverAutonomousContainerDatabaseDataguardAssociationRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            autonomousContainerDatabaseDataguardAssociationId(
+                    o.getAutonomousContainerDatabaseDataguardAssociationId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of FailoverAutonomousContainerDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of FailoverAutonomousContainerDatabaseDataguardAssociationRequest
+         */
+        public FailoverAutonomousContainerDatabaseDataguardAssociationRequest build() {
+            FailoverAutonomousContainerDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetAutonomousContainerDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetAutonomousContainerDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetAutonomousContainerDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseDataguardAssociationId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAutonomousContainerDatabaseDataguardAssociationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutonomousContainerDatabaseDataguardAssociationRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            autonomousContainerDatabaseDataguardAssociationId(
+                    o.getAutonomousContainerDatabaseDataguardAssociationId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAutonomousContainerDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAutonomousContainerDatabaseDataguardAssociationRequest
+         */
+        public GetAutonomousContainerDatabaseDataguardAssociationRequest build() {
+            GetAutonomousContainerDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetAutonomousDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetAutonomousDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetAutonomousDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousDatabaseDataguardAssociationId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAutonomousDatabaseDataguardAssociationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutonomousDatabaseDataguardAssociationRequest o) {
+            autonomousDatabaseId(o.getAutonomousDatabaseId());
+            autonomousDatabaseDataguardAssociationId(
+                    o.getAutonomousDatabaseDataguardAssociationId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAutonomousDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAutonomousDatabaseDataguardAssociationRequest
+         */
+        public GetAutonomousDatabaseDataguardAssociationRequest build() {
+            GetAutonomousDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousContainerDatabaseDataguardAssociationsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousContainerDatabaseDataguardAssociationsRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListAutonomousContainerDatabaseDataguardAssociationsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAutonomousContainerDatabaseDataguardAssociationsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousContainerDatabaseDataguardAssociationsRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAutonomousContainerDatabaseDataguardAssociationsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAutonomousContainerDatabaseDataguardAssociationsRequest
+         */
+        public ListAutonomousContainerDatabaseDataguardAssociationsRequest build() {
+            ListAutonomousContainerDatabaseDataguardAssociationsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousContainerDatabasesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousContainerDatabasesRequest.java
@@ -143,6 +143,11 @@ public class ListAutonomousContainerDatabasesRequest
      */
     private String displayName;
 
+    /**
+     * A filter to return only resources that match the given service-level agreement type exactly.
+     */
+    private String serviceLevelAgreementType;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListAutonomousContainerDatabasesRequest, java.lang.Void> {
@@ -189,6 +194,7 @@ public class ListAutonomousContainerDatabasesRequest
             lifecycleState(o.getLifecycleState());
             availabilityDomain(o.getAvailabilityDomain());
             displayName(o.getDisplayName());
+            serviceLevelAgreementType(o.getServiceLevelAgreementType());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousDatabaseDataguardAssociationsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListAutonomousDatabaseDataguardAssociationsRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListAutonomousDatabaseDataguardAssociationsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousDatabaseId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAutonomousDatabaseDataguardAssociationsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousDatabaseDataguardAssociationsRequest o) {
+            autonomousDatabaseId(o.getAutonomousDatabaseId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAutonomousDatabaseDataguardAssociationsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAutonomousDatabaseDataguardAssociationsRequest
+         */
+        public ListAutonomousDatabaseDataguardAssociationsRequest build() {
+            ListAutonomousDatabaseDataguardAssociationsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListCloudVmClusterUpdateHistoryEntriesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListCloudVmClusterUpdateHistoryEntriesRequest.java
@@ -26,6 +26,7 @@ public class ListCloudVmClusterUpdateHistoryEntriesRequest
      * A filter to return only resources that match the given update type exactly.
      **/
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
         ;
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListCloudVmClusterUpdatesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListCloudVmClusterUpdatesRequest.java
@@ -26,6 +26,7 @@ public class ListCloudVmClusterUpdatesRequest
      * A filter to return only resources that match the given update type exactly.
      **/
     public enum UpdateType {
+        GiUpgrade("GI_UPGRADE"),
         GiPatch("GI_PATCH"),
         ;
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbHomesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbHomesRequest.java
@@ -32,6 +32,11 @@ public class ListDbHomesRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String backupId;
 
     /**
+     * A filter to return only DB Homes that match the specified dbVersion.
+     */
+    private String dbVersion;
+
+    /**
      * The maximum number of items to return per page.
      */
     private Integer limit;
@@ -170,6 +175,7 @@ public class ListDbHomesRequest extends com.oracle.bmc.requests.BmcRequest<java.
             dbSystemId(o.getDbSystemId());
             vmClusterId(o.getVmClusterId());
             backupId(o.getBackupId());
+            dbVersion(o.getDbVersion());
             limit(o.getLimit());
             page(o.getPage());
             sortBy(o.getSortBy());

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ReinstateAutonomousContainerDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ReinstateAutonomousContainerDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ReinstateAutonomousContainerDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseDataguardAssociationId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ReinstateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ReinstateAutonomousContainerDatabaseDataguardAssociationRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            autonomousContainerDatabaseDataguardAssociationId(
+                    o.getAutonomousContainerDatabaseDataguardAssociationId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ReinstateAutonomousContainerDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ReinstateAutonomousContainerDatabaseDataguardAssociationRequest
+         */
+        public ReinstateAutonomousContainerDatabaseDataguardAssociationRequest build() {
+            ReinstateAutonomousContainerDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseDataguardAssociationId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest,
+                    java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            autonomousContainerDatabaseDataguardAssociationId(
+                    o.getAutonomousContainerDatabaseDataguardAssociationId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest
+         */
+        public SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest build() {
+            SwitchoverAutonomousContainerDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/FailoverAutonomousContainerDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/FailoverAutonomousContainerDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class FailoverAutonomousContainerDatabaseDataguardAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AutonomousContainerDatabaseDataguardAssociation instance.
+     */
+    private AutonomousContainerDatabaseDataguardAssociation
+            autonomousContainerDatabaseDataguardAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(FailoverAutonomousContainerDatabaseDataguardAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            autonomousContainerDatabaseDataguardAssociation(
+                    o.getAutonomousContainerDatabaseDataguardAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetAutonomousContainerDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetAutonomousContainerDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetAutonomousContainerDatabaseDataguardAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AutonomousContainerDatabaseDataguardAssociation instance.
+     */
+    private AutonomousContainerDatabaseDataguardAssociation
+            autonomousContainerDatabaseDataguardAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutonomousContainerDatabaseDataguardAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            autonomousContainerDatabaseDataguardAssociation(
+                    o.getAutonomousContainerDatabaseDataguardAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetAutonomousDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetAutonomousDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetAutonomousDatabaseDataguardAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AutonomousDatabaseDataguardAssociation instance.
+     */
+    private AutonomousDatabaseDataguardAssociation autonomousDatabaseDataguardAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutonomousDatabaseDataguardAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            autonomousDatabaseDataguardAssociation(o.getAutonomousDatabaseDataguardAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousContainerDatabaseDataguardAssociationsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousContainerDatabaseDataguardAssociationsResponse.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListAutonomousContainerDatabaseDataguardAssociationsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of AutonomousContainerDatabaseDataguardAssociation instances.
+     */
+    private java.util.List<AutonomousContainerDatabaseDataguardAssociation> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousContainerDatabaseDataguardAssociationsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousDatabaseDataguardAssociationsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListAutonomousDatabaseDataguardAssociationsResponse.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListAutonomousDatabaseDataguardAssociationsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the `page` parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of AutonomousDatabaseDataguardAssociation instances.
+     */
+    private java.util.List<AutonomousDatabaseDataguardAssociation> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAutonomousDatabaseDataguardAssociationsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ReinstateAutonomousContainerDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ReinstateAutonomousContainerDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ReinstateAutonomousContainerDatabaseDataguardAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AutonomousContainerDatabaseDataguardAssociation instance.
+     */
+    private AutonomousContainerDatabaseDataguardAssociation
+            autonomousContainerDatabaseDataguardAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ReinstateAutonomousContainerDatabaseDataguardAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            autonomousContainerDatabaseDataguardAssociation(
+                    o.getAutonomousContainerDatabaseDataguardAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AutonomousContainerDatabaseDataguardAssociation instance.
+     */
+    private AutonomousContainerDatabaseDataguardAssociation
+            autonomousContainerDatabaseDataguardAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SwitchoverAutonomousContainerDatabaseDataguardAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            autonomousContainerDatabaseDataguardAssociation(
+                    o.getAutonomousContainerDatabaseDataguardAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalog.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalog.java
@@ -46,6 +46,22 @@ public interface DataCatalog extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Add data selector pattern to the data asset.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AddDataSelectorPatternsResponse addDataSelectorPatterns(AddDataSelectorPatternsRequest request);
+
+    /**
+     * Associate the custom property for the given type
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AssociateCustomPropertyResponse associateCustomProperty(AssociateCustomPropertyRequest request);
+
+    /**
      * Attaches a private reverse connection endpoint resource to a data catalog resource. When provided, 'If-Match' is checked against 'ETag' values of the resource.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -114,6 +130,14 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     CreateConnectionResponse createConnection(CreateConnectionRequest request);
+
+    /**
+     * Create a new Custom Property
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateCustomPropertyResponse createCustomProperty(CreateCustomPropertyRequest request);
 
     /**
      * Create a new data asset.
@@ -196,6 +220,22 @@ public interface DataCatalog extends AutoCloseable {
     CreateJobExecutionResponse createJobExecution(CreateJobExecutionRequest request);
 
     /**
+     * Create a new Namespace to be used by a custom property
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateNamespaceResponse createNamespace(CreateNamespaceRequest request);
+
+    /**
+     * Create a new pattern.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreatePatternResponse createPattern(CreatePatternRequest request);
+
+    /**
      * Create a new term within a glossary.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -251,6 +291,14 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     DeleteConnectionResponse deleteConnection(DeleteConnectionRequest request);
+
+    /**
+     * Deletes a specific custom property identified by it's key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteCustomPropertyResponse deleteCustomProperty(DeleteCustomPropertyRequest request);
 
     /**
      * Deletes a specific data asset identified by it's key.
@@ -325,6 +373,22 @@ public interface DataCatalog extends AutoCloseable {
     DeleteJobDefinitionResponse deleteJobDefinition(DeleteJobDefinitionRequest request);
 
     /**
+     * Deletes a specific Namespace identified by it's key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteNamespaceResponse deleteNamespace(DeleteNamespaceRequest request);
+
+    /**
+     * Deletes a specific pattern identified by it's key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeletePatternResponse deletePattern(DeletePatternRequest request);
+
+    /**
      * Deletes a specific glossary term.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -348,6 +412,15 @@ public interface DataCatalog extends AutoCloseable {
      */
     DetachCatalogPrivateEndpointResponse detachCatalogPrivateEndpoint(
             DetachCatalogPrivateEndpointRequest request);
+
+    /**
+     * Remove the custom property for the given type
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DisassociateCustomPropertyResponse disassociateCustomProperty(
+            DisassociateCustomPropertyRequest request);
 
     /**
      * Returns the fully expanded tree hierarchy of parent and child terms in this glossary.
@@ -405,6 +478,14 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetConnectionResponse getConnection(GetConnectionRequest request);
+
+    /**
+     * Gets a specific custom property for the given key within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetCustomPropertyResponse getCustomProperty(GetCustomPropertyRequest request);
 
     /**
      * Gets a specific data asset for the given key within a data catalog.
@@ -503,6 +584,22 @@ public interface DataCatalog extends AutoCloseable {
     GetJobMetricsResponse getJobMetrics(GetJobMetricsRequest request);
 
     /**
+     * Gets a specific namespace for the given key within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetNamespaceResponse getNamespace(GetNamespaceRequest request);
+
+    /**
+     * Gets a specific pattern for the given key within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetPatternResponse getPattern(GetPatternRequest request);
+
+    /**
      * Gets a specific glossary term by key.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -551,6 +648,15 @@ public interface DataCatalog extends AutoCloseable {
     ImportGlossaryResponse importGlossary(ImportGlossaryRequest request);
 
     /**
+     * List the physical entities aggregated by this logical entity.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListAggregatedPhysicalEntitiesResponse listAggregatedPhysicalEntities(
+            ListAggregatedPhysicalEntitiesRequest request);
+
+    /**
      * Returns a list of all tags for an entity attribute.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -594,6 +700,14 @@ public interface DataCatalog extends AutoCloseable {
     ListConnectionsResponse listConnections(ListConnectionsRequest request);
 
     /**
+     * Returns a list of custom properties within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListCustomPropertiesResponse listCustomProperties(ListCustomPropertiesRequest request);
+
+    /**
      * Returns a list of all tags for a data asset.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -608,6 +722,15 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ListDataAssetsResponse listDataAssets(ListDataAssetsRequest request);
+
+    /**
+     * List logical entities derived from this pattern.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListDerivedLogicalEntitiesResponse listDerivedLogicalEntities(
+            ListDerivedLogicalEntitiesRequest request);
 
     /**
      * Returns a list of all entities of a data asset.
@@ -690,6 +813,22 @@ public interface DataCatalog extends AutoCloseable {
     ListJobsResponse listJobs(ListJobsRequest request);
 
     /**
+     * Returns a list of namespaces within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListNamespacesResponse listNamespaces(ListNamespacesRequest request);
+
+    /**
+     * Returns a list of patterns within a data catalog.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListPatternsResponse listPatterns(ListPatternsRequest request);
+
+    /**
      * Returns a list of all user created tags in the system.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -765,6 +904,15 @@ public interface DataCatalog extends AutoCloseable {
     ParseConnectionResponse parseConnection(ParseConnectionRequest request);
 
     /**
+     * Remove data selector pattern from the data asset.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    RemoveDataSelectorPatternsResponse removeDataSelectorPatterns(
+            RemoveDataSelectorPatternsRequest request);
+
+    /**
      * Returns a list of search results within a data catalog.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -812,6 +960,14 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     UpdateConnectionResponse updateConnection(UpdateConnectionRequest request);
+
+    /**
+     * Updates a specific custom property identified by the given key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateCustomPropertyResponse updateCustomProperty(UpdateCustomPropertyRequest request);
 
     /**
      * Updates a specific data asset identified by the given key.
@@ -862,6 +1018,22 @@ public interface DataCatalog extends AutoCloseable {
     UpdateJobDefinitionResponse updateJobDefinition(UpdateJobDefinitionRequest request);
 
     /**
+     * Updates a specific namespace identified by the given key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateNamespaceResponse updateNamespace(UpdateNamespaceRequest request);
+
+    /**
+     * Updates a specific pattern identified by the given key.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdatePatternResponse updatePattern(UpdatePatternRequest request);
+
+    /**
      * Updates a specific glossary term.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -900,6 +1072,14 @@ public interface DataCatalog extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     ValidateConnectionResponse validateConnection(ValidateConnectionRequest request);
+
+    /**
+     * Validate pattern by deriving file groups representing logical entities using the expression
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ValidatePatternResponse validatePattern(ValidatePatternRequest request);
 
     /**
      * Gets the pre-configured waiters available for resources for this service.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsync.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsync.java
@@ -46,6 +46,38 @@ public interface DataCatalogAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Add data selector pattern to the data asset.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AddDataSelectorPatternsResponse> addDataSelectorPatterns(
+            AddDataSelectorPatternsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            AddDataSelectorPatternsRequest, AddDataSelectorPatternsResponse>
+                    handler);
+
+    /**
+     * Associate the custom property for the given type
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AssociateCustomPropertyResponse> associateCustomProperty(
+            AssociateCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            AssociateCustomPropertyRequest, AssociateCustomPropertyResponse>
+                    handler);
+
+    /**
      * Attaches a private reverse connection endpoint resource to a data catalog resource. When provided, 'If-Match' is checked against 'ETag' values of the resource.
      *
      * @param request The request object containing the details to send
@@ -174,6 +206,22 @@ public interface DataCatalogAsync extends AutoCloseable {
     java.util.concurrent.Future<CreateConnectionResponse> createConnection(
             CreateConnectionRequest request,
             com.oracle.bmc.responses.AsyncHandler<CreateConnectionRequest, CreateConnectionResponse>
+                    handler);
+
+    /**
+     * Create a new Custom Property
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateCustomPropertyResponse> createCustomProperty(
+            CreateCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateCustomPropertyRequest, CreateCustomPropertyResponse>
                     handler);
 
     /**
@@ -329,6 +377,36 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Create a new Namespace to be used by a custom property
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateNamespaceResponse> createNamespace(
+            CreateNamespaceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateNamespaceRequest, CreateNamespaceResponse>
+                    handler);
+
+    /**
+     * Create a new pattern.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreatePatternResponse> createPattern(
+            CreatePatternRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreatePatternRequest, CreatePatternResponse>
+                    handler);
+
+    /**
      * Create a new term within a glossary.
      *
      * @param request The request object containing the details to send
@@ -434,6 +512,22 @@ public interface DataCatalogAsync extends AutoCloseable {
     java.util.concurrent.Future<DeleteConnectionResponse> deleteConnection(
             DeleteConnectionRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeleteConnectionRequest, DeleteConnectionResponse>
+                    handler);
+
+    /**
+     * Deletes a specific custom property identified by it's key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteCustomPropertyResponse> deleteCustomProperty(
+            DeleteCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteCustomPropertyRequest, DeleteCustomPropertyResponse>
                     handler);
 
     /**
@@ -573,6 +667,36 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes a specific Namespace identified by it's key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteNamespaceResponse> deleteNamespace(
+            DeleteNamespaceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteNamespaceRequest, DeleteNamespaceResponse>
+                    handler);
+
+    /**
+     * Deletes a specific pattern identified by it's key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeletePatternResponse> deletePattern(
+            DeletePatternRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeletePatternRequest, DeletePatternResponse>
+                    handler);
+
+    /**
      * Deletes a specific glossary term.
      *
      * @param request The request object containing the details to send
@@ -617,6 +741,22 @@ public interface DataCatalogAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             DetachCatalogPrivateEndpointRequest,
                             DetachCatalogPrivateEndpointResponse>
+                    handler);
+
+    /**
+     * Remove the custom property for the given type
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DisassociateCustomPropertyResponse> disassociateCustomProperty(
+            DisassociateCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DisassociateCustomPropertyRequest, DisassociateCustomPropertyResponse>
                     handler);
 
     /**
@@ -723,6 +863,22 @@ public interface DataCatalogAsync extends AutoCloseable {
     java.util.concurrent.Future<GetConnectionResponse> getConnection(
             GetConnectionRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetConnectionRequest, GetConnectionResponse>
+                    handler);
+
+    /**
+     * Gets a specific custom property for the given key within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetCustomPropertyResponse> getCustomProperty(
+            GetCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetCustomPropertyRequest, GetCustomPropertyResponse>
                     handler);
 
     /**
@@ -901,6 +1057,35 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets a specific namespace for the given key within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetNamespaceResponse> getNamespace(
+            GetNamespaceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetNamespaceRequest, GetNamespaceResponse>
+                    handler);
+
+    /**
+     * Gets a specific pattern for the given key within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetPatternResponse> getPattern(
+            GetPatternRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetPatternRequest, GetPatternResponse> handler);
+
+    /**
      * Gets a specific glossary term by key.
      *
      * @param request The request object containing the details to send
@@ -990,6 +1175,24 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * List the physical entities aggregated by this logical entity.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAggregatedPhysicalEntitiesResponse>
+            listAggregatedPhysicalEntities(
+                    ListAggregatedPhysicalEntitiesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListAggregatedPhysicalEntitiesRequest,
+                                    ListAggregatedPhysicalEntitiesResponse>
+                            handler);
+
+    /**
      * Returns a list of all tags for an entity attribute.
      *
      * @param request The request object containing the details to send
@@ -1069,6 +1272,22 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Returns a list of custom properties within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListCustomPropertiesResponse> listCustomProperties(
+            ListCustomPropertiesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListCustomPropertiesRequest, ListCustomPropertiesResponse>
+                    handler);
+
+    /**
      * Returns a list of all tags for a data asset.
      *
      * @param request The request object containing the details to send
@@ -1097,6 +1316,22 @@ public interface DataCatalogAsync extends AutoCloseable {
     java.util.concurrent.Future<ListDataAssetsResponse> listDataAssets(
             ListDataAssetsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListDataAssetsRequest, ListDataAssetsResponse>
+                    handler);
+
+    /**
+     * List logical entities derived from this pattern.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDerivedLogicalEntitiesResponse> listDerivedLogicalEntities(
+            ListDerivedLogicalEntitiesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListDerivedLogicalEntitiesRequest, ListDerivedLogicalEntitiesResponse>
                     handler);
 
     /**
@@ -1249,6 +1484,36 @@ public interface DataCatalogAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListJobsRequest, ListJobsResponse> handler);
 
     /**
+     * Returns a list of namespaces within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListNamespacesResponse> listNamespaces(
+            ListNamespacesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListNamespacesRequest, ListNamespacesResponse>
+                    handler);
+
+    /**
+     * Returns a list of patterns within a data catalog.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListPatternsResponse> listPatterns(
+            ListPatternsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListPatternsRequest, ListPatternsResponse>
+                    handler);
+
+    /**
      * Returns a list of all user created tags in the system.
      *
      * @param request The request object containing the details to send
@@ -1386,6 +1651,22 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Remove data selector pattern from the data asset.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveDataSelectorPatternsResponse> removeDataSelectorPatterns(
+            RemoveDataSelectorPatternsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RemoveDataSelectorPatternsRequest, RemoveDataSelectorPatternsResponse>
+                    handler);
+
+    /**
      * Returns a list of search results within a data catalog.
      *
      * @param request The request object containing the details to send
@@ -1475,6 +1756,22 @@ public interface DataCatalogAsync extends AutoCloseable {
     java.util.concurrent.Future<UpdateConnectionResponse> updateConnection(
             UpdateConnectionRequest request,
             com.oracle.bmc.responses.AsyncHandler<UpdateConnectionRequest, UpdateConnectionResponse>
+                    handler);
+
+    /**
+     * Updates a specific custom property identified by the given key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateCustomPropertyResponse> updateCustomProperty(
+            UpdateCustomPropertyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateCustomPropertyRequest, UpdateCustomPropertyResponse>
                     handler);
 
     /**
@@ -1568,6 +1865,36 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Updates a specific namespace identified by the given key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateNamespaceResponse> updateNamespace(
+            UpdateNamespaceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateNamespaceRequest, UpdateNamespaceResponse>
+                    handler);
+
+    /**
+     * Updates a specific pattern identified by the given key.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdatePatternResponse> updatePattern(
+            UpdatePatternRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdatePatternRequest, UpdatePatternResponse>
+                    handler);
+
+    /**
      * Updates a specific glossary term.
      *
      * @param request The request object containing the details to send
@@ -1641,5 +1968,20 @@ public interface DataCatalogAsync extends AutoCloseable {
             ValidateConnectionRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ValidateConnectionRequest, ValidateConnectionResponse>
+                    handler);
+
+    /**
+     * Validate pattern by deriving file groups representing logical entities using the expression
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ValidatePatternResponse> validatePattern(
+            ValidatePatternRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ValidatePatternRequest, ValidatePatternResponse>
                     handler);
 }

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsyncClient.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsyncClient.java
@@ -324,6 +324,188 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AddDataSelectorPatternsResponse> addDataSelectorPatterns(
+            final AddDataSelectorPatternsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            AddDataSelectorPatternsRequest, AddDataSelectorPatternsResponse>
+                    handler) {
+        LOG.trace("Called async addDataSelectorPatterns");
+        final AddDataSelectorPatternsRequest interceptedRequest =
+                AddDataSelectorPatternsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddDataSelectorPatternsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AddDataSelectorPatternsResponse>
+                transformer = AddDataSelectorPatternsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AddDataSelectorPatternsRequest, AddDataSelectorPatternsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            AddDataSelectorPatternsRequest, AddDataSelectorPatternsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getDataSelectorPatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getDataSelectorPatternDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, AddDataSelectorPatternsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getDataSelectorPatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<AssociateCustomPropertyResponse> associateCustomProperty(
+            final AssociateCustomPropertyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            AssociateCustomPropertyRequest, AssociateCustomPropertyResponse>
+                    handler) {
+        LOG.trace("Called async associateCustomProperty");
+        final AssociateCustomPropertyRequest interceptedRequest =
+                AssociateCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AssociateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AssociateCustomPropertyResponse>
+                transformer = AssociateCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AssociateCustomPropertyRequest, AssociateCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            AssociateCustomPropertyRequest, AssociateCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getAssociateCustomPropertyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getAssociateCustomPropertyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, AssociateCustomPropertyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getAssociateCustomPropertyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<AttachCatalogPrivateEndpointResponse>
             attachCatalogPrivateEndpoint(
                     final AttachCatalogPrivateEndpointRequest request,
@@ -1044,6 +1226,97 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getCreateConnectionDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateCustomPropertyResponse> createCustomProperty(
+            final CreateCustomPropertyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateCustomPropertyRequest, CreateCustomPropertyResponse>
+                    handler) {
+        LOG.trace("Called async createCustomProperty");
+        final CreateCustomPropertyRequest interceptedRequest =
+                CreateCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateCustomPropertyResponse>
+                transformer = CreateCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateCustomPropertyRequest, CreateCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateCustomPropertyRequest, CreateCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateCustomPropertyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateCustomPropertyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateCustomPropertyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateCustomPropertyDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -1944,6 +2217,183 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateNamespaceResponse> createNamespace(
+            final CreateNamespaceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateNamespaceRequest, CreateNamespaceResponse>
+                    handler) {
+        LOG.trace("Called async createNamespace");
+        final CreateNamespaceRequest interceptedRequest =
+                CreateNamespaceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateNamespaceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateNamespaceResponse>
+                transformer = CreateNamespaceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreateNamespaceRequest, CreateNamespaceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreateNamespaceRequest, CreateNamespaceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreateNamespaceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreateNamespaceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreateNamespaceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreateNamespaceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreatePatternResponse> createPattern(
+            final CreatePatternRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreatePatternRequest, CreatePatternResponse>
+                    handler) {
+        LOG.trace("Called async createPattern");
+        final CreatePatternRequest interceptedRequest =
+                CreatePatternConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePatternConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreatePatternResponse>
+                transformer = CreatePatternConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<CreatePatternRequest, CreatePatternResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            CreatePatternRequest, CreatePatternResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getCreatePatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getCreatePatternDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, CreatePatternResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getCreatePatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateTermResponse> createTerm(
             final CreateTermRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateTermRequest, CreateTermResponse>
@@ -2478,6 +2928,82 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, DeleteConnectionResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteCustomPropertyResponse> deleteCustomProperty(
+            final DeleteCustomPropertyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteCustomPropertyRequest, DeleteCustomPropertyResponse>
+                    handler) {
+        LOG.trace("Called async deleteCustomProperty");
+        final DeleteCustomPropertyRequest interceptedRequest =
+                DeleteCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteCustomPropertyResponse>
+                transformer = DeleteCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteCustomPropertyRequest, DeleteCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteCustomPropertyRequest, DeleteCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteCustomPropertyResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -3160,6 +3686,153 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteNamespaceResponse> deleteNamespace(
+            final DeleteNamespaceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteNamespaceRequest, DeleteNamespaceResponse>
+                    handler) {
+        LOG.trace("Called async deleteNamespace");
+        final DeleteNamespaceRequest interceptedRequest =
+                DeleteNamespaceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteNamespaceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteNamespaceResponse>
+                transformer = DeleteNamespaceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteNamespaceRequest, DeleteNamespaceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeleteNamespaceRequest, DeleteNamespaceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeleteNamespaceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeletePatternResponse> deletePattern(
+            final DeletePatternRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeletePatternRequest, DeletePatternResponse>
+                    handler) {
+        LOG.trace("Called async deletePattern");
+        final DeletePatternRequest interceptedRequest =
+                DeletePatternConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePatternConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeletePatternResponse>
+                transformer = DeletePatternConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeletePatternRequest, DeletePatternResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DeletePatternRequest, DeletePatternResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.delete(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DeletePatternResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.delete(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteTermResponse> deleteTerm(
             final DeleteTermRequest request,
             final com.oracle.bmc.responses.AsyncHandler<DeleteTermRequest, DeleteTermResponse>
@@ -3390,6 +4063,99 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getDetachCatalogPrivateEndpointDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DisassociateCustomPropertyResponse>
+            disassociateCustomProperty(
+                    final DisassociateCustomPropertyRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DisassociateCustomPropertyRequest,
+                                    DisassociateCustomPropertyResponse>
+                            handler) {
+        LOG.trace("Called async disassociateCustomProperty");
+        final DisassociateCustomPropertyRequest interceptedRequest =
+                DisassociateCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisassociateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DisassociateCustomPropertyResponse>
+                transformer = DisassociateCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DisassociateCustomPropertyRequest, DisassociateCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            DisassociateCustomPropertyRequest, DisassociateCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getDisassociateCustomPropertyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getDisassociateCustomPropertyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, DisassociateCustomPropertyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getDisassociateCustomPropertyDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -3902,6 +4668,80 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
                     javax.ws.rs.core.Response, GetConnectionResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetCustomPropertyResponse> getCustomProperty(
+            final GetCustomPropertyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetCustomPropertyRequest, GetCustomPropertyResponse>
+                    handler) {
+        LOG.trace("Called async getCustomProperty");
+        final GetCustomPropertyRequest interceptedRequest =
+                GetCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetCustomPropertyResponse>
+                transformer = GetCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetCustomPropertyRequest, GetCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetCustomPropertyRequest, GetCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetCustomPropertyResponse>(
                     responseFuture,
                     transformer,
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
@@ -4793,6 +5633,151 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetNamespaceResponse> getNamespace(
+            final GetNamespaceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetNamespaceRequest, GetNamespaceResponse>
+                    handler) {
+        LOG.trace("Called async getNamespace");
+        final GetNamespaceRequest interceptedRequest =
+                GetNamespaceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetNamespaceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetNamespaceResponse>
+                transformer = GetNamespaceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetNamespaceRequest, GetNamespaceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetNamespaceRequest, GetNamespaceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetNamespaceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetPatternResponse> getPattern(
+            final GetPatternRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetPatternRequest, GetPatternResponse>
+                    handler) {
+        LOG.trace("Called async getPattern");
+        final GetPatternRequest interceptedRequest = GetPatternConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPatternConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetPatternResponse>
+                transformer = GetPatternConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetPatternRequest, GetPatternResponse> handlerToUse =
+                handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            GetPatternRequest, GetPatternResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, GetPatternResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetTermResponse> getTerm(
             final GetTermRequest request,
             final com.oracle.bmc.responses.AsyncHandler<GetTermRequest, GetTermResponse> handler) {
@@ -5263,6 +6248,86 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListAggregatedPhysicalEntitiesResponse>
+            listAggregatedPhysicalEntities(
+                    final ListAggregatedPhysicalEntitiesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListAggregatedPhysicalEntitiesRequest,
+                                    ListAggregatedPhysicalEntitiesResponse>
+                            handler) {
+        LOG.trace("Called async listAggregatedPhysicalEntities");
+        final ListAggregatedPhysicalEntitiesRequest interceptedRequest =
+                ListAggregatedPhysicalEntitiesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAggregatedPhysicalEntitiesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAggregatedPhysicalEntitiesResponse>
+                transformer = ListAggregatedPhysicalEntitiesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListAggregatedPhysicalEntitiesRequest,
+                        ListAggregatedPhysicalEntitiesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListAggregatedPhysicalEntitiesRequest,
+                            ListAggregatedPhysicalEntitiesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListAggregatedPhysicalEntitiesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListAttributeTagsResponse> listAttributeTags(
             final ListAttributeTagsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -5637,6 +6702,82 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListCustomPropertiesResponse> listCustomProperties(
+            final ListCustomPropertiesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListCustomPropertiesRequest, ListCustomPropertiesResponse>
+                    handler) {
+        LOG.trace("Called async listCustomProperties");
+        final ListCustomPropertiesRequest interceptedRequest =
+                ListCustomPropertiesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListCustomPropertiesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListCustomPropertiesResponse>
+                transformer = ListCustomPropertiesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListCustomPropertiesRequest, ListCustomPropertiesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListCustomPropertiesRequest, ListCustomPropertiesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListCustomPropertiesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListDataAssetTagsResponse> listDataAssetTags(
             final ListDataAssetTagsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -5776,6 +6917,84 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                         @Override
                         public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
                             return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListDerivedLogicalEntitiesResponse>
+            listDerivedLogicalEntities(
+                    final ListDerivedLogicalEntitiesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListDerivedLogicalEntitiesRequest,
+                                    ListDerivedLogicalEntitiesResponse>
+                            handler) {
+        LOG.trace("Called async listDerivedLogicalEntities");
+        final ListDerivedLogicalEntitiesRequest interceptedRequest =
+                ListDerivedLogicalEntitiesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDerivedLogicalEntitiesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDerivedLogicalEntitiesResponse>
+                transformer = ListDerivedLogicalEntitiesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListDerivedLogicalEntitiesRequest, ListDerivedLogicalEntitiesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListDerivedLogicalEntitiesRequest, ListDerivedLogicalEntitiesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListDerivedLogicalEntitiesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(ib, interceptedRequest, onSuccess, onError);
                         }
                     });
         } else {
@@ -6520,6 +7739,153 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListNamespacesResponse> listNamespaces(
+            final ListNamespacesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListNamespacesRequest, ListNamespacesResponse>
+                    handler) {
+        LOG.trace("Called async listNamespaces");
+        final ListNamespacesRequest interceptedRequest =
+                ListNamespacesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListNamespacesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListNamespacesResponse>
+                transformer = ListNamespacesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListNamespacesRequest, ListNamespacesResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListNamespacesRequest, ListNamespacesResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListNamespacesResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListPatternsResponse> listPatterns(
+            final ListPatternsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListPatternsRequest, ListPatternsResponse>
+                    handler) {
+        LOG.trace("Called async listPatterns");
+        final ListPatternsRequest interceptedRequest =
+                ListPatternsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPatternsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListPatternsResponse>
+                transformer = ListPatternsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListPatternsRequest, ListPatternsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ListPatternsRequest, ListPatternsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.get(ib, interceptedRequest, onSuccess, onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ListPatternsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.get(ib, interceptedRequest, onSuccess, onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListTagsResponse> listTags(
             final ListTagsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<ListTagsRequest, ListTagsResponse>
@@ -7200,6 +8566,99 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<RemoveDataSelectorPatternsResponse>
+            removeDataSelectorPatterns(
+                    final RemoveDataSelectorPatternsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    RemoveDataSelectorPatternsRequest,
+                                    RemoveDataSelectorPatternsResponse>
+                            handler) {
+        LOG.trace("Called async removeDataSelectorPatterns");
+        final RemoveDataSelectorPatternsRequest interceptedRequest =
+                RemoveDataSelectorPatternsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveDataSelectorPatternsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveDataSelectorPatternsResponse>
+                transformer = RemoveDataSelectorPatternsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RemoveDataSelectorPatternsRequest, RemoveDataSelectorPatternsResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            RemoveDataSelectorPatternsRequest, RemoveDataSelectorPatternsResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getDataSelectorPatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getDataSelectorPatternDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, RemoveDataSelectorPatternsResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getDataSelectorPatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<SearchCriteriaResponse> searchCriteria(
             final SearchCriteriaRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -7711,6 +9170,97 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                             return client.put(
                                     ib,
                                     interceptedRequest.getUpdateConnectionDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateCustomPropertyResponse> updateCustomProperty(
+            final UpdateCustomPropertyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateCustomPropertyRequest, UpdateCustomPropertyResponse>
+                    handler) {
+        LOG.trace("Called async updateCustomProperty");
+        final UpdateCustomPropertyRequest interceptedRequest =
+                UpdateCustomPropertyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateCustomPropertyResponse>
+                transformer = UpdateCustomPropertyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateCustomPropertyRequest, UpdateCustomPropertyResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateCustomPropertyRequest, UpdateCustomPropertyResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateCustomPropertyDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateCustomPropertyDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateCustomPropertyResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateCustomPropertyDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);
@@ -8255,6 +9805,183 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<UpdateNamespaceResponse> updateNamespace(
+            final UpdateNamespaceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateNamespaceRequest, UpdateNamespaceResponse>
+                    handler) {
+        LOG.trace("Called async updateNamespace");
+        final UpdateNamespaceRequest interceptedRequest =
+                UpdateNamespaceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateNamespaceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateNamespaceResponse>
+                transformer = UpdateNamespaceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateNamespaceRequest, UpdateNamespaceResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdateNamespaceRequest, UpdateNamespaceResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateNamespaceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdateNamespaceDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdateNamespaceResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdateNamespaceDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdatePatternResponse> updatePattern(
+            final UpdatePatternRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdatePatternRequest, UpdatePatternResponse>
+                    handler) {
+        LOG.trace("Called async updatePattern");
+        final UpdatePatternRequest interceptedRequest =
+                UpdatePatternConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePatternConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePatternResponse>
+                transformer = UpdatePatternConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdatePatternRequest, UpdatePatternResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            UpdatePatternRequest, UpdatePatternResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.put(
+                                    ib,
+                                    interceptedRequest.getUpdatePatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.put(
+                        ib,
+                        interceptedRequest.getUpdatePatternDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, UpdatePatternResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.put(
+                                    ib,
+                                    interceptedRequest.getUpdatePatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateTermResponse> updateTerm(
             final UpdateTermRequest request,
             final com.oracle.bmc.responses.AsyncHandler<UpdateTermRequest, UpdateTermResponse>
@@ -8669,6 +10396,95 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
                             return client.post(
                                     ib,
                                     interceptedRequest.getValidateConnectionDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    });
+        } else {
+            return new com.oracle.bmc.util.internal.TransformingFuture<>(
+                    responseFuture, transformer);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ValidatePatternResponse> validatePattern(
+            final ValidatePatternRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ValidatePatternRequest, ValidatePatternResponse>
+                    handler) {
+        LOG.trace("Called async validatePattern");
+        final ValidatePatternRequest interceptedRequest =
+                ValidatePatternConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ValidatePatternConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ValidatePatternResponse>
+                transformer = ValidatePatternConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ValidatePatternRequest, ValidatePatternResponse>
+                handlerToUse = handler;
+        if (handler != null
+                && this.authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            handlerToUse =
+                    new com.oracle.bmc.util.internal.RefreshAuthTokenWrappingAsyncHandler<
+                            ValidatePatternRequest, ValidatePatternResponse>(
+                            (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                                    this.authenticationDetailsProvider,
+                            handler) {
+                        @Override
+                        public void retryCall() {
+                            final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response>
+                                    onSuccess =
+                                            new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                                    this, transformer, interceptedRequest);
+                            final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                                    new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                            this, interceptedRequest);
+                            client.post(
+                                    ib,
+                                    interceptedRequest.getValidatePatternDetails(),
+                                    interceptedRequest,
+                                    onSuccess,
+                                    onError);
+                        }
+                    };
+        }
+
+        final com.oracle.bmc.util.internal.Consumer<javax.ws.rs.core.Response> onSuccess =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.SuccessConsumer<>(
+                                handlerToUse, transformer, interceptedRequest);
+        final com.oracle.bmc.util.internal.Consumer<Throwable> onError =
+                (handler == null)
+                        ? null
+                        : new com.oracle.bmc.http.internal.ErrorConsumer<>(
+                                handlerToUse, interceptedRequest);
+
+        java.util.concurrent.Future<javax.ws.rs.core.Response> responseFuture =
+                client.post(
+                        ib,
+                        interceptedRequest.getValidatePatternDetails(),
+                        interceptedRequest,
+                        onSuccess,
+                        onError);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenTransformingFuture<
+                    javax.ws.rs.core.Response, ValidatePatternResponse>(
+                    responseFuture,
+                    transformer,
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    new com.google.common.base.Supplier<
+                            java.util.concurrent.Future<javax.ws.rs.core.Response>>() {
+                        @Override
+                        public java.util.concurrent.Future<javax.ws.rs.core.Response> get() {
+                            return client.post(
+                                    ib,
+                                    interceptedRequest.getValidatePatternDetails(),
                                     interceptedRequest,
                                     onSuccess,
                                     onError);

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogClient.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogClient.java
@@ -440,6 +440,72 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public AddDataSelectorPatternsResponse addDataSelectorPatterns(
+            AddDataSelectorPatternsRequest request) {
+        LOG.trace("Called addDataSelectorPatterns");
+        final AddDataSelectorPatternsRequest interceptedRequest =
+                AddDataSelectorPatternsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddDataSelectorPatternsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AddDataSelectorPatternsResponse>
+                transformer = AddDataSelectorPatternsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getDataSelectorPatternDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public AssociateCustomPropertyResponse associateCustomProperty(
+            AssociateCustomPropertyRequest request) {
+        LOG.trace("Called associateCustomProperty");
+        final AssociateCustomPropertyRequest interceptedRequest =
+                AssociateCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AssociateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AssociateCustomPropertyResponse>
+                transformer = AssociateCustomPropertyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAssociateCustomPropertyDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public AttachCatalogPrivateEndpointResponse attachCatalogPrivateEndpoint(
             AttachCatalogPrivateEndpointRequest request) {
         LOG.trace("Called attachCatalogPrivateEndpoint");
@@ -700,6 +766,38 @@ public class DataCatalogClient implements DataCatalog {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getCreateConnectionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateCustomPropertyResponse createCustomProperty(CreateCustomPropertyRequest request) {
+        LOG.trace("Called createCustomProperty");
+        final CreateCustomPropertyRequest interceptedRequest =
+                CreateCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateCustomPropertyResponse>
+                transformer = CreateCustomPropertyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateCustomPropertyDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -1026,6 +1124,70 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
+        LOG.trace("Called createNamespace");
+        final CreateNamespaceRequest interceptedRequest =
+                CreateNamespaceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateNamespaceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateNamespaceResponse>
+                transformer = CreateNamespaceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateNamespaceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreatePatternResponse createPattern(CreatePatternRequest request) {
+        LOG.trace("Called createPattern");
+        final CreatePatternRequest interceptedRequest =
+                CreatePatternConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePatternConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreatePatternResponse>
+                transformer = CreatePatternConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreatePatternDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateTermResponse createTerm(CreateTermRequest request) {
         LOG.trace("Called createTerm");
         final CreateTermRequest interceptedRequest = CreateTermConverter.interceptRequest(request);
@@ -1216,6 +1378,35 @@ public class DataCatalogClient implements DataCatalog {
                 DeleteConnectionConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteConnectionResponse>
                 transformer = DeleteConnectionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteCustomPropertyResponse deleteCustomProperty(DeleteCustomPropertyRequest request) {
+        LOG.trace("Called deleteCustomProperty");
+        final DeleteCustomPropertyRequest interceptedRequest =
+                DeleteCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteCustomPropertyResponse>
+                transformer = DeleteCustomPropertyConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1497,6 +1688,64 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public DeleteNamespaceResponse deleteNamespace(DeleteNamespaceRequest request) {
+        LOG.trace("Called deleteNamespace");
+        final DeleteNamespaceRequest interceptedRequest =
+                DeleteNamespaceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteNamespaceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteNamespaceResponse>
+                transformer = DeleteNamespaceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeletePatternResponse deletePattern(DeletePatternRequest request) {
+        LOG.trace("Called deletePattern");
+        final DeletePatternRequest interceptedRequest =
+                DeletePatternConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePatternConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeletePatternResponse>
+                transformer = DeletePatternConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteTermResponse deleteTerm(DeleteTermRequest request) {
         LOG.trace("Called deleteTerm");
         final DeleteTermRequest interceptedRequest = DeleteTermConverter.interceptRequest(request);
@@ -1583,6 +1832,41 @@ public class DataCatalogClient implements DataCatalog {
                                                 ib,
                                                 retriedRequest
                                                         .getDetachCatalogPrivateEndpointDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DisassociateCustomPropertyResponse disassociateCustomProperty(
+            DisassociateCustomPropertyRequest request) {
+        LOG.trace("Called disassociateCustomProperty");
+        final DisassociateCustomPropertyRequest interceptedRequest =
+                DisassociateCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisassociateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DisassociateCustomPropertyResponse>
+                transformer = DisassociateCustomPropertyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getDisassociateCustomPropertyDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -1770,6 +2054,34 @@ public class DataCatalogClient implements DataCatalog {
                 GetConnectionConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetConnectionResponse>
                 transformer = GetConnectionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetCustomPropertyResponse getCustomProperty(GetCustomPropertyRequest request) {
+        LOG.trace("Called getCustomProperty");
+        final GetCustomPropertyRequest interceptedRequest =
+                GetCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetCustomPropertyResponse>
+                transformer = GetCustomPropertyConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2122,6 +2434,61 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public GetNamespaceResponse getNamespace(GetNamespaceRequest request) {
+        LOG.trace("Called getNamespace");
+        final GetNamespaceRequest interceptedRequest =
+                GetNamespaceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetNamespaceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetNamespaceResponse>
+                transformer = GetNamespaceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetPatternResponse getPattern(GetPatternRequest request) {
+        LOG.trace("Called getPattern");
+        final GetPatternRequest interceptedRequest = GetPatternConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPatternConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetPatternResponse> transformer =
+                GetPatternConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetTermResponse getTerm(GetTermRequest request) {
         LOG.trace("Called getTerm");
         final GetTermRequest interceptedRequest = GetTermConverter.interceptRequest(request);
@@ -2296,6 +2663,37 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public ListAggregatedPhysicalEntitiesResponse listAggregatedPhysicalEntities(
+            ListAggregatedPhysicalEntitiesRequest request) {
+        LOG.trace("Called listAggregatedPhysicalEntities");
+        final ListAggregatedPhysicalEntitiesRequest interceptedRequest =
+                ListAggregatedPhysicalEntitiesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAggregatedPhysicalEntitiesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAggregatedPhysicalEntitiesResponse>
+                transformer = ListAggregatedPhysicalEntitiesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListAttributeTagsResponse listAttributeTags(ListAttributeTagsRequest request) {
         LOG.trace("Called listAttributeTags");
         final ListAttributeTagsRequest interceptedRequest =
@@ -2438,6 +2836,34 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public ListCustomPropertiesResponse listCustomProperties(ListCustomPropertiesRequest request) {
+        LOG.trace("Called listCustomProperties");
+        final ListCustomPropertiesRequest interceptedRequest =
+                ListCustomPropertiesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListCustomPropertiesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListCustomPropertiesResponse>
+                transformer = ListCustomPropertiesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListDataAssetTagsResponse listDataAssetTags(ListDataAssetTagsRequest request) {
         LOG.trace("Called listDataAssetTags");
         final ListDataAssetTagsRequest interceptedRequest =
@@ -2488,6 +2914,37 @@ public class DataCatalogClient implements DataCatalog {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListDerivedLogicalEntitiesResponse listDerivedLogicalEntities(
+            ListDerivedLogicalEntitiesRequest request) {
+        LOG.trace("Called listDerivedLogicalEntities");
+        final ListDerivedLogicalEntitiesRequest interceptedRequest =
+                ListDerivedLogicalEntitiesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDerivedLogicalEntitiesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDerivedLogicalEntitiesResponse>
+                transformer = ListDerivedLogicalEntitiesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -2773,6 +3230,62 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public ListNamespacesResponse listNamespaces(ListNamespacesRequest request) {
+        LOG.trace("Called listNamespaces");
+        final ListNamespacesRequest interceptedRequest =
+                ListNamespacesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListNamespacesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListNamespacesResponse>
+                transformer = ListNamespacesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListPatternsResponse listPatterns(ListPatternsRequest request) {
+        LOG.trace("Called listPatterns");
+        final ListPatternsRequest interceptedRequest =
+                ListPatternsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPatternsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListPatternsResponse>
+                transformer = ListPatternsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListTagsResponse listTags(ListTagsRequest request) {
         LOG.trace("Called listTags");
         final ListTagsRequest interceptedRequest = ListTagsConverter.interceptRequest(request);
@@ -3029,6 +3542,40 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public RemoveDataSelectorPatternsResponse removeDataSelectorPatterns(
+            RemoveDataSelectorPatternsRequest request) {
+        LOG.trace("Called removeDataSelectorPatterns");
+        final RemoveDataSelectorPatternsRequest interceptedRequest =
+                RemoveDataSelectorPatternsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveDataSelectorPatternsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveDataSelectorPatternsResponse>
+                transformer = RemoveDataSelectorPatternsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getDataSelectorPatternDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public SearchCriteriaResponse searchCriteria(SearchCriteriaRequest request) {
         LOG.trace("Called searchCriteria");
         final SearchCriteriaRequest interceptedRequest =
@@ -3214,6 +3761,38 @@ public class DataCatalogClient implements DataCatalog {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateConnectionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateCustomPropertyResponse updateCustomProperty(UpdateCustomPropertyRequest request) {
+        LOG.trace("Called updateCustomProperty");
+        final UpdateCustomPropertyRequest interceptedRequest =
+                UpdateCustomPropertyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateCustomPropertyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateCustomPropertyResponse>
+                transformer = UpdateCustomPropertyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateCustomPropertyDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -3412,6 +3991,70 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public UpdateNamespaceResponse updateNamespace(UpdateNamespaceRequest request) {
+        LOG.trace("Called updateNamespace");
+        final UpdateNamespaceRequest interceptedRequest =
+                UpdateNamespaceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateNamespaceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateNamespaceResponse>
+                transformer = UpdateNamespaceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateNamespaceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdatePatternResponse updatePattern(UpdatePatternRequest request) {
+        LOG.trace("Called updatePattern");
+        final UpdatePatternRequest interceptedRequest =
+                UpdatePatternConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePatternConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePatternResponse>
+                transformer = UpdatePatternConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdatePatternDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateTermResponse updateTerm(UpdateTermRequest request) {
         LOG.trace("Called updateTerm");
         final UpdateTermRequest interceptedRequest = UpdateTermConverter.interceptRequest(request);
@@ -3561,6 +4204,38 @@ public class DataCatalogClient implements DataCatalog {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getValidateConnectionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ValidatePatternResponse validatePattern(ValidatePatternRequest request) {
+        LOG.trace("Called validatePattern");
+        final ValidatePatternRequest interceptedRequest =
+                ValidatePatternConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ValidatePatternConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ValidatePatternResponse>
+                transformer = ValidatePatternConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getValidatePatternDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogPaginators.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogPaginators.java
@@ -598,6 +598,120 @@ public class DataCatalogPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listCustomProperties operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListCustomPropertiesResponse> listCustomPropertiesResponseIterator(
+            final ListCustomPropertiesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListCustomPropertiesRequest.Builder, ListCustomPropertiesRequest,
+                ListCustomPropertiesResponse>(
+                new com.google.common.base.Supplier<ListCustomPropertiesRequest.Builder>() {
+                    @Override
+                    public ListCustomPropertiesRequest.Builder get() {
+                        return ListCustomPropertiesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListCustomPropertiesResponse, String>() {
+                    @Override
+                    public String apply(ListCustomPropertiesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListCustomPropertiesRequest.Builder>,
+                        ListCustomPropertiesRequest>() {
+                    @Override
+                    public ListCustomPropertiesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListCustomPropertiesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListCustomPropertiesRequest, ListCustomPropertiesResponse>() {
+                    @Override
+                    public ListCustomPropertiesResponse apply(ListCustomPropertiesRequest request) {
+                        return client.listCustomProperties(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datacatalog.model.CustomPropertySummary} objects
+     * contained in responses from the listCustomProperties operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datacatalog.model.CustomPropertySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datacatalog.model.CustomPropertySummary>
+            listCustomPropertiesRecordIterator(final ListCustomPropertiesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListCustomPropertiesRequest.Builder, ListCustomPropertiesRequest,
+                ListCustomPropertiesResponse,
+                com.oracle.bmc.datacatalog.model.CustomPropertySummary>(
+                new com.google.common.base.Supplier<ListCustomPropertiesRequest.Builder>() {
+                    @Override
+                    public ListCustomPropertiesRequest.Builder get() {
+                        return ListCustomPropertiesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListCustomPropertiesResponse, String>() {
+                    @Override
+                    public String apply(ListCustomPropertiesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListCustomPropertiesRequest.Builder>,
+                        ListCustomPropertiesRequest>() {
+                    @Override
+                    public ListCustomPropertiesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListCustomPropertiesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListCustomPropertiesRequest, ListCustomPropertiesResponse>() {
+                    @Override
+                    public ListCustomPropertiesResponse apply(ListCustomPropertiesRequest request) {
+                        return client.listCustomProperties(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListCustomPropertiesResponse,
+                        java.util.List<com.oracle.bmc.datacatalog.model.CustomPropertySummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.datacatalog.model.CustomPropertySummary>
+                            apply(ListCustomPropertiesResponse response) {
+                        return response.getCustomPropertyCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listDataAssetTags operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -1931,6 +2045,228 @@ public class DataCatalogPaginators {
                     public java.util.List<com.oracle.bmc.datacatalog.model.JobSummary> apply(
                             ListJobsResponse response) {
                         return response.getJobCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listNamespaces operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListNamespacesResponse> listNamespacesResponseIterator(
+            final ListNamespacesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListNamespacesRequest.Builder, ListNamespacesRequest, ListNamespacesResponse>(
+                new com.google.common.base.Supplier<ListNamespacesRequest.Builder>() {
+                    @Override
+                    public ListNamespacesRequest.Builder get() {
+                        return ListNamespacesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListNamespacesResponse, String>() {
+                    @Override
+                    public String apply(ListNamespacesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListNamespacesRequest.Builder>,
+                        ListNamespacesRequest>() {
+                    @Override
+                    public ListNamespacesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListNamespacesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListNamespacesRequest, ListNamespacesResponse>() {
+                    @Override
+                    public ListNamespacesResponse apply(ListNamespacesRequest request) {
+                        return client.listNamespaces(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datacatalog.model.NamespaceSummary} objects
+     * contained in responses from the listNamespaces operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datacatalog.model.NamespaceSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datacatalog.model.NamespaceSummary> listNamespacesRecordIterator(
+            final ListNamespacesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListNamespacesRequest.Builder, ListNamespacesRequest, ListNamespacesResponse,
+                com.oracle.bmc.datacatalog.model.NamespaceSummary>(
+                new com.google.common.base.Supplier<ListNamespacesRequest.Builder>() {
+                    @Override
+                    public ListNamespacesRequest.Builder get() {
+                        return ListNamespacesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListNamespacesResponse, String>() {
+                    @Override
+                    public String apply(ListNamespacesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListNamespacesRequest.Builder>,
+                        ListNamespacesRequest>() {
+                    @Override
+                    public ListNamespacesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListNamespacesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListNamespacesRequest, ListNamespacesResponse>() {
+                    @Override
+                    public ListNamespacesResponse apply(ListNamespacesRequest request) {
+                        return client.listNamespaces(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListNamespacesResponse,
+                        java.util.List<com.oracle.bmc.datacatalog.model.NamespaceSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.datacatalog.model.NamespaceSummary> apply(
+                            ListNamespacesResponse response) {
+                        return response.getNamespaceCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listPatterns operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListPatternsResponse> listPatternsResponseIterator(
+            final ListPatternsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListPatternsRequest.Builder, ListPatternsRequest, ListPatternsResponse>(
+                new com.google.common.base.Supplier<ListPatternsRequest.Builder>() {
+                    @Override
+                    public ListPatternsRequest.Builder get() {
+                        return ListPatternsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPatternsResponse, String>() {
+                    @Override
+                    public String apply(ListPatternsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPatternsRequest.Builder>,
+                        ListPatternsRequest>() {
+                    @Override
+                    public ListPatternsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPatternsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPatternsRequest, ListPatternsResponse>() {
+                    @Override
+                    public ListPatternsResponse apply(ListPatternsRequest request) {
+                        return client.listPatterns(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datacatalog.model.PatternSummary} objects
+     * contained in responses from the listPatterns operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datacatalog.model.PatternSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datacatalog.model.PatternSummary> listPatternsRecordIterator(
+            final ListPatternsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListPatternsRequest.Builder, ListPatternsRequest, ListPatternsResponse,
+                com.oracle.bmc.datacatalog.model.PatternSummary>(
+                new com.google.common.base.Supplier<ListPatternsRequest.Builder>() {
+                    @Override
+                    public ListPatternsRequest.Builder get() {
+                        return ListPatternsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPatternsResponse, String>() {
+                    @Override
+                    public String apply(ListPatternsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPatternsRequest.Builder>,
+                        ListPatternsRequest>() {
+                    @Override
+                    public ListPatternsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPatternsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPatternsRequest, ListPatternsResponse>() {
+                    @Override
+                    public ListPatternsResponse apply(ListPatternsRequest request) {
+                        return client.listPatterns(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPatternsResponse,
+                        java.util.List<com.oracle.bmc.datacatalog.model.PatternSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.datacatalog.model.PatternSummary> apply(
+                            ListPatternsResponse response) {
+                        return response.getPatternCollection().getItems();
                     }
                 });
     }

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogWaiters.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogWaiters.java
@@ -525,6 +525,108 @@ public class DataCatalogWaiters {
      * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetCustomPropertyRequest, GetCustomPropertyResponse>
+            forCustomProperty(
+                    GetCustomPropertyRequest request,
+                    com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forCustomProperty(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetCustomPropertyRequest, GetCustomPropertyResponse>
+            forCustomProperty(
+                    GetCustomPropertyRequest request,
+                    com.oracle.bmc.datacatalog.model.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forCustomProperty(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetCustomPropertyRequest, GetCustomPropertyResponse>
+            forCustomProperty(
+                    GetCustomPropertyRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forCustomProperty(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for CustomProperty.
+    private com.oracle.bmc.waiter.Waiter<GetCustomPropertyRequest, GetCustomPropertyResponse>
+            forCustomProperty(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetCustomPropertyRequest request,
+                    final com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.datacatalog.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetCustomPropertyRequest, GetCustomPropertyResponse>() {
+                            @Override
+                            public GetCustomPropertyResponse apply(
+                                    GetCustomPropertyRequest request) {
+                                return client.getCustomProperty(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetCustomPropertyResponse>() {
+                            @Override
+                            public boolean apply(GetCustomPropertyResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getCustomProperty().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datacatalog.model.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetDataAssetRequest, GetDataAssetResponse> forDataAsset(
             GetDataAssetRequest request,
             com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
@@ -1491,6 +1593,200 @@ public class DataCatalogWaiters {
                             }
                         },
                         false),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetNamespaceRequest, GetNamespaceResponse> forNamespace(
+            GetNamespaceRequest request,
+            com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forNamespace(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetNamespaceRequest, GetNamespaceResponse> forNamespace(
+            GetNamespaceRequest request,
+            com.oracle.bmc.datacatalog.model.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forNamespace(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetNamespaceRequest, GetNamespaceResponse> forNamespace(
+            GetNamespaceRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forNamespace(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Namespace.
+    private com.oracle.bmc.waiter.Waiter<GetNamespaceRequest, GetNamespaceResponse> forNamespace(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetNamespaceRequest request,
+            final com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.datacatalog.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetNamespaceRequest, GetNamespaceResponse>() {
+                            @Override
+                            public GetNamespaceResponse apply(GetNamespaceRequest request) {
+                                return client.getNamespace(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetNamespaceResponse>() {
+                            @Override
+                            public boolean apply(GetNamespaceResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getNamespace().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datacatalog.model.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetPatternRequest, GetPatternResponse> forPattern(
+            GetPatternRequest request,
+            com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forPattern(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetPatternRequest, GetPatternResponse> forPattern(
+            GetPatternRequest request,
+            com.oracle.bmc.datacatalog.model.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forPattern(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetPatternRequest, GetPatternResponse> forPattern(
+            GetPatternRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forPattern(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Pattern.
+    private com.oracle.bmc.waiter.Waiter<GetPatternRequest, GetPatternResponse> forPattern(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetPatternRequest request,
+            final com.oracle.bmc.datacatalog.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.datacatalog.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetPatternRequest, GetPatternResponse>() {
+                            @Override
+                            public GetPatternResponse apply(GetPatternRequest request) {
+                                return client.getPattern(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetPatternResponse>() {
+                            @Override
+                            public boolean apply(GetPatternResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getPattern().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datacatalog.model.LifecycleState.Deleted)),
                 request);
     }
 

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/AddDataSelectorPatternsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/AddDataSelectorPatternsConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class AddDataSelectorPatternsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.AddDataSelectorPatternsRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.AddDataSelectorPatternsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.AddDataSelectorPatternsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getDataAssetKey(), "dataAssetKey must not be blank");
+        Validate.notNull(
+                request.getDataSelectorPatternDetails(), "dataSelectorPatternDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("dataAssets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataAssetKey()))
+                        .path("actions")
+                        .path("addDataSelectorPatterns");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.AddDataSelectorPatternsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.AddDataSelectorPatternsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .AddDataSelectorPatternsResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .AddDataSelectorPatternsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.AddDataSelectorPatternsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<DataAsset>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(DataAsset.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataAsset> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.AddDataSelectorPatternsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .AddDataSelectorPatternsResponse.builder();
+
+                                builder.dataAsset(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.AddDataSelectorPatternsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/AssociateCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/AssociateCustomPropertyConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class AssociateCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.AssociateCustomPropertyRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.AssociateCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.AssociateCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getTypeKey(), "typeKey must not be blank");
+        Validate.notNull(
+                request.getAssociateCustomPropertyDetails(),
+                "associateCustomPropertyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("types")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTypeKey()))
+                        .path("actions")
+                        .path("associateCustomProperties");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.AssociateCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.AssociateCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .AssociateCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .AssociateCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.AssociateCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Type>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(Type.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Type> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.AssociateCustomPropertyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .AssociateCustomPropertyResponse.builder();
+
+                                builder.type(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.AssociateCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreateCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreateCustomPropertyConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class CreateCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.CreateCustomPropertyRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.CreateCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.CreateCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+        Validate.notNull(
+                request.getCreateCustomPropertyDetails(),
+                "createCustomPropertyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()))
+                        .path("customProperties");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .CreateCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        CustomProperty>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        CustomProperty.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<CustomProperty> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .CreateCustomPropertyResponse.builder();
+
+                                builder.customProperty(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.CreateCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreateNamespaceConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreateNamespaceConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class CreateNamespaceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.CreateNamespaceRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.CreateNamespaceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.CreateNamespaceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notNull(request.getCreateNamespaceDetails(), "createNamespaceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Namespace>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Namespace.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Namespace> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .CreateNamespaceResponse.builder();
+
+                                builder.namespace(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.CreateNamespaceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreatePatternConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/CreatePatternConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class CreatePatternConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.CreatePatternRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.CreatePatternRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.CreatePatternRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notNull(request.getCreatePatternDetails(), "createPatternDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.CreatePatternResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.CreatePatternResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.CreatePatternResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.CreatePatternResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.CreatePatternResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pattern>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pattern.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pattern> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.CreatePatternResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .CreatePatternResponse.builder();
+
+                                builder.pattern(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.CreatePatternResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeleteCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeleteCustomPropertyConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class DeleteCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.DeleteCustomPropertyRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.DeleteCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.DeleteCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+        Validate.notBlank(request.getCustomPropertyKey(), "customPropertyKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()))
+                        .path("customProperties")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCustomPropertyKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .DeleteCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .DeleteCustomPropertyResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.DeleteCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeleteNamespaceConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeleteNamespaceConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class DeleteNamespaceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.DeleteNamespaceRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.DeleteNamespaceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.DeleteNamespaceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .DeleteNamespaceResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.DeleteNamespaceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeletePatternConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DeletePatternConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class DeletePatternConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.DeletePatternRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.DeletePatternRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.DeletePatternRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getPatternKey(), "patternKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatternKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.DeletePatternResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.DeletePatternResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.DeletePatternResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.DeletePatternResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.DeletePatternResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.DeletePatternResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .DeletePatternResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.DeletePatternResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DisassociateCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/DisassociateCustomPropertyConverter.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class DisassociateCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.DisassociateCustomPropertyRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.DisassociateCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.DisassociateCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getTypeKey(), "typeKey must not be blank");
+        Validate.notNull(
+                request.getDisassociateCustomPropertyDetails(),
+                "disassociateCustomPropertyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("types")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getTypeKey()))
+                        .path("actions")
+                        .path("disassociateCustomProperties");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.DisassociateCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.DisassociateCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .DisassociateCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .DisassociateCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.DisassociateCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Type>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(Type.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Type> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .DisassociateCustomPropertyResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .DisassociateCustomPropertyResponse
+                                                        .builder();
+
+                                builder.type(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .DisassociateCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetCustomPropertyConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class GetCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.GetCustomPropertyRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.GetCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.GetCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+        Validate.notBlank(request.getCustomPropertyKey(), "customPropertyKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()))
+                        .path("customProperties")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCustomPropertyKey()));
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        CustomProperty>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        CustomProperty.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<CustomProperty> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .GetCustomPropertyResponse.builder();
+
+                                builder.customProperty(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.GetCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetNamespaceConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetNamespaceConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class GetNamespaceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.GetNamespaceRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.GetNamespaceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.GetNamespaceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()));
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.GetNamespaceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.GetNamespaceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.GetNamespaceResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.GetNamespaceResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.GetNamespaceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Namespace>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Namespace.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Namespace> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.GetNamespaceResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .GetNamespaceResponse.builder();
+
+                                builder.namespace(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.GetNamespaceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetPatternConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/GetPatternConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class GetPatternConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.GetPatternRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.GetPatternRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.GetPatternRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getPatternKey(), "patternKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatternKey()));
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.GetPatternResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.GetPatternResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.GetPatternResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.GetPatternResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.GetPatternResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pattern>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pattern.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pattern> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.GetPatternResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .GetPatternResponse.builder();
+
+                                builder.pattern(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.GetPatternResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAggregatedPhysicalEntitiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAggregatedPhysicalEntitiesConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ListAggregatedPhysicalEntitiesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ListAggregatedPhysicalEntitiesRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.ListAggregatedPhysicalEntitiesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ListAggregatedPhysicalEntitiesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getDataAssetKey(), "dataAssetKey must not be blank");
+        Validate.notBlank(request.getEntityKey(), "entityKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("dataAssets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataAssetKey()))
+                        .path("entities")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getEntityKey()))
+                        .path("actions")
+                        .path("listAggregatedPhysicalEntities");
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ListAggregatedPhysicalEntitiesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ListAggregatedPhysicalEntitiesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .ListAggregatedPhysicalEntitiesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .ListAggregatedPhysicalEntitiesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ListAggregatedPhysicalEntitiesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        EntityCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        EntityCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<EntityCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .ListAggregatedPhysicalEntitiesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ListAggregatedPhysicalEntitiesResponse
+                                                        .builder();
+
+                                builder.entityCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .ListAggregatedPhysicalEntitiesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListCustomPropertiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListCustomPropertiesConverter.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ListCustomPropertiesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ListCustomPropertiesRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.ListCustomPropertiesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ListCustomPropertiesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()))
+                        .path("customProperties");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
+        if (request.getDataTypes() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "dataTypes",
+                            request.getDataTypes(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getTypeName() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "typeName",
+                            request.getTypeName(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getTimeCreated() != null) {
+            target =
+                    target.queryParam(
+                            "timeCreated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeCreated()));
+        }
+
+        if (request.getTimeUpdated() != null) {
+            target =
+                    target.queryParam(
+                            "timeUpdated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeUpdated()));
+        }
+
+        if (request.getCreatedById() != null) {
+            target =
+                    target.queryParam(
+                            "createdById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCreatedById()));
+        }
+
+        if (request.getUpdatedById() != null) {
+            target =
+                    target.queryParam(
+                            "updatedById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getUpdatedById()));
+        }
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .ListCustomPropertiesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        CustomPropertyCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        CustomPropertyCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<CustomPropertyCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ListCustomPropertiesResponse.builder();
+
+                                builder.customPropertyCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.ListCustomPropertiesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListDerivedLogicalEntitiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListDerivedLogicalEntitiesConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ListDerivedLogicalEntitiesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ListDerivedLogicalEntitiesRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.ListDerivedLogicalEntitiesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ListDerivedLogicalEntitiesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getPatternKey(), "patternKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatternKey()))
+                        .path("actions")
+                        .path("listDerivedLogicalEntities");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ListDerivedLogicalEntitiesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ListDerivedLogicalEntitiesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .ListDerivedLogicalEntitiesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .ListDerivedLogicalEntitiesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ListDerivedLogicalEntitiesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        EntityCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        EntityCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<EntityCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .ListDerivedLogicalEntitiesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ListDerivedLogicalEntitiesResponse
+                                                        .builder();
+
+                                builder.entityCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .ListDerivedLogicalEntitiesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
@@ -107,6 +107,14 @@ public class ListEntitiesConverter {
                                     request.getExternalKey()));
         }
 
+        if (request.getPatternKey() != null) {
+            target =
+                    target.queryParam(
+                            "patternKey",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPatternKey()));
+        }
+
         if (request.getTimeExternal() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListNamespacesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListNamespacesConverter.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ListNamespacesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ListNamespacesRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.ListNamespacesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ListNamespacesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getTimeCreated() != null) {
+            target =
+                    target.queryParam(
+                            "timeCreated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeCreated()));
+        }
+
+        if (request.getTimeUpdated() != null) {
+            target =
+                    target.queryParam(
+                            "timeUpdated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeUpdated()));
+        }
+
+        if (request.getCreatedById() != null) {
+            target =
+                    target.queryParam(
+                            "createdById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCreatedById()));
+        }
+
+        if (request.getUpdatedById() != null) {
+            target =
+                    target.queryParam(
+                            "updatedById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getUpdatedById()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ListNamespacesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ListNamespacesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.ListNamespacesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.ListNamespacesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ListNamespacesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        NamespaceCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        NamespaceCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<NamespaceCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.ListNamespacesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ListNamespacesResponse.builder();
+
+                                builder.namespaceCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.ListNamespacesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListPatternsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListPatternsConverter.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ListPatternsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ListPatternsRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.ListPatternsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ListPatternsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getDisplayNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayNameContains()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getTimeCreated() != null) {
+            target =
+                    target.queryParam(
+                            "timeCreated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeCreated()));
+        }
+
+        if (request.getTimeUpdated() != null) {
+            target =
+                    target.queryParam(
+                            "timeUpdated",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeUpdated()));
+        }
+
+        if (request.getCreatedById() != null) {
+            target =
+                    target.queryParam(
+                            "createdById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCreatedById()));
+        }
+
+        if (request.getUpdatedById() != null) {
+            target =
+                    target.queryParam(
+                            "updatedById",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getUpdatedById()));
+        }
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ListPatternsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ListPatternsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.ListPatternsResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.ListPatternsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ListPatternsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PatternCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PatternCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PatternCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.ListPatternsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ListPatternsResponse.builder();
+
+                                builder.patternCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.ListPatternsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/RemoveDataSelectorPatternsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/RemoveDataSelectorPatternsConverter.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class RemoveDataSelectorPatternsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.RemoveDataSelectorPatternsRequest
+            interceptRequest(
+                    com.oracle.bmc.datacatalog.requests.RemoveDataSelectorPatternsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.RemoveDataSelectorPatternsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getDataAssetKey(), "dataAssetKey must not be blank");
+        Validate.notNull(
+                request.getDataSelectorPatternDetails(), "dataSelectorPatternDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("dataAssets")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataAssetKey()))
+                        .path("actions")
+                        .path("removeDataSelectorPatterns");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.RemoveDataSelectorPatternsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.RemoveDataSelectorPatternsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .RemoveDataSelectorPatternsResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses
+                                            .RemoveDataSelectorPatternsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.RemoveDataSelectorPatternsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<DataAsset>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(DataAsset.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataAsset> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .RemoveDataSelectorPatternsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .RemoveDataSelectorPatternsResponse
+                                                        .builder();
+
+                                builder.dataAsset(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses
+                                                .RemoveDataSelectorPatternsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdateCustomPropertyConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdateCustomPropertyConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class UpdateCustomPropertyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.UpdateCustomPropertyRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.UpdateCustomPropertyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.UpdateCustomPropertyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+        Validate.notBlank(request.getCustomPropertyKey(), "customPropertyKey must not be blank");
+        Validate.notNull(
+                request.getUpdateCustomPropertyDetails(),
+                "updateCustomPropertyDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()))
+                        .path("customProperties")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCustomPropertyKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses
+                                        .UpdateCustomPropertyResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        CustomProperty>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        CustomProperty.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<CustomProperty> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .UpdateCustomPropertyResponse.builder();
+
+                                builder.customProperty(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.UpdateCustomPropertyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdateNamespaceConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdateNamespaceConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class UpdateNamespaceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.UpdateNamespaceRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.UpdateNamespaceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.UpdateNamespaceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getNamespaceId(), "namespaceId must not be blank");
+        Validate.notNull(request.getUpdateNamespaceDetails(), "updateNamespaceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Namespace>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Namespace.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Namespace> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .UpdateNamespaceResponse.builder();
+
+                                builder.namespace(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.UpdateNamespaceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdatePatternConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/UpdatePatternConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class UpdatePatternConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.UpdatePatternRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.UpdatePatternRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.UpdatePatternRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getPatternKey(), "patternKey must not be blank");
+        Validate.notNull(request.getUpdatePatternDetails(), "updatePatternDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatternKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.UpdatePatternResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.UpdatePatternResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.UpdatePatternResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.UpdatePatternResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.UpdatePatternResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pattern>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pattern.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pattern> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.UpdatePatternResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .UpdatePatternResponse.builder();
+
+                                builder.pattern(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.UpdatePatternResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ValidatePatternConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ValidatePatternConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class ValidatePatternConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.ValidatePatternRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.ValidatePatternRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.ValidatePatternRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notBlank(request.getPatternKey(), "patternKey must not be blank");
+        Validate.notNull(request.getValidatePatternDetails(), "validatePatternDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("patterns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPatternKey()))
+                        .path("actions")
+                        .path("validate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.ValidatePatternResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.ValidatePatternResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.ValidatePatternResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.ValidatePatternResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.ValidatePatternResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ValidatePatternResult>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ValidatePatternResult.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ValidatePatternResult>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.ValidatePatternResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .ValidatePatternResponse.builder();
+
+                                builder.validatePatternResult(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.ValidatePatternResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
@@ -260,6 +260,16 @@ public class Attribute {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -301,6 +311,7 @@ public class Attribute {
                             timeExternal,
                             uri,
                             path,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -335,6 +346,7 @@ public class Attribute {
                             .timeExternal(o.getTimeExternal())
                             .uri(o.getUri())
                             .path(o.getPath())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -516,6 +528,12 @@ public class Attribute {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("path")
     String path;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Connection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Connection.java
@@ -87,6 +87,16 @@ public class Connection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -172,6 +182,7 @@ public class Connection {
                             timeUpdated,
                             createdById,
                             updatedById,
+                            customPropertyMembers,
                             properties,
                             externalKey,
                             timeStatusUpdated,
@@ -194,6 +205,7 @@ public class Connection {
                             .timeUpdated(o.getTimeUpdated())
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .externalKey(o.getExternalKey())
                             .timeStatusUpdated(o.getTimeStatusUpdated())
@@ -261,6 +273,12 @@ public class Connection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
     String updatedById;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the connection type. Each connection type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
@@ -152,6 +152,16 @@ public class CreateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -181,6 +191,7 @@ public class CreateAttributeDetails {
                             maxCollectionCount,
                             externalDatatypeEntityKey,
                             externalParentAttributeKey,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -203,6 +214,7 @@ public class CreateAttributeDetails {
                             .maxCollectionCount(o.getMaxCollectionCount())
                             .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
                             .externalParentAttributeKey(o.getExternalParentAttributeKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -305,6 +317,12 @@ public class CreateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
     String externalParentAttributeKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateConnectionDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateConnectionDetails.java
@@ -53,6 +53,16 @@ public class CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -90,6 +100,7 @@ public class CreateConnectionDetails {
                             description,
                             displayName,
                             typeKey,
+                            customPropertyMembers,
                             properties,
                             encProperties,
                             isDefault);
@@ -103,6 +114,7 @@ public class CreateConnectionDetails {
                     description(o.getDescription())
                             .displayName(o.getDisplayName())
                             .typeKey(o.getTypeKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .encProperties(o.getEncProperties())
                             .isDefault(o.getIsDefault());
@@ -138,6 +150,12 @@ public class CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
     String typeKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the connection type. Each connection type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateCustomPropertyDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateCustomPropertyDetails.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in custom property create operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateCustomPropertyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateCustomPropertyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+        private CustomPropertyDataType dataType;
+
+        public Builder dataType(CustomPropertyDataType dataType) {
+            this.dataType = dataType;
+            this.__explicitlySet__.add("dataType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+        private Boolean isSortable;
+
+        public Builder isSortable(Boolean isSortable) {
+            this.isSortable = isSortable;
+            this.__explicitlySet__.add("isSortable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+        private Boolean isFilterable;
+
+        public Builder isFilterable(Boolean isFilterable) {
+            this.isFilterable = isFilterable;
+            this.__explicitlySet__.add("isFilterable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+        private Boolean isMultiValued;
+
+        public Builder isMultiValued(Boolean isMultiValued) {
+            this.isMultiValued = isMultiValued;
+            this.__explicitlySet__.add("isMultiValued");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+        private Boolean isHidden;
+
+        public Builder isHidden(Boolean isHidden) {
+            this.isHidden = isHidden;
+            this.__explicitlySet__.add("isHidden");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+        private Boolean isEditable;
+
+        public Builder isEditable(Boolean isEditable) {
+            this.isEditable = isEditable;
+            this.__explicitlySet__.add("isEditable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+        private Boolean isHiddenInSearch;
+
+        public Builder isHiddenInSearch(Boolean isHiddenInSearch) {
+            this.isHiddenInSearch = isHiddenInSearch;
+            this.__explicitlySet__.add("isHiddenInSearch");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+        private java.util.List<String> allowedValues;
+
+        public Builder allowedValues(java.util.List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+            this.__explicitlySet__.add("allowedValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateCustomPropertyDetails build() {
+            CreateCustomPropertyDetails __instance__ =
+                    new CreateCustomPropertyDetails(
+                            displayName,
+                            description,
+                            dataType,
+                            isSortable,
+                            isFilterable,
+                            isMultiValued,
+                            isHidden,
+                            isEditable,
+                            isHiddenInSearch,
+                            allowedValues,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateCustomPropertyDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .dataType(o.getDataType())
+                            .isSortable(o.getIsSortable())
+                            .isFilterable(o.getIsFilterable())
+                            .isMultiValued(o.getIsMultiValued())
+                            .isHidden(o.getIsHidden())
+                            .isEditable(o.getIsEditable())
+                            .isHiddenInSearch(o.getIsHiddenInSearch())
+                            .allowedValues(o.getAllowedValues())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the custom property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The data type of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+    CustomPropertyDataType dataType;
+
+    /**
+     * If this field allows to sort from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+    Boolean isSortable;
+
+    /**
+     * If this field allows to filter or create facets from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+    Boolean isFilterable;
+
+    /**
+     * If this field allows multiple values to be set
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+    Boolean isMultiValued;
+
+    /**
+     * If this field is a hidden field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+    Boolean isHidden;
+
+    /**
+     * If this field is a editable field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+    Boolean isEditable;
+
+    /**
+     * If this field is allowed to pop in search results
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+    Boolean isHiddenInSearch;
+
+    /**
+     * Allowed values for the custom property if any
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+    java.util.List<String> allowedValues;
+
+    /**
+     * A map of maps that contains the properties which are specific to the data asset type. Each data asset type
+     * definition defines it's set of required and optional properties. The map keys are category names and the
+     * values are maps of property name to property value. Every property is contained inside of a category. Most
+     * data assets have required properties within the \"default\" category. To determine the set of optional and
+     * required properties for a data asset type, a query can be done on '/types?type=dataAsset' that returns a
+     * collection of all data asset types. The appropriate data asset type, which includes definitions of all of
+     * it's properties, can be identified from this collection.
+     * Example: `{\"properties\": { \"default\": { \"host\": \"host1\", \"port\": \"1521\", \"database\": \"orcl\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateDataAssetDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateDataAssetDetails.java
@@ -53,6 +53,16 @@ public class CreateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -67,7 +77,8 @@ public class CreateDataAssetDetails {
 
         public CreateDataAssetDetails build() {
             CreateDataAssetDetails __instance__ =
-                    new CreateDataAssetDetails(displayName, description, typeKey, properties);
+                    new CreateDataAssetDetails(
+                            displayName, description, typeKey, customPropertyMembers, properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,6 +89,7 @@ public class CreateDataAssetDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .typeKey(o.getTypeKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -111,6 +123,12 @@ public class CreateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
     String typeKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the data asset type. Each data asset type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateEntityDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateEntityDetails.java
@@ -80,6 +80,24 @@ public class CreateEntityDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+        private String patternKey;
+
+        public Builder patternKey(String patternKey) {
+            this.patternKey = patternKey;
+            this.__explicitlySet__.add("patternKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+        private String realizedExpression;
+
+        public Builder realizedExpression(String realizedExpression) {
+            this.realizedExpression = realizedExpression;
+            this.__explicitlySet__.add("realizedExpression");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("harvestStatus")
         private HarvestStatus harvestStatus;
 
@@ -95,6 +113,16 @@ public class CreateEntityDetails {
         public Builder lastJobKey(String lastJobKey) {
             this.lastJobKey = lastJobKey;
             this.__explicitlySet__.add("lastJobKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
             return this;
         }
 
@@ -119,8 +147,11 @@ public class CreateEntityDetails {
                             isLogical,
                             isPartition,
                             folderKey,
+                            patternKey,
+                            realizedExpression,
                             harvestStatus,
                             lastJobKey,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -135,8 +166,11 @@ public class CreateEntityDetails {
                             .isLogical(o.getIsLogical())
                             .isPartition(o.getIsPartition())
                             .folderKey(o.getFolderKey())
+                            .patternKey(o.getPatternKey())
+                            .realizedExpression(o.getRealizedExpression())
                             .harvestStatus(o.getHarvestStatus())
                             .lastJobKey(o.getLastJobKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -190,6 +224,18 @@ public class CreateEntityDetails {
     String folderKey;
 
     /**
+     * Key of the associated pattern if this is a logical entity.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+    String patternKey;
+
+    /**
+     * The expression realized after resolving qualifiers . Used in deriving this logical entity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+    String realizedExpression;
+
+    /**
      * Status of the object as updated by the harvest process. When an entity object is created , it's harvest status
      * will indicate if the entity's metadata has been fully harvested or not. The harvest process can perform
      * shallow harvesting to allow users to browse the metadata and can on-demand deep harvest on any object
@@ -204,6 +250,12 @@ public class CreateEntityDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lastJobKey")
     String lastJobKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the entity type. Each entity type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
@@ -44,6 +44,16 @@ public class CreateFolderDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -97,6 +107,7 @@ public class CreateFolderDetails {
                     new CreateFolderDetails(
                             displayName,
                             description,
+                            customPropertyMembers,
                             properties,
                             parentFolderKey,
                             timeExternal,
@@ -111,6 +122,7 @@ public class CreateFolderDetails {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .parentFolderKey(o.getParentFolderKey())
                             .timeExternal(o.getTimeExternal())
@@ -142,6 +154,12 @@ public class CreateFolderDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the folder type. Each folder type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateGlossaryDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateGlossaryDetails.java
@@ -62,12 +62,23 @@ public class CreateGlossaryDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateGlossaryDetails build() {
             CreateGlossaryDetails __instance__ =
-                    new CreateGlossaryDetails(displayName, description, workflowStatus, owner);
+                    new CreateGlossaryDetails(
+                            displayName, description, workflowStatus, owner, customPropertyMembers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,7 +89,8 @@ public class CreateGlossaryDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .workflowStatus(o.getWorkflowStatus())
-                            .owner(o.getOwner());
+                            .owner(o.getOwner())
+                            .customPropertyMembers(o.getCustomPropertyMembers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -117,6 +129,12 @@ public class CreateGlossaryDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("owner")
     String owner;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateNamespaceDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateNamespaceDetails.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in custom property create operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateNamespaceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateNamespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateNamespaceDetails build() {
+            CreateNamespaceDetails __instance__ =
+                    new CreateNamespaceDetails(displayName, description, isServiceDefined);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateNamespaceDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .isServiceDefined(o.getIsServiceDefined());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the Namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreatePatternDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreatePatternDetails.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in data asset create operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePatternDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreatePatternDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+        private java.util.List<String> checkFilePathList;
+
+        public Builder checkFilePathList(java.util.List<String> checkFilePathList) {
+            this.checkFilePathList = checkFilePathList;
+            this.__explicitlySet__.add("checkFilePathList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+        private Boolean isEnableCheckFailureLimit;
+
+        public Builder isEnableCheckFailureLimit(Boolean isEnableCheckFailureLimit) {
+            this.isEnableCheckFailureLimit = isEnableCheckFailureLimit;
+            this.__explicitlySet__.add("isEnableCheckFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+        private Integer checkFailureLimit;
+
+        public Builder checkFailureLimit(Integer checkFailureLimit) {
+            this.checkFailureLimit = checkFailureLimit;
+            this.__explicitlySet__.add("checkFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePatternDetails build() {
+            CreatePatternDetails __instance__ =
+                    new CreatePatternDetails(
+                            displayName,
+                            description,
+                            expression,
+                            checkFilePathList,
+                            isEnableCheckFailureLimit,
+                            checkFailureLimit,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePatternDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .expression(o.getExpression())
+                            .checkFilePathList(o.getCheckFilePathList())
+                            .isEnableCheckFailureLimit(o.getIsEnableCheckFailureLimit())
+                            .checkFailureLimit(o.getCheckFailureLimit())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the Pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The expression used in the pattern that may include qualifiers. Refer to the user documentation for details of the format and examples.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * List of file paths against which the expression can be tried, as a check. This documents, for reference
+     * purposes, some example objects a pattern is meant to work with. If isEnableCheckFailureLimit is set to true,
+     * this will be run as a validation during the request, such that if the check fails the request fails. If
+     * isEnableCheckFailureLimit instead is set to (the default) false, a pattern will still be created or updated even
+     * if the check fails, with a lifecycleState of FAILED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+    java.util.List<String> checkFilePathList;
+
+    /**
+     * Indicates whether the expression check, against the checkFilePathList, will fail the request if the count of
+     * UNMATCHED files is above the checkFailureLimit.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+    Boolean isEnableCheckFailureLimit;
+
+    /**
+     * The maximum number of UNMATCHED files, in checkFilePathList, above which the check fails. Optional, if
+     * checkFilePathList is provided - but if isEnableCheckFailureLimit is set to true it is required.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+    Integer checkFailureLimit;
+
+    /**
+     * A map of maps that contains the properties which are specific to the pattern type. Each pattern type
+     * definition defines it's set of required and optional properties.
+     * Example: `{\"properties\": { \"default\": { \"tbd\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateTermDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateTermDetails.java
@@ -80,6 +80,16 @@ public class CreateTermDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -91,7 +101,8 @@ public class CreateTermDetails {
                             isAllowedToHaveChildTerms,
                             parentTermKey,
                             owner,
-                            workflowStatus);
+                            workflowStatus,
+                            customPropertyMembers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -104,7 +115,8 @@ public class CreateTermDetails {
                             .isAllowedToHaveChildTerms(o.getIsAllowedToHaveChildTerms())
                             .parentTermKey(o.getParentTermKey())
                             .owner(o.getOwner())
-                            .workflowStatus(o.getWorkflowStatus());
+                            .workflowStatus(o.getWorkflowStatus())
+                            .customPropertyMembers(o.getCustomPropertyMembers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -155,6 +167,12 @@ public class CreateTermDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workflowStatus")
     TermWorkflowStatus workflowStatus;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomProperty.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomProperty.java
@@ -1,0 +1,439 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Custom Property Definition
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CustomProperty.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomProperty {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+        private CustomPropertyDataType dataType;
+
+        public Builder dataType(CustomPropertyDataType dataType) {
+            this.dataType = dataType;
+            this.__explicitlySet__.add("dataType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+        private String namespaceName;
+
+        public Builder namespaceName(String namespaceName) {
+            this.namespaceName = namespaceName;
+            this.__explicitlySet__.add("namespaceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isListType")
+        private Boolean isListType;
+
+        public Builder isListType(Boolean isListType) {
+            this.isListType = isListType;
+            this.__explicitlySet__.add("isListType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+        private Boolean isSortable;
+
+        public Builder isSortable(Boolean isSortable) {
+            this.isSortable = isSortable;
+            this.__explicitlySet__.add("isSortable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+        private Boolean isFilterable;
+
+        public Builder isFilterable(Boolean isFilterable) {
+            this.isFilterable = isFilterable;
+            this.__explicitlySet__.add("isFilterable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+        private Boolean isMultiValued;
+
+        public Builder isMultiValued(Boolean isMultiValued) {
+            this.isMultiValued = isMultiValued;
+            this.__explicitlySet__.add("isMultiValued");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+        private Boolean isHidden;
+
+        public Builder isHidden(Boolean isHidden) {
+            this.isHidden = isHidden;
+            this.__explicitlySet__.add("isHidden");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+        private Boolean isEditable;
+
+        public Builder isEditable(Boolean isEditable) {
+            this.isEditable = isEditable;
+            this.__explicitlySet__.add("isEditable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+        private Boolean isHiddenInSearch;
+
+        public Builder isHiddenInSearch(Boolean isHiddenInSearch) {
+            this.isHiddenInSearch = isHiddenInSearch;
+            this.__explicitlySet__.add("isHiddenInSearch");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+        private String createdById;
+
+        public Builder createdById(String createdById) {
+            this.createdById = createdById;
+            this.__explicitlySet__.add("createdById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+        private String updatedById;
+
+        public Builder updatedById(String updatedById) {
+            this.updatedById = updatedById;
+            this.__explicitlySet__.add("updatedById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("usageCount")
+        private Integer usageCount;
+
+        public Builder usageCount(Integer usageCount) {
+            this.usageCount = usageCount;
+            this.__explicitlySet__.add("usageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scope")
+        private java.util.List<CustomPropertyTypeUsage> scope;
+
+        public Builder scope(java.util.List<CustomPropertyTypeUsage> scope) {
+            this.scope = scope;
+            this.__explicitlySet__.add("scope");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+        private java.util.List<String> allowedValues;
+
+        public Builder allowedValues(java.util.List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+            this.__explicitlySet__.add("allowedValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomProperty build() {
+            CustomProperty __instance__ =
+                    new CustomProperty(
+                            key,
+                            displayName,
+                            dataType,
+                            description,
+                            namespaceName,
+                            isListType,
+                            isSortable,
+                            isFilterable,
+                            isMultiValued,
+                            isHidden,
+                            isEditable,
+                            isServiceDefined,
+                            isHiddenInSearch,
+                            lifecycleState,
+                            timeCreated,
+                            timeUpdated,
+                            createdById,
+                            updatedById,
+                            usageCount,
+                            scope,
+                            allowedValues,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomProperty o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .dataType(o.getDataType())
+                            .description(o.getDescription())
+                            .namespaceName(o.getNamespaceName())
+                            .isListType(o.getIsListType())
+                            .isSortable(o.getIsSortable())
+                            .isFilterable(o.getIsFilterable())
+                            .isMultiValued(o.getIsMultiValued())
+                            .isHidden(o.getIsHidden())
+                            .isEditable(o.getIsEditable())
+                            .isServiceDefined(o.getIsServiceDefined())
+                            .isHiddenInSearch(o.getIsHiddenInSearch())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .createdById(o.getCreatedById())
+                            .updatedById(o.getUpdatedById())
+                            .usageCount(o.getUsageCount())
+                            .scope(o.getScope())
+                            .allowedValues(o.getAllowedValues())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique data asset key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Display name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Data type of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+    CustomPropertyDataType dataType;
+
+    /**
+     * Description for the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Namespace name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+    String namespaceName;
+
+    /**
+     * Is this property allowed to have list of values
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isListType")
+    Boolean isListType;
+
+    /**
+     * If this field allows to sort from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+    Boolean isSortable;
+
+    /**
+     * If this field allows to filter or create facets from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+    Boolean isFilterable;
+
+    /**
+     * If this field allows multiple values to be set
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+    Boolean isMultiValued;
+
+    /**
+     * If this field is a hidden field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+    Boolean isHidden;
+
+    /**
+     * If this field is a editable field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+    Boolean isEditable;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    /**
+     * If this field is allowed to pop in search results
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+    Boolean isHiddenInSearch;
+
+    /**
+     * The current state of the custom property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the custom property was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The last time that any change was made to the custom property. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the custom property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+    String createdById;
+
+    /**
+     * OCID of the user who last modified the custom property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+    String updatedById;
+
+    /**
+     * Total number of first class objects using this custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("usageCount")
+    Integer usageCount;
+
+    /**
+     * Type or scope of the custom property belongs to. This will be an array of type id it will be belongs to
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scope")
+    java.util.List<CustomPropertyTypeUsage> scope;
+
+    /**
+     * Allowed values for the custom property if any
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+    java.util.List<String> allowedValues;
+
+    /**
+     * A map of maps that contains the properties which are specific to the asset type. Each data asset type
+     * definition defines it's set of required and optional properties. The map keys are category names and the
+     * values are maps of property name to property value. Every property is contained inside of a category. Most
+     * data assets have required properties within the \"default\" category.
+     * Example: `{\"properties\": { \"default\": { \"host\": \"host1\", \"port\": \"1521\", \"database\": \"orcl\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyCollection.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Results of a custom properties listing. A custom property is an user defined attribute tied to the first class object of data catalog
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomPropertyCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomPropertyCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<CustomPropertySummary> items;
+
+        public Builder items(java.util.List<CustomPropertySummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomPropertyCollection build() {
+            CustomPropertyCollection __instance__ = new CustomPropertyCollection(count, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomPropertyCollection o) {
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
+
+    /**
+     * Collection of custom property summaries
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<CustomPropertySummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyDataType.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyDataType.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Enum Representing various data types allowed for the custom property
+ * TEXT - String data type
+ * RICH_TEXT - Rich text to hold long descriptions and formatted values
+ * NUMBER - Numeric Data type
+ * BOOLEAN - Boolean type with allowed values of true or false
+ * DATE - Date data type
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public enum CustomPropertyDataType {
+    Text("TEXT"),
+    RichText("RICH_TEXT"),
+    Boolean("BOOLEAN"),
+    Number("NUMBER"),
+    Date("DATE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, CustomPropertyDataType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (CustomPropertyDataType v : CustomPropertyDataType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    CustomPropertyDataType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static CustomPropertyDataType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'CustomPropertyDataType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyGetUsage.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyGetUsage.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Details of a single custom property
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomPropertyGetUsage.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomPropertyGetUsage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+        private CustomPropertyDataType dataType;
+
+        public Builder dataType(CustomPropertyDataType dataType) {
+            this.dataType = dataType;
+            this.__explicitlySet__.add("dataType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+        private String namespaceName;
+
+        public Builder namespaceName(String namespaceName) {
+            this.namespaceName = namespaceName;
+            this.__explicitlySet__.add("namespaceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceKey")
+        private String namespaceKey;
+
+        public Builder namespaceKey(String namespaceKey) {
+            this.namespaceKey = namespaceKey;
+            this.__explicitlySet__.add("namespaceKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+        private Boolean isMultiValued;
+
+        public Builder isMultiValued(Boolean isMultiValued) {
+            this.isMultiValued = isMultiValued;
+            this.__explicitlySet__.add("isMultiValued");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+        private Boolean isHidden;
+
+        public Builder isHidden(Boolean isHidden) {
+            this.isHidden = isHidden;
+            this.__explicitlySet__.add("isHidden");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+        private Boolean isEditable;
+
+        public Builder isEditable(Boolean isEditable) {
+            this.isEditable = isEditable;
+            this.__explicitlySet__.add("isEditable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isListType")
+        private Boolean isListType;
+
+        public Builder isListType(Boolean isListType) {
+            this.isListType = isListType;
+            this.__explicitlySet__.add("isListType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+        private java.util.List<String> allowedValues;
+
+        public Builder allowedValues(java.util.List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+            this.__explicitlySet__.add("allowedValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomPropertyGetUsage build() {
+            CustomPropertyGetUsage __instance__ =
+                    new CustomPropertyGetUsage(
+                            key,
+                            displayName,
+                            description,
+                            value,
+                            dataType,
+                            namespaceName,
+                            namespaceKey,
+                            isMultiValued,
+                            isHidden,
+                            isEditable,
+                            isListType,
+                            allowedValues);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomPropertyGetUsage o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .value(o.getValue())
+                            .dataType(o.getDataType())
+                            .namespaceName(o.getNamespaceName())
+                            .namespaceKey(o.getNamespaceKey())
+                            .isMultiValued(o.getIsMultiValued())
+                            .isHidden(o.getIsHidden())
+                            .isEditable(o.getIsEditable())
+                            .isListType(o.getIsListType())
+                            .allowedValues(o.getAllowedValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique Identifier of the attribute which is ID
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Display name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Description of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The custom property value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    /**
+     * The data type of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+    CustomPropertyDataType dataType;
+
+    /**
+     * Namespace name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+    String namespaceName;
+
+    /**
+     * Unique namespace key that is immutable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceKey")
+    String namespaceKey;
+
+    /**
+     * If this field allows multiple values to be set
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+    Boolean isMultiValued;
+
+    /**
+     * If this field is a hidden field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+    Boolean isHidden;
+
+    /**
+     * If this field is a editable field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+    Boolean isEditable;
+
+    /**
+     * Is this property allowed to have list of values
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isListType")
+    Boolean isListType;
+
+    /**
+     * Allowed values for the custom property if any
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+    java.util.List<String> allowedValues;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySetUsage.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySetUsage.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Details of a single custom property.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomPropertySetUsage.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomPropertySetUsage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+        private String namespaceName;
+
+        public Builder namespaceName(String namespaceName) {
+            this.namespaceName = namespaceName;
+            this.__explicitlySet__.add("namespaceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomPropertySetUsage build() {
+            CustomPropertySetUsage __instance__ =
+                    new CustomPropertySetUsage(key, displayName, value, namespaceName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomPropertySetUsage o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .value(o.getValue())
+                            .namespaceName(o.getNamespaceName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique Identifier of the attribute which is ID
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The custom property value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    /**
+     * Namespace name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+    String namespaceName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySummary.java
@@ -1,0 +1,350 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Summary of a custom property
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomPropertySummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomPropertySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+        private CustomPropertyDataType dataType;
+
+        public Builder dataType(CustomPropertyDataType dataType) {
+            this.dataType = dataType;
+            this.__explicitlySet__.add("dataType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+        private String namespaceName;
+
+        public Builder namespaceName(String namespaceName) {
+            this.namespaceName = namespaceName;
+            this.__explicitlySet__.add("namespaceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+        private Boolean isSortable;
+
+        public Builder isSortable(Boolean isSortable) {
+            this.isSortable = isSortable;
+            this.__explicitlySet__.add("isSortable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+        private Boolean isFilterable;
+
+        public Builder isFilterable(Boolean isFilterable) {
+            this.isFilterable = isFilterable;
+            this.__explicitlySet__.add("isFilterable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+        private Boolean isMultiValued;
+
+        public Builder isMultiValued(Boolean isMultiValued) {
+            this.isMultiValued = isMultiValued;
+            this.__explicitlySet__.add("isMultiValued");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+        private Boolean isHidden;
+
+        public Builder isHidden(Boolean isHidden) {
+            this.isHidden = isHidden;
+            this.__explicitlySet__.add("isHidden");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+        private Boolean isEditable;
+
+        public Builder isEditable(Boolean isEditable) {
+            this.isEditable = isEditable;
+            this.__explicitlySet__.add("isEditable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+        private Boolean isHiddenInSearch;
+
+        public Builder isHiddenInSearch(Boolean isHiddenInSearch) {
+            this.isHiddenInSearch = isHiddenInSearch;
+            this.__explicitlySet__.add("isHiddenInSearch");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("usageCount")
+        private Integer usageCount;
+
+        public Builder usageCount(Integer usageCount) {
+            this.usageCount = usageCount;
+            this.__explicitlySet__.add("usageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scope")
+        private java.util.List<CustomPropertyTypeUsage> scope;
+
+        public Builder scope(java.util.List<CustomPropertyTypeUsage> scope) {
+            this.scope = scope;
+            this.__explicitlySet__.add("scope");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+        private java.util.List<String> allowedValues;
+
+        public Builder allowedValues(java.util.List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+            this.__explicitlySet__.add("allowedValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomPropertySummary build() {
+            CustomPropertySummary __instance__ =
+                    new CustomPropertySummary(
+                            key,
+                            displayName,
+                            description,
+                            dataType,
+                            namespaceName,
+                            isSortable,
+                            isFilterable,
+                            isMultiValued,
+                            isHidden,
+                            isEditable,
+                            isServiceDefined,
+                            isHiddenInSearch,
+                            timeCreated,
+                            lifecycleState,
+                            usageCount,
+                            scope,
+                            allowedValues);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomPropertySummary o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .dataType(o.getDataType())
+                            .namespaceName(o.getNamespaceName())
+                            .isSortable(o.getIsSortable())
+                            .isFilterable(o.getIsFilterable())
+                            .isMultiValued(o.getIsMultiValued())
+                            .isHidden(o.getIsHidden())
+                            .isEditable(o.getIsEditable())
+                            .isServiceDefined(o.getIsServiceDefined())
+                            .isHiddenInSearch(o.getIsHiddenInSearch())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .usageCount(o.getUsageCount())
+                            .scope(o.getScope())
+                            .allowedValues(o.getAllowedValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique custom property key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Display name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Description of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Data type of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+    CustomPropertyDataType dataType;
+
+    /**
+     * Namespace name of the custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaceName")
+    String namespaceName;
+
+    /**
+     * If this field allows to sort from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+    Boolean isSortable;
+
+    /**
+     * If this field allows to filter or create facets from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+    Boolean isFilterable;
+
+    /**
+     * If this field allows multiple values to be set
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+    Boolean isMultiValued;
+
+    /**
+     * If this field is a hidden field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+    Boolean isHidden;
+
+    /**
+     * If this field is a editable field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+    Boolean isEditable;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    /**
+     * If this field is allowed to pop in search results
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+    Boolean isHiddenInSearch;
+
+    /**
+     * The date and time the custom property was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The current state of the custom property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Total number of first class objects using this custom property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("usageCount")
+    Integer usageCount;
+
+    /**
+     * Type or scope of the custom property belongs to. This will be an array of type id it will be belongs to
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scope")
+    java.util.List<CustomPropertyTypeUsage> scope;
+
+    /**
+     * Allowed values for the custom property if any
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+    java.util.List<String> allowedValues;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyTypeUsage.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyTypeUsage.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Object which describes the indivial object stats for every custom property
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomPropertyTypeUsage.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomPropertyTypeUsage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("typeId")
+        private String typeId;
+
+        public Builder typeId(String typeId) {
+            this.typeId = typeId;
+            this.__explicitlySet__.add("typeId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("typeName")
+        private String typeName;
+
+        public Builder typeName(String typeName) {
+            this.typeName = typeName;
+            this.__explicitlySet__.add("typeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomPropertyTypeUsage build() {
+            CustomPropertyTypeUsage __instance__ =
+                    new CustomPropertyTypeUsage(typeId, typeName, count);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomPropertyTypeUsage o) {
+            Builder copiedBuilder =
+                    typeId(o.getTypeId()).typeName(o.getTypeName()).count(o.getCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique type key identifier
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeId")
+    String typeId;
+
+    /**
+     * Name of the type associated with
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeName")
+    String typeName;
+
+    /**
+     * Number of objects associated with this type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAsset.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataAsset.java
@@ -135,6 +135,25 @@ public class DataAsset {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataSelectorPatterns")
+        private java.util.List<PatternSummary> dataSelectorPatterns;
+
+        public Builder dataSelectorPatterns(java.util.List<PatternSummary> dataSelectorPatterns) {
+            this.dataSelectorPatterns = dataSelectorPatterns;
+            this.__explicitlySet__.add("dataSelectorPatterns");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -162,6 +181,8 @@ public class DataAsset {
                             createdById,
                             updatedById,
                             uri,
+                            customPropertyMembers,
+                            dataSelectorPatterns,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -182,6 +203,8 @@ public class DataAsset {
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
                             .uri(o.getUri())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
+                            .dataSelectorPatterns(o.getDataSelectorPatterns())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -273,6 +296,18 @@ public class DataAsset {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+    /**
+     * The list of data selector patterns used in the harvest for this data asset to derive logical entities.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataSelectorPatterns")
+    java.util.List<PatternSummary> dataSelectorPatterns;
 
     /**
      * A map of maps that contains the properties which are specific to the asset type. Each data asset type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataSelectorPatternDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DataSelectorPatternDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * List of pattern Ids.  Used in the addition and removal of patterns in data assets.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DataSelectorPatternDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DataSelectorPatternDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<String> items;
+
+        public Builder items(java.util.List<String> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DataSelectorPatternDetails build() {
+            DataSelectorPatternDetails __instance__ = new DataSelectorPatternDetails(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DataSelectorPatternDetails o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Collection of pattern Ids.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<String> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DerivedLogicalEntities.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/DerivedLogicalEntities.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Entities derived from the application of a pattern to a list of file paths.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DerivedLogicalEntities.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DerivedLogicalEntities {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+        private String realizedExpression;
+
+        public Builder realizedExpression(String realizedExpression) {
+            this.realizedExpression = realizedExpression;
+            this.__explicitlySet__.add("realizedExpression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("filesInLogicalGrouping")
+        private java.util.List<String> filesInLogicalGrouping;
+
+        public Builder filesInLogicalGrouping(java.util.List<String> filesInLogicalGrouping) {
+            this.filesInLogicalGrouping = filesInLogicalGrouping;
+            this.__explicitlySet__.add("filesInLogicalGrouping");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DerivedLogicalEntities build() {
+            DerivedLogicalEntities __instance__ =
+                    new DerivedLogicalEntities(name, realizedExpression, filesInLogicalGrouping);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DerivedLogicalEntities o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .realizedExpression(o.getRealizedExpression())
+                            .filesInLogicalGrouping(o.getFilesInLogicalGrouping());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the derived logical entity. The group name of the unmatched files will be UNMATCHED
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The expression realized after resolving qualifiers . Used in deriving this logical entity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+    String realizedExpression;
+
+    /**
+     * The list of file paths that belong to the grouping of logical entity or UNMATCHED for which realizedExpression is a selector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("filesInLogicalGrouping")
+    java.util.List<String> filesInLogicalGrouping;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
@@ -108,6 +108,24 @@ public class Entity {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+        private String patternKey;
+
+        public Builder patternKey(String patternKey) {
+            this.patternKey = patternKey;
+            this.__explicitlySet__.add("patternKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+        private String realizedExpression;
+
+        public Builder realizedExpression(String realizedExpression) {
+            this.realizedExpression = realizedExpression;
+            this.__explicitlySet__.add("realizedExpression");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeExternal")
         private java.util.Date timeExternal;
 
@@ -216,6 +234,16 @@ public class Entity {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -240,6 +268,8 @@ public class Entity {
                             updatedById,
                             lifecycleState,
                             externalKey,
+                            patternKey,
+                            realizedExpression,
                             timeExternal,
                             timeStatusUpdated,
                             isLogical,
@@ -252,6 +282,7 @@ public class Entity {
                             lastJobKey,
                             typeKey,
                             uri,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -269,6 +300,8 @@ public class Entity {
                             .updatedById(o.getUpdatedById())
                             .lifecycleState(o.getLifecycleState())
                             .externalKey(o.getExternalKey())
+                            .patternKey(o.getPatternKey())
+                            .realizedExpression(o.getRealizedExpression())
                             .timeExternal(o.getTimeExternal())
                             .timeStatusUpdated(o.getTimeStatusUpdated())
                             .isLogical(o.getIsLogical())
@@ -281,6 +314,7 @@ public class Entity {
                             .lastJobKey(o.getLastJobKey())
                             .typeKey(o.getTypeKey())
                             .uri(o.getUri())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -355,6 +389,18 @@ public class Entity {
     String externalKey;
 
     /**
+     * Key of the associated pattern if this is a logical entity.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+    String patternKey;
+
+    /**
+     * The expression realized after resolving qualifiers . Used in deriving this logical entity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+    String realizedExpression;
+
+    /**
      * Last modified timestamp of this object in the external system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeExternal")
@@ -427,6 +473,12 @@ public class Entity {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the entity type. Each entity type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
@@ -90,6 +90,24 @@ public class EntitySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+        private String patternKey;
+
+        public Builder patternKey(String patternKey) {
+            this.patternKey = patternKey;
+            this.__explicitlySet__.add("patternKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+        private String realizedExpression;
+
+        public Builder realizedExpression(String realizedExpression) {
+            this.realizedExpression = realizedExpression;
+            this.__explicitlySet__.add("realizedExpression");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("path")
         private String path;
 
@@ -157,6 +175,8 @@ public class EntitySummary {
                             folderKey,
                             folderName,
                             externalKey,
+                            patternKey,
+                            realizedExpression,
                             path,
                             timeCreated,
                             timeUpdated,
@@ -177,6 +197,8 @@ public class EntitySummary {
                             .folderKey(o.getFolderKey())
                             .folderName(o.getFolderName())
                             .externalKey(o.getExternalKey())
+                            .patternKey(o.getPatternKey())
+                            .realizedExpression(o.getRealizedExpression())
                             .path(o.getPath())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
@@ -239,6 +261,18 @@ public class EntitySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalKey")
     String externalKey;
+
+    /**
+     * Key of the associated pattern if this is a logical entity.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+    String patternKey;
+
+    /**
+     * The expression realized after resolving qualifiers . Used in deriving this logical entity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+    String realizedExpression;
 
     /**
      * Full path of the data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchAggregation.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchAggregation.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Aggregation/facets on properties of data object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchAggregation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchAggregation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("aggregation")
+        private java.util.Map<String, Long> aggregation;
+
+        public Builder aggregation(java.util.Map<String, Long> aggregation) {
+            this.aggregation = aggregation;
+            this.__explicitlySet__.add("aggregation");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchAggregation build() {
+            FacetedSearchAggregation __instance__ = new FacetedSearchAggregation(type, aggregation);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchAggregation o) {
+            Builder copiedBuilder = type(o.getType()).aggregation(o.getAggregation());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of data object property
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
+
+    /**
+     * Count of number of data objects having property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("aggregation")
+    java.util.Map<String, Long> aggregation;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchCustomProperty.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchCustomProperty.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Details about custom property
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchCustomProperty.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchCustomProperty {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+        private String dataType;
+
+        public Builder dataType(String dataType) {
+            this.dataType = dataType;
+            this.__explicitlySet__.add("dataType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchCustomProperty build() {
+            FacetedSearchCustomProperty __instance__ =
+                    new FacetedSearchCustomProperty(name, value, dataType);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchCustomProperty o) {
+            Builder copiedBuilder = name(o.getName()).value(o.getValue()).dataType(o.getDataType());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of custom property field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Value of the custom property field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    /**
+     * Data type of the custom property field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataType")
+    String dataType;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchDateFilterRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchDateFilterRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Object with date filter criteria
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchDateFilterRequest.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchDateFilterRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("fieldName")
+        private String fieldName;
+
+        public Builder fieldName(String fieldName) {
+            this.fieldName = fieldName;
+            this.__explicitlySet__.add("fieldName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAfter")
+        private java.util.Date timeAfter;
+
+        public Builder timeAfter(java.util.Date timeAfter) {
+            this.timeAfter = timeAfter;
+            this.__explicitlySet__.add("timeAfter");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeBefore")
+        private java.util.Date timeBefore;
+
+        public Builder timeBefore(java.util.Date timeBefore) {
+            this.timeBefore = timeBefore;
+            this.__explicitlySet__.add("timeBefore");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchDateFilterRequest build() {
+            FacetedSearchDateFilterRequest __instance__ =
+                    new FacetedSearchDateFilterRequest(fieldName, timeAfter, timeBefore);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchDateFilterRequest o) {
+            Builder copiedBuilder =
+                    fieldName(o.getFieldName())
+                            .timeAfter(o.getTimeAfter())
+                            .timeBefore(o.getTimeBefore());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Date field name that needs to be filtered by.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fieldName")
+    String fieldName;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAfter")
+    java.util.Date timeAfter;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeBefore")
+    java.util.Date timeBefore;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchFilterRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchFilterRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Object with details about filter criteria.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchFilterRequest.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchFilterRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("searchDateFilters")
+        private java.util.List<FacetedSearchDateFilterRequest> searchDateFilters;
+
+        public Builder searchDateFilters(
+                java.util.List<FacetedSearchDateFilterRequest> searchDateFilters) {
+            this.searchDateFilters = searchDateFilters;
+            this.__explicitlySet__.add("searchDateFilters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("searchStringFilters")
+        private java.util.List<FacetedSearchStringFilterRequest> searchStringFilters;
+
+        public Builder searchStringFilters(
+                java.util.List<FacetedSearchStringFilterRequest> searchStringFilters) {
+            this.searchStringFilters = searchStringFilters;
+            this.__explicitlySet__.add("searchStringFilters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchFilterRequest build() {
+            FacetedSearchFilterRequest __instance__ =
+                    new FacetedSearchFilterRequest(searchDateFilters, searchStringFilters);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchFilterRequest o) {
+            Builder copiedBuilder =
+                    searchDateFilters(o.getSearchDateFilters())
+                            .searchStringFilters(o.getSearchStringFilters());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Object with date filter criteria
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("searchDateFilters")
+    java.util.List<FacetedSearchDateFilterRequest> searchDateFilters;
+
+    /**
+     * Object with string filter criteria
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("searchStringFilters")
+    java.util.List<FacetedSearchStringFilterRequest> searchStringFilters;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchSortRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchSortRequest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Object with sort criteria details
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchSortRequest.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchSortRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("sortBy")
+        private String sortBy;
+
+        public Builder sortBy(String sortBy) {
+            this.sortBy = sortBy;
+            this.__explicitlySet__.add("sortBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sortOrder")
+        private SortOrder sortOrder;
+
+        public Builder sortOrder(SortOrder sortOrder) {
+            this.sortOrder = sortOrder;
+            this.__explicitlySet__.add("sortOrder");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchSortRequest build() {
+            FacetedSearchSortRequest __instance__ = new FacetedSearchSortRequest(sortBy, sortOrder);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchSortRequest o) {
+            Builder copiedBuilder = sortBy(o.getSortBy()).sortOrder(o.getSortOrder());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Filed name that needs to be sorted by.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sortBy")
+    String sortBy;
+    /**
+     * Sort order for search results.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Sort order for search results.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sortOrder")
+    SortOrder sortOrder;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchStringFilterRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FacetedSearchStringFilterRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Object with string filter criteria
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FacetedSearchStringFilterRequest.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FacetedSearchStringFilterRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("field")
+        private String field;
+
+        public Builder field(String field) {
+            this.field = field;
+            this.__explicitlySet__.add("field");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("values")
+        private java.util.List<String> values;
+
+        public Builder values(java.util.List<String> values) {
+            this.values = values;
+            this.__explicitlySet__.add("values");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FacetedSearchStringFilterRequest build() {
+            FacetedSearchStringFilterRequest __instance__ =
+                    new FacetedSearchStringFilterRequest(field, values);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FacetedSearchStringFilterRequest o) {
+            Builder copiedBuilder = field(o.getField()).values(o.getValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * String/boolean/numerical field name that needs to filtered with
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("field")
+    String field;
+
+    /**
+     * Array of values that the search results needs to be filtered by.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    java.util.List<String> values;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
@@ -82,6 +82,16 @@ public class Folder {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -193,6 +203,7 @@ public class Folder {
                             parentFolderKey,
                             path,
                             dataAssetKey,
+                            customPropertyMembers,
                             properties,
                             externalKey,
                             timeCreated,
@@ -217,6 +228,7 @@ public class Folder {
                             .parentFolderKey(o.getParentFolderKey())
                             .path(o.getPath())
                             .dataAssetKey(o.getDataAssetKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .externalKey(o.getExternalKey())
                             .timeCreated(o.getTimeCreated())
@@ -278,6 +290,12 @@ public class Folder {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
     String dataAssetKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the folder type. Each folder type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Glossary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Glossary.java
@@ -131,6 +131,52 @@ public class Glossary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("importJobDefinitionKey")
+        private String importJobDefinitionKey;
+
+        public Builder importJobDefinitionKey(String importJobDefinitionKey) {
+            this.importJobDefinitionKey = importJobDefinitionKey;
+            this.__explicitlySet__.add("importJobDefinitionKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("importJobKey")
+        private String importJobKey;
+
+        public Builder importJobKey(String importJobKey) {
+            this.importJobKey = importJobKey;
+            this.__explicitlySet__.add("importJobKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionKey")
+        private String latestImportJobExecutionKey;
+
+        public Builder latestImportJobExecutionKey(String latestImportJobExecutionKey) {
+            this.latestImportJobExecutionKey = latestImportJobExecutionKey;
+            this.__explicitlySet__.add("latestImportJobExecutionKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionStatus")
+        private String latestImportJobExecutionStatus;
+
+        public Builder latestImportJobExecutionStatus(String latestImportJobExecutionStatus) {
+            this.latestImportJobExecutionStatus = latestImportJobExecutionStatus;
+            this.__explicitlySet__.add("latestImportJobExecutionStatus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("uri")
         private String uri;
 
@@ -157,6 +203,11 @@ public class Glossary {
                             updatedById,
                             owner,
                             workflowStatus,
+                            customPropertyMembers,
+                            importJobDefinitionKey,
+                            importJobKey,
+                            latestImportJobExecutionKey,
+                            latestImportJobExecutionStatus,
                             uri);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -176,6 +227,11 @@ public class Glossary {
                             .updatedById(o.getUpdatedById())
                             .owner(o.getOwner())
                             .workflowStatus(o.getWorkflowStatus())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
+                            .importJobDefinitionKey(o.getImportJobDefinitionKey())
+                            .importJobKey(o.getImportJobKey())
+                            .latestImportJobExecutionKey(o.getLatestImportJobExecutionKey())
+                            .latestImportJobExecutionStatus(o.getLatestImportJobExecutionStatus())
                             .uri(o.getUri());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -260,6 +316,38 @@ public class Glossary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workflowStatus")
     TermWorkflowStatus workflowStatus;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+    /**
+     * The unique key of the job definition resource that was used in the Glossary import.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("importJobDefinitionKey")
+    String importJobDefinitionKey;
+
+    /**
+     * The unique key of the job policy for Glossary import.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("importJobKey")
+    String importJobKey;
+
+    /**
+     * The unique key of the parent job execution for which the log resource was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionKey")
+    String latestImportJobExecutionKey;
+
+    /**
+     * Status of the latest glossary import job execution, such as running, paused, or completed.
+     * This may include additional information like time import started , import file size and % of completion
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionStatus")
+    String latestImportJobExecutionStatus;
 
     /**
      * URI to the tag instance in the API.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/GlossarySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/GlossarySummary.java
@@ -104,6 +104,42 @@ public class GlossarySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("importJobDefinitionKey")
+        private String importJobDefinitionKey;
+
+        public Builder importJobDefinitionKey(String importJobDefinitionKey) {
+            this.importJobDefinitionKey = importJobDefinitionKey;
+            this.__explicitlySet__.add("importJobDefinitionKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("importJobKey")
+        private String importJobKey;
+
+        public Builder importJobKey(String importJobKey) {
+            this.importJobKey = importJobKey;
+            this.__explicitlySet__.add("importJobKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionKey")
+        private String latestImportJobExecutionKey;
+
+        public Builder latestImportJobExecutionKey(String latestImportJobExecutionKey) {
+            this.latestImportJobExecutionKey = latestImportJobExecutionKey;
+            this.__explicitlySet__.add("latestImportJobExecutionKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionStatus")
+        private String latestImportJobExecutionStatus;
+
+        public Builder latestImportJobExecutionStatus(String latestImportJobExecutionStatus) {
+            this.latestImportJobExecutionStatus = latestImportJobExecutionStatus;
+            this.__explicitlySet__.add("latestImportJobExecutionStatus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -117,7 +153,11 @@ public class GlossarySummary {
                             description,
                             uri,
                             workflowStatus,
-                            lifecycleState);
+                            lifecycleState,
+                            importJobDefinitionKey,
+                            importJobKey,
+                            latestImportJobExecutionKey,
+                            latestImportJobExecutionStatus);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -132,7 +172,11 @@ public class GlossarySummary {
                             .description(o.getDescription())
                             .uri(o.getUri())
                             .workflowStatus(o.getWorkflowStatus())
-                            .lifecycleState(o.getLifecycleState());
+                            .lifecycleState(o.getLifecycleState())
+                            .importJobDefinitionKey(o.getImportJobDefinitionKey())
+                            .importJobKey(o.getImportJobKey())
+                            .latestImportJobExecutionKey(o.getLatestImportJobExecutionKey())
+                            .latestImportJobExecutionStatus(o.getLatestImportJobExecutionStatus());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -197,6 +241,32 @@ public class GlossarySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * The unique key of the job definition resource that was used in the Glossary import.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("importJobDefinitionKey")
+    String importJobDefinitionKey;
+
+    /**
+     * The unique key of the job policy for Glossary import.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("importJobKey")
+    String importJobKey;
+
+    /**
+     * The unique key of the parent job execution for which the log resource was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionKey")
+    String latestImportJobExecutionKey;
+
+    /**
+     * Status of the latest glossary import job execution, such as running, paused, or completed.
+     * This may include additional information like time import started , import file size and % of completion
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestImportJobExecutionStatus")
+    String latestImportJobExecutionStatus;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Namespace.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Namespace.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Namespace Definition
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Namespace.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Namespace {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+        private String createdById;
+
+        public Builder createdById(String createdById) {
+            this.createdById = createdById;
+            this.__explicitlySet__.add("createdById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+        private String updatedById;
+
+        public Builder updatedById(String updatedById) {
+            this.updatedById = updatedById;
+            this.__explicitlySet__.add("updatedById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Namespace build() {
+            Namespace __instance__ =
+                    new Namespace(
+                            key,
+                            displayName,
+                            description,
+                            isServiceDefined,
+                            lifecycleState,
+                            timeCreated,
+                            timeUpdated,
+                            createdById,
+                            updatedById);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Namespace o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .isServiceDefined(o.getIsServiceDefined())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .createdById(o.getCreatedById())
+                            .updatedById(o.getUpdatedById());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique namespace key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Name of the Namespace
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Description for the namespace
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    /**
+     * The current state of the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the namespace was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The last time that any change was made to the namespace. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+    String createdById;
+
+    /**
+     * OCID of the user who last modified the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+    String updatedById;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/NamespaceCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/NamespaceCollection.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Results of a namespaces listing. A namespace is an unique name tied to the first class object of data catalog which will be used to create a custom property
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NamespaceCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NamespaceCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<NamespaceSummary> items;
+
+        public Builder items(java.util.List<NamespaceSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NamespaceCollection build() {
+            NamespaceCollection __instance__ = new NamespaceCollection(count, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NamespaceCollection o) {
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
+
+    /**
+     * Collection of namespace summaries
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<NamespaceSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/NamespaceSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/NamespaceSummary.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Summary of a namespace
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = NamespaceSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NamespaceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NamespaceSummary build() {
+            NamespaceSummary __instance__ =
+                    new NamespaceSummary(
+                            key,
+                            displayName,
+                            description,
+                            isServiceDefined,
+                            lifecycleState,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NamespaceSummary o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .isServiceDefined(o.getIsServiceDefined())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique namespace key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Name of the namespace
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    /**
+     * The current state of the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the namespace was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Pattern.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Pattern.java
@@ -1,0 +1,313 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Pattern representation. A Pattern is defined using an expression and can be used as data selectors or filters
+ * to provide a singular view of an entity across multiple physical data artifacts.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Pattern.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Pattern {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("catalogId")
+        private String catalogId;
+
+        public Builder catalogId(String catalogId) {
+            this.catalogId = catalogId;
+            this.__explicitlySet__.add("catalogId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+        private String createdById;
+
+        public Builder createdById(String createdById) {
+            this.createdById = createdById;
+            this.__explicitlySet__.add("createdById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+        private String updatedById;
+
+        public Builder updatedById(String updatedById) {
+            this.updatedById = updatedById;
+            this.__explicitlySet__.add("updatedById");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+        private java.util.List<String> checkFilePathList;
+
+        public Builder checkFilePathList(java.util.List<String> checkFilePathList) {
+            this.checkFilePathList = checkFilePathList;
+            this.__explicitlySet__.add("checkFilePathList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+        private Boolean isEnableCheckFailureLimit;
+
+        public Builder isEnableCheckFailureLimit(Boolean isEnableCheckFailureLimit) {
+            this.isEnableCheckFailureLimit = isEnableCheckFailureLimit;
+            this.__explicitlySet__.add("isEnableCheckFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+        private Integer checkFailureLimit;
+
+        public Builder checkFailureLimit(Integer checkFailureLimit) {
+            this.checkFailureLimit = checkFailureLimit;
+            this.__explicitlySet__.add("checkFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Pattern build() {
+            Pattern __instance__ =
+                    new Pattern(
+                            key,
+                            displayName,
+                            description,
+                            catalogId,
+                            lifecycleState,
+                            timeCreated,
+                            timeUpdated,
+                            createdById,
+                            updatedById,
+                            expression,
+                            checkFilePathList,
+                            isEnableCheckFailureLimit,
+                            checkFailureLimit,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Pattern o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .catalogId(o.getCatalogId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .createdById(o.getCreatedById())
+                            .updatedById(o.getUpdatedById())
+                            .expression(o.getExpression())
+                            .checkFilePathList(o.getCheckFilePathList())
+                            .isEnableCheckFailureLimit(o.getIsEnableCheckFailureLimit())
+                            .checkFailureLimit(o.getCheckFailureLimit())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique pattern key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The data catalog's OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("catalogId")
+    String catalogId;
+
+    /**
+     * The current state of the data asset.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the pattern was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The last time that any change was made to the pattern. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdById")
+    String createdById;
+
+    /**
+     * OCID of the user who last modified the pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("updatedById")
+    String updatedById;
+
+    /**
+     * The expression used in the pattern that may include qualifiers. Refer to the user documentation for details of the format and examples.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * List of file paths against which the expression can be tried, as a check. This documents, for reference
+     * purposes, some example objects a pattern is meant to work with. If isEnableCheckFailureLimit is set to true,
+     * this will be run as a validation during the request, such that if the check fails the request fails. If
+     * isEnableCheckFailureLimit instead is set to (the default) false, a pattern will still be created or updated even
+     * if the check fails, with a lifecycleState of FAILED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+    java.util.List<String> checkFilePathList;
+
+    /**
+     * Indicates whether the expression check, against the checkFilePathList, will fail the request if the count of
+     * UNMATCHED files is above the checkFailureLimit.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+    Boolean isEnableCheckFailureLimit;
+
+    /**
+     * The maximum number of UNMATCHED files, in checkFilePathList, above which the check fails. Optional, if
+     * checkFilePathList is provided - but if isEnableCheckFailureLimit is set to true it is required.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+    Integer checkFailureLimit;
+
+    /**
+     * A map of maps that contains the properties which are specific to the pattern type. Each pattern type
+     * definition defines it's set of required and optional properties.
+     * Example: `{\"properties\": { \"default\": { \"tbd\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/PatternCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/PatternCollection.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Results of a patterns listing.  A Pattern is defined using an expression and can be used as data selectors or filters
+ * to provide a singular view of an entity across multiple physical data artifacts.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PatternCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PatternCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("count")
+        private Integer count;
+
+        public Builder count(Integer count) {
+            this.count = count;
+            this.__explicitlySet__.add("count");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<PatternSummary> items;
+
+        public Builder items(java.util.List<PatternSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PatternCollection build() {
+            PatternCollection __instance__ = new PatternCollection(count, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PatternCollection o) {
+            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("count")
+    Integer count;
+
+    /**
+     * Collection of pattern summaries.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<PatternSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/PatternSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/PatternSummary.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Summary of a pattern. A Pattern is defined using an expression and can be used as data selectors or filters
+ * to provide a singular view of an entity across multiple physical data artifacts.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PatternSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PatternSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("catalogId")
+        private String catalogId;
+
+        public Builder catalogId(String catalogId) {
+            this.catalogId = catalogId;
+            this.__explicitlySet__.add("catalogId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PatternSummary build() {
+            PatternSummary __instance__ =
+                    new PatternSummary(
+                            key,
+                            displayName,
+                            description,
+                            catalogId,
+                            timeCreated,
+                            expression,
+                            lifecycleState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PatternSummary o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .catalogId(o.getCatalogId())
+                            .timeCreated(o.getTimeCreated())
+                            .expression(o.getExpression())
+                            .lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique pattern key that is immutable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The data catalog's OCID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("catalogId")
+    String catalogId;
+
+    /**
+     * The date and time the pattern was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2019-03-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The expression used in the pattern that may include qualifiers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * State of the pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchCriteria.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchCriteria.java
@@ -34,18 +34,60 @@ public class SearchCriteria {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("facetedQuery")
+        private String facetedQuery;
+
+        public Builder facetedQuery(String facetedQuery) {
+            this.facetedQuery = facetedQuery;
+            this.__explicitlySet__.add("facetedQuery");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dimensions")
+        private java.util.List<String> dimensions;
+
+        public Builder dimensions(java.util.List<String> dimensions) {
+            this.dimensions = dimensions;
+            this.__explicitlySet__.add("dimensions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sort")
+        private java.util.List<FacetedSearchSortRequest> sort;
+
+        public Builder sort(java.util.List<FacetedSearchSortRequest> sort) {
+            this.sort = sort;
+            this.__explicitlySet__.add("sort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("filters")
+        private FacetedSearchFilterRequest filters;
+
+        public Builder filters(FacetedSearchFilterRequest filters) {
+            this.filters = filters;
+            this.__explicitlySet__.add("filters");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public SearchCriteria build() {
-            SearchCriteria __instance__ = new SearchCriteria(query);
+            SearchCriteria __instance__ =
+                    new SearchCriteria(query, facetedQuery, dimensions, sort, filters);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SearchCriteria o) {
-            Builder copiedBuilder = query(o.getQuery());
+            Builder copiedBuilder =
+                    query(o.getQuery())
+                            .facetedQuery(o.getFacetedQuery())
+                            .dimensions(o.getDimensions())
+                            .sort(o.getSort())
+                            .filters(o.getFilters());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -64,6 +106,27 @@ public class SearchCriteria {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("query")
     String query;
+
+    /**
+     * Query string that a dataObject is to be searched with. Used in the faceted query request
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("facetedQuery")
+    String facetedQuery;
+
+    /**
+     * List of properties of dataObjects that needs to aggregated on for facets.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dimensions")
+    java.util.List<String> dimensions;
+
+    /**
+     * Array of objects having details about sort field and order.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sort")
+    java.util.List<FacetedSearchSortRequest> sort;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("filters")
+    FacetedSearchFilterRequest filters;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResult.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResult.java
@@ -261,6 +261,25 @@ public class SearchResult {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customProperties")
+        private java.util.List<FacetedSearchCustomProperty> customProperties;
+
+        public Builder customProperties(
+                java.util.List<FacetedSearchCustomProperty> customProperties) {
+            this.customProperties = customProperties;
+            this.__explicitlySet__.add("customProperties");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -292,7 +311,9 @@ public class SearchResult {
                             parentTermName,
                             createdById,
                             updatedById,
-                            path);
+                            path,
+                            expression,
+                            customProperties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -325,7 +346,9 @@ public class SearchResult {
                             .parentTermName(o.getParentTermName())
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
-                            .path(o.getPath());
+                            .path(o.getPath())
+                            .expression(o.getExpression())
+                            .customProperties(o.getCustomProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -498,6 +521,18 @@ public class SearchResult {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("path")
     String path;
+
+    /**
+     * Expression for logical entities against which names of dataObjects will be matched.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * Custom properties defined by users.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customProperties")
+    java.util.List<FacetedSearchCustomProperty> customProperties;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResultCollection.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResultCollection.java
@@ -46,18 +46,42 @@ public class SearchResultCollection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("query")
+        private String query;
+
+        public Builder query(String query) {
+            this.query = query;
+            this.__explicitlySet__.add("query");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("facetedSearchAggregation")
+        private java.util.List<FacetedSearchAggregation> facetedSearchAggregation;
+
+        public Builder facetedSearchAggregation(
+                java.util.List<FacetedSearchAggregation> facetedSearchAggregation) {
+            this.facetedSearchAggregation = facetedSearchAggregation;
+            this.__explicitlySet__.add("facetedSearchAggregation");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public SearchResultCollection build() {
-            SearchResultCollection __instance__ = new SearchResultCollection(count, items);
+            SearchResultCollection __instance__ =
+                    new SearchResultCollection(count, items, query, facetedSearchAggregation);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(SearchResultCollection o) {
-            Builder copiedBuilder = count(o.getCount()).items(o.getItems());
+            Builder copiedBuilder =
+                    count(o.getCount())
+                            .items(o.getItems())
+                            .query(o.getQuery())
+                            .facetedSearchAggregation(o.getFacetedSearchAggregation());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -82,6 +106,18 @@ public class SearchResultCollection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<SearchResult> items;
+
+    /**
+     * String that data objects are to be searched with.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("query")
+    String query;
+
+    /**
+     * Aggregations/facets on properties of data objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("facetedSearchAggregation")
+    java.util.List<FacetedSearchAggregation> facetedSearchAggregation;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Term.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Term.java
@@ -180,6 +180,16 @@ public class Term {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -202,7 +212,8 @@ public class Term {
                             workflowStatus,
                             uri,
                             associatedObjectCount,
-                            associatedObjects);
+                            associatedObjects,
+                            customPropertyMembers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -226,7 +237,8 @@ public class Term {
                             .workflowStatus(o.getWorkflowStatus())
                             .uri(o.getUri())
                             .associatedObjectCount(o.getAssociatedObjectCount())
-                            .associatedObjects(o.getAssociatedObjects());
+                            .associatedObjects(o.getAssociatedObjects())
+                            .customPropertyMembers(o.getCustomPropertyMembers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -346,6 +358,12 @@ public class Term {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("associatedObjects")
     java.util.List<TermAssociatedObject> associatedObjects;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Type.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Type.java
@@ -135,6 +135,15 @@ public class Type {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customProperties")
+        private java.util.List<CustomPropertySummary> customProperties;
+
+        public Builder customProperties(java.util.List<CustomPropertySummary> customProperties) {
+            this.customProperties = customProperties;
+            this.__explicitlySet__.add("customProperties");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -152,7 +161,8 @@ public class Type {
                             isApproved,
                             typeCategory,
                             externalTypeName,
-                            uri);
+                            uri,
+                            customProperties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -171,7 +181,8 @@ public class Type {
                             .isApproved(o.getIsApproved())
                             .typeCategory(o.getTypeCategory())
                             .externalTypeName(o.getExternalTypeName())
-                            .uri(o.getUri());
+                            .uri(o.getUri())
+                            .customProperties(o.getCustomProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -275,6 +286,12 @@ public class Type {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("uri")
     String uri;
+
+    /**
+     * Custom properties associated with this Type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customProperties")
+    java.util.List<CustomPropertySummary> customProperties;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TypeCustomPropertyDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/TypeCustomPropertyDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Array of custom property IDs for which we have to associate the custom property to the type
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TypeCustomPropertyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TypeCustomPropertyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyIds")
+        private java.util.List<String> customPropertyIds;
+
+        public Builder customPropertyIds(java.util.List<String> customPropertyIds) {
+            this.customPropertyIds = customPropertyIds;
+            this.__explicitlySet__.add("customPropertyIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TypeCustomPropertyDetails build() {
+            TypeCustomPropertyDetails __instance__ =
+                    new TypeCustomPropertyDetails(customPropertyIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TypeCustomPropertyDetails o) {
+            Builder copiedBuilder = customPropertyIds(o.getCustomPropertyIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * array of custom property Ids
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyIds")
+    java.util.List<String> customPropertyIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
@@ -152,6 +152,16 @@ public class UpdateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -181,6 +191,7 @@ public class UpdateAttributeDetails {
                             maxCollectionCount,
                             externalDatatypeEntityKey,
                             externalParentAttributeKey,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -203,6 +214,7 @@ public class UpdateAttributeDetails {
                             .maxCollectionCount(o.getMaxCollectionCount())
                             .externalDatatypeEntityKey(o.getExternalDatatypeEntityKey())
                             .externalParentAttributeKey(o.getExternalParentAttributeKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -305,6 +317,12 @@ public class UpdateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalParentAttributeKey")
     String externalParentAttributeKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the attribute type. Each attribute type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateConnectionDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateConnectionDetails.java
@@ -44,6 +44,16 @@ public class UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -78,7 +88,12 @@ public class UpdateConnectionDetails {
         public UpdateConnectionDetails build() {
             UpdateConnectionDetails __instance__ =
                     new UpdateConnectionDetails(
-                            description, displayName, properties, encProperties, isDefault);
+                            description,
+                            displayName,
+                            customPropertyMembers,
+                            properties,
+                            encProperties,
+                            isDefault);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -88,6 +103,7 @@ public class UpdateConnectionDetails {
             Builder copiedBuilder =
                     description(o.getDescription())
                             .displayName(o.getDisplayName())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .encProperties(o.getEncProperties())
                             .isDefault(o.getIsDefault());
@@ -117,6 +133,12 @@ public class UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the connection type. Each connection type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateCustomPropertyDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateCustomPropertyDetails.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in custom atrribute update operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateCustomPropertyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateCustomPropertyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+        private Boolean isSortable;
+
+        public Builder isSortable(Boolean isSortable) {
+            this.isSortable = isSortable;
+            this.__explicitlySet__.add("isSortable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+        private Boolean isFilterable;
+
+        public Builder isFilterable(Boolean isFilterable) {
+            this.isFilterable = isFilterable;
+            this.__explicitlySet__.add("isFilterable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+        private Boolean isMultiValued;
+
+        public Builder isMultiValued(Boolean isMultiValued) {
+            this.isMultiValued = isMultiValued;
+            this.__explicitlySet__.add("isMultiValued");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+        private Boolean isHidden;
+
+        public Builder isHidden(Boolean isHidden) {
+            this.isHidden = isHidden;
+            this.__explicitlySet__.add("isHidden");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+        private Boolean isEditable;
+
+        public Builder isEditable(Boolean isEditable) {
+            this.isEditable = isEditable;
+            this.__explicitlySet__.add("isEditable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+        private Boolean isHiddenInSearch;
+
+        public Builder isHiddenInSearch(Boolean isHiddenInSearch) {
+            this.isHiddenInSearch = isHiddenInSearch;
+            this.__explicitlySet__.add("isHiddenInSearch");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+        private java.util.List<String> allowedValues;
+
+        public Builder allowedValues(java.util.List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+            this.__explicitlySet__.add("allowedValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateCustomPropertyDetails build() {
+            UpdateCustomPropertyDetails __instance__ =
+                    new UpdateCustomPropertyDetails(
+                            displayName,
+                            description,
+                            isSortable,
+                            isFilterable,
+                            isMultiValued,
+                            isHidden,
+                            isEditable,
+                            isHiddenInSearch,
+                            allowedValues,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateCustomPropertyDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .isSortable(o.getIsSortable())
+                            .isFilterable(o.getIsFilterable())
+                            .isMultiValued(o.getIsMultiValued())
+                            .isHidden(o.getIsHidden())
+                            .isEditable(o.getIsEditable())
+                            .isHiddenInSearch(o.getIsHiddenInSearch())
+                            .allowedValues(o.getAllowedValues())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the data asset.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * If this field allows to sort from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSortable")
+    Boolean isSortable;
+
+    /**
+     * If this field allows to filter or create facets from UI
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isFilterable")
+    Boolean isFilterable;
+
+    /**
+     * If this field allows multiple values to be set
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isMultiValued")
+    Boolean isMultiValued;
+
+    /**
+     * If this field is a hidden field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHidden")
+    Boolean isHidden;
+
+    /**
+     * If this field is a editable field
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
+    Boolean isEditable;
+
+    /**
+     * If this field is allowed to pop in search results
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
+    Boolean isHiddenInSearch;
+
+    /**
+     * Allowed values for the custom property if any
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowedValues")
+    java.util.List<String> allowedValues;
+
+    /**
+     * A map of maps that contains the properties which are specific to the asset type. Each data asset type
+     * definition defines it's set of required and optional properties. The map keys are category names and the
+     * values are maps of property name to property value. Every property is contained inside of a category. Most
+     * data assets have required properties within the \"default\" category.
+     * Example: `{\"properties\": { \"default\": { \"host\": \"host1\", \"port\": \"1521\", \"database\": \"orcl\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateDataAssetDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateDataAssetDetails.java
@@ -44,6 +44,16 @@ public class UpdateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -58,7 +68,8 @@ public class UpdateDataAssetDetails {
 
         public UpdateDataAssetDetails build() {
             UpdateDataAssetDetails __instance__ =
-                    new UpdateDataAssetDetails(displayName, description, properties);
+                    new UpdateDataAssetDetails(
+                            displayName, description, customPropertyMembers, properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -68,6 +79,7 @@ public class UpdateDataAssetDetails {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -95,6 +107,12 @@ public class UpdateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the asset type. Each data asset type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateEntityDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateEntityDetails.java
@@ -80,6 +80,24 @@ public class UpdateEntityDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+        private String patternKey;
+
+        public Builder patternKey(String patternKey) {
+            this.patternKey = patternKey;
+            this.__explicitlySet__.add("patternKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+        private String realizedExpression;
+
+        public Builder realizedExpression(String realizedExpression) {
+            this.realizedExpression = realizedExpression;
+            this.__explicitlySet__.add("realizedExpression");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("harvestStatus")
         private HarvestStatus harvestStatus;
 
@@ -95,6 +113,16 @@ public class UpdateEntityDetails {
         public Builder lastJobKey(String lastJobKey) {
             this.lastJobKey = lastJobKey;
             this.__explicitlySet__.add("lastJobKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
             return this;
         }
 
@@ -119,8 +147,11 @@ public class UpdateEntityDetails {
                             isLogical,
                             isPartition,
                             folderKey,
+                            patternKey,
+                            realizedExpression,
                             harvestStatus,
                             lastJobKey,
+                            customPropertyMembers,
                             properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -135,8 +166,11 @@ public class UpdateEntityDetails {
                             .isLogical(o.getIsLogical())
                             .isPartition(o.getIsPartition())
                             .folderKey(o.getFolderKey())
+                            .patternKey(o.getPatternKey())
+                            .realizedExpression(o.getRealizedExpression())
                             .harvestStatus(o.getHarvestStatus())
                             .lastJobKey(o.getLastJobKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -190,6 +224,18 @@ public class UpdateEntityDetails {
     String folderKey;
 
     /**
+     * Key of the associated pattern if this is a logical entity.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
+    String patternKey;
+
+    /**
+     * The expression realized after resolving qualifiers . Used in deriving this logical entity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("realizedExpression")
+    String realizedExpression;
+
+    /**
      * Status of the object as updated by the harvest process. When an entity object is created, it's harvest status
      * will indicate if the entity's metadata has been fully harvested or not. The harvest process can perform
      * shallow harvesting to allow users to browse the metadata and can on-demand deep harvest on any object
@@ -204,6 +250,12 @@ public class UpdateEntityDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lastJobKey")
     String lastJobKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the entity type. Each entity type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateFolderDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateFolderDetails.java
@@ -53,6 +53,16 @@ public class UpdateFolderDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("properties")
         private java.util.Map<String, java.util.Map<String, String>> properties;
 
@@ -98,6 +108,7 @@ public class UpdateFolderDetails {
                             displayName,
                             description,
                             parentFolderKey,
+                            customPropertyMembers,
                             properties,
                             timeExternal,
                             harvestStatus,
@@ -112,6 +123,7 @@ public class UpdateFolderDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .parentFolderKey(o.getParentFolderKey())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
                             .timeExternal(o.getTimeExternal())
                             .harvestStatus(o.getHarvestStatus())
@@ -148,6 +160,12 @@ public class UpdateFolderDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parentFolderKey")
     String parentFolderKey;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     /**
      * A map of maps that contains the properties which are specific to the folder type. Each folder type

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateGlossaryDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateGlossaryDetails.java
@@ -62,12 +62,23 @@ public class UpdateGlossaryDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateGlossaryDetails build() {
             UpdateGlossaryDetails __instance__ =
-                    new UpdateGlossaryDetails(displayName, description, owner, workflowStatus);
+                    new UpdateGlossaryDetails(
+                            displayName, description, owner, workflowStatus, customPropertyMembers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,7 +89,8 @@ public class UpdateGlossaryDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .owner(o.getOwner())
-                            .workflowStatus(o.getWorkflowStatus());
+                            .workflowStatus(o.getWorkflowStatus())
+                            .customPropertyMembers(o.getCustomPropertyMembers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -117,6 +129,12 @@ public class UpdateGlossaryDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workflowStatus")
     TermWorkflowStatus workflowStatus;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateNamespaceDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateNamespaceDetails.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in namespace update operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateNamespaceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateNamespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+        private Boolean isServiceDefined;
+
+        public Builder isServiceDefined(Boolean isServiceDefined) {
+            this.isServiceDefined = isServiceDefined;
+            this.__explicitlySet__.add("isServiceDefined");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateNamespaceDetails build() {
+            UpdateNamespaceDetails __instance__ =
+                    new UpdateNamespaceDetails(displayName, description, isServiceDefined);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateNamespaceDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .isServiceDefined(o.getIsServiceDefined());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * If this field is defined by service or by a user
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
+    Boolean isServiceDefined;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdatePatternDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdatePatternDetails.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Properties used in pattern update operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdatePatternDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdatePatternDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+        private java.util.List<String> checkFilePathList;
+
+        public Builder checkFilePathList(java.util.List<String> checkFilePathList) {
+            this.checkFilePathList = checkFilePathList;
+            this.__explicitlySet__.add("checkFilePathList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+        private Boolean isEnableCheckFailureLimit;
+
+        public Builder isEnableCheckFailureLimit(Boolean isEnableCheckFailureLimit) {
+            this.isEnableCheckFailureLimit = isEnableCheckFailureLimit;
+            this.__explicitlySet__.add("isEnableCheckFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+        private Integer checkFailureLimit;
+
+        public Builder checkFailureLimit(Integer checkFailureLimit) {
+            this.checkFailureLimit = checkFailureLimit;
+            this.__explicitlySet__.add("checkFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("properties")
+        private java.util.Map<String, java.util.Map<String, String>> properties;
+
+        public Builder properties(java.util.Map<String, java.util.Map<String, String>> properties) {
+            this.properties = properties;
+            this.__explicitlySet__.add("properties");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdatePatternDetails build() {
+            UpdatePatternDetails __instance__ =
+                    new UpdatePatternDetails(
+                            displayName,
+                            description,
+                            expression,
+                            checkFilePathList,
+                            isEnableCheckFailureLimit,
+                            checkFailureLimit,
+                            properties);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdatePatternDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .expression(o.getExpression())
+                            .checkFilePathList(o.getCheckFilePathList())
+                            .isEnableCheckFailureLimit(o.getIsEnableCheckFailureLimit())
+                            .checkFailureLimit(o.getCheckFailureLimit())
+                            .properties(o.getProperties());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Detailed description of the Pattern.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The expression used in the pattern that may include qualifiers. Refer to the user documentation for details of the format and examples.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * List of file paths against which the expression can be tried, as a check. This documents, for reference
+     * purposes, some example objects a pattern is meant to work with. If isEnableCheckFailureLimit is set to true,
+     * this will be run as a validation during the request, such that if the check fails the request fails. If
+     * isEnableCheckFailureLimit instead is set to (the default) false, a pattern will still be created or updated even
+     * if the check fails, with a lifecycleState of FAILED.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+    java.util.List<String> checkFilePathList;
+
+    /**
+     * Indicates whether the expression check, against the checkFilePathList, will fail the request if the count of
+     * UNMATCHED files is above the checkFailureLimit.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnableCheckFailureLimit")
+    Boolean isEnableCheckFailureLimit;
+
+    /**
+     * The maximum number of UNMATCHED files, in checkFilePathList, above which the check fails. Optional, if
+     * checkFilePathList is provided - but if isEnableCheckFailureLimit is set to true it is required.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+    Integer checkFailureLimit;
+
+    /**
+     * A map of maps that contains the properties which are specific to the pattern type. Each pattern type
+     * definition defines it's set of required and optional properties.
+     * Example: `{\"properties\": { \"default\": { \"tbd\"}}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("properties")
+    java.util.Map<String, java.util.Map<String, String>> properties;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateTermDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateTermDetails.java
@@ -71,13 +71,28 @@ public class UpdateTermDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertySetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertySetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateTermDetails build() {
             UpdateTermDetails __instance__ =
                     new UpdateTermDetails(
-                            displayName, description, parentTermKey, owner, workflowStatus);
+                            displayName,
+                            description,
+                            parentTermKey,
+                            owner,
+                            workflowStatus,
+                            customPropertyMembers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,7 +104,8 @@ public class UpdateTermDetails {
                             .description(o.getDescription())
                             .parentTermKey(o.getParentTermKey())
                             .owner(o.getOwner())
-                            .workflowStatus(o.getWorkflowStatus());
+                            .workflowStatus(o.getWorkflowStatus())
+                            .customPropertyMembers(o.getCustomPropertyMembers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -134,6 +150,12 @@ public class UpdateTermDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workflowStatus")
     TermWorkflowStatus workflowStatus;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertySetUsage> customPropertyMembers;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ValidatePatternDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ValidatePatternDetails.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Validate pattern using the expression and file list.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ValidatePatternDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ValidatePatternDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+        private java.util.List<String> checkFilePathList;
+
+        public Builder checkFilePathList(java.util.List<String> checkFilePathList) {
+            this.checkFilePathList = checkFilePathList;
+            this.__explicitlySet__.add("checkFilePathList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+        private Integer checkFailureLimit;
+
+        public Builder checkFailureLimit(Integer checkFailureLimit) {
+            this.checkFailureLimit = checkFailureLimit;
+            this.__explicitlySet__.add("checkFailureLimit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ValidatePatternDetails build() {
+            ValidatePatternDetails __instance__ =
+                    new ValidatePatternDetails(expression, checkFilePathList, checkFailureLimit);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ValidatePatternDetails o) {
+            Builder copiedBuilder =
+                    expression(o.getExpression())
+                            .checkFilePathList(o.getCheckFilePathList())
+                            .checkFailureLimit(o.getCheckFailureLimit());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The expression used in the pattern that may include qualifiers. Refer to the user documentation for details of the format and examples.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * List of file paths against which the expression can be tried, as a check. This documents, for reference
+     * purposes, some example objects a pattern is meant to work with.
+     * <p>
+     * If provided with the request,this overrides the list which already exists as part of the pattern, if any.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFilePathList")
+    java.util.List<String> checkFilePathList;
+
+    /**
+     * The maximum number of UNMATCHED files, in checkFilePathList, above which the check fails.
+     * Optional, if checkFilePathList is provided.
+     * <p>
+     * If provided with the request, this overrides the value which already exists as part of the pattern, if any.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("checkFailureLimit")
+    Integer checkFailureLimit;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ValidatePatternResult.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/ValidatePatternResult.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Details regarding the validation of a pattern resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ValidatePatternResult.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ValidatePatternResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private String status;
+
+        public Builder status(String status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expression")
+        private String expression;
+
+        public Builder expression(String expression) {
+            this.expression = expression;
+            this.__explicitlySet__.add("expression");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("derivedLogicalEntities")
+        private java.util.List<DerivedLogicalEntities> derivedLogicalEntities;
+
+        public Builder derivedLogicalEntities(
+                java.util.List<DerivedLogicalEntities> derivedLogicalEntities) {
+            this.derivedLogicalEntities = derivedLogicalEntities;
+            this.__explicitlySet__.add("derivedLogicalEntities");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ValidatePatternResult build() {
+            ValidatePatternResult __instance__ =
+                    new ValidatePatternResult(message, status, expression, derivedLogicalEntities);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ValidatePatternResult o) {
+            Builder copiedBuilder =
+                    message(o.getMessage())
+                            .status(o.getStatus())
+                            .expression(o.getExpression())
+                            .derivedLogicalEntities(o.getDerivedLogicalEntities());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The message from the pattern validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * The status returned from the pattern validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    String status;
+
+    /**
+     * The expression used in the pattern validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expression")
+    String expression;
+
+    /**
+     * Collection of logical entities derived from the expression applied to a list of file paths.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("derivedLogicalEntities")
+    java.util.List<DerivedLogicalEntities> derivedLogicalEntities;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/AddDataSelectorPatternsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/AddDataSelectorPatternsRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AddDataSelectorPatternsRequest
+        extends com.oracle.bmc.requests.BmcRequest<DataSelectorPatternDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique data asset key.
+     */
+    private String dataAssetKey;
+
+    /**
+     * The information used to add the patterns for deriving logical entities.
+     */
+    private DataSelectorPatternDetails dataSelectorPatternDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public DataSelectorPatternDetails getBody$() {
+        return dataSelectorPatternDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AddDataSelectorPatternsRequest, DataSelectorPatternDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddDataSelectorPatternsRequest o) {
+            catalogId(o.getCatalogId());
+            dataAssetKey(o.getDataAssetKey());
+            dataSelectorPatternDetails(o.getDataSelectorPatternDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AddDataSelectorPatternsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AddDataSelectorPatternsRequest
+         */
+        public AddDataSelectorPatternsRequest build() {
+            AddDataSelectorPatternsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(DataSelectorPatternDetails body) {
+            dataSelectorPatternDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/AssociateCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/AssociateCustomPropertyRequest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AssociateCustomPropertyRequest
+        extends com.oracle.bmc.requests.BmcRequest<TypeCustomPropertyDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique type key.
+     */
+    private String typeKey;
+
+    /**
+     * The information used to associate the custom property for the type.
+     *
+     */
+    private TypeCustomPropertyDetails associateCustomPropertyDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public TypeCustomPropertyDetails getBody$() {
+        return associateCustomPropertyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AssociateCustomPropertyRequest, TypeCustomPropertyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AssociateCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            typeKey(o.getTypeKey());
+            associateCustomPropertyDetails(o.getAssociateCustomPropertyDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AssociateCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AssociateCustomPropertyRequest
+         */
+        public AssociateCustomPropertyRequest build() {
+            AssociateCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(TypeCustomPropertyDetails body) {
+            associateCustomPropertyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreateCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreateCustomPropertyRequest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateCustomPropertyRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateCustomPropertyDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * The information used to create the Custom Property.
+     *
+     */
+    private CreateCustomPropertyDetails createCustomPropertyDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateCustomPropertyDetails getBody$() {
+        return createCustomPropertyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateCustomPropertyRequest, CreateCustomPropertyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            createCustomPropertyDetails(o.getCreateCustomPropertyDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateCustomPropertyRequest
+         */
+        public CreateCustomPropertyRequest build() {
+            CreateCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateCustomPropertyDetails body) {
+            createCustomPropertyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreateNamespaceRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreateNamespaceRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateNamespaceRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateNamespaceDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * The information used to create the Namespace.
+     *
+     */
+    private CreateNamespaceDetails createNamespaceDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateNamespaceDetails getBody$() {
+        return createNamespaceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateNamespaceRequest, CreateNamespaceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateNamespaceRequest o) {
+            catalogId(o.getCatalogId());
+            createNamespaceDetails(o.getCreateNamespaceDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateNamespaceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateNamespaceRequest
+         */
+        public CreateNamespaceRequest build() {
+            CreateNamespaceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateNamespaceDetails body) {
+            createNamespaceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreatePatternRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/CreatePatternRequest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreatePatternRequest extends com.oracle.bmc.requests.BmcRequest<CreatePatternDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * The information used to create the pattern.
+     */
+    private CreatePatternDetails createPatternDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreatePatternDetails getBody$() {
+        return createPatternDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreatePatternRequest, CreatePatternDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePatternRequest o) {
+            catalogId(o.getCatalogId());
+            createPatternDetails(o.getCreatePatternDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreatePatternRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreatePatternRequest
+         */
+        public CreatePatternRequest build() {
+            CreatePatternRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreatePatternDetails body) {
+            createPatternDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeleteCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeleteCustomPropertyRequest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteCustomPropertyRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * Unique Custom Property key
+     */
+    private String customPropertyKey;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteCustomPropertyRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            customPropertyKey(o.getCustomPropertyKey());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteCustomPropertyRequest
+         */
+        public DeleteCustomPropertyRequest build() {
+            DeleteCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeleteNamespaceRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeleteNamespaceRequest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteNamespaceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteNamespaceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteNamespaceRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteNamespaceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteNamespaceRequest
+         */
+        public DeleteNamespaceRequest build() {
+            DeleteNamespaceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeletePatternRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DeletePatternRequest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeletePatternRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeletePatternRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePatternRequest o) {
+            catalogId(o.getCatalogId());
+            patternKey(o.getPatternKey());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeletePatternRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeletePatternRequest
+         */
+        public DeletePatternRequest build() {
+            DeletePatternRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DisassociateCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/DisassociateCustomPropertyRequest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DisassociateCustomPropertyRequest
+        extends com.oracle.bmc.requests.BmcRequest<TypeCustomPropertyDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique type key.
+     */
+    private String typeKey;
+
+    /**
+     * The information used to remove the custom properties.
+     *
+     */
+    private TypeCustomPropertyDetails disassociateCustomPropertyDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public TypeCustomPropertyDetails getBody$() {
+        return disassociateCustomPropertyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DisassociateCustomPropertyRequest, TypeCustomPropertyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisassociateCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            typeKey(o.getTypeKey());
+            disassociateCustomPropertyDetails(o.getDisassociateCustomPropertyDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DisassociateCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DisassociateCustomPropertyRequest
+         */
+        public DisassociateCustomPropertyRequest build() {
+            DisassociateCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(TypeCustomPropertyDetails body) {
+            disassociateCustomPropertyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetCustomPropertyRequest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetCustomPropertyRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * Unique Custom Property key
+     */
+    private String customPropertyKey;
+
+    /**
+     * Specifies the fields to return in a custom property response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a custom property response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        DataType("dataType"),
+        NamespaceName("namespaceName"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        TimeUpdated("timeUpdated"),
+        CreatedById("createdById"),
+        UpdatedById("updatedById"),
+        Properties("properties"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetCustomPropertyRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            customPropertyKey(o.getCustomPropertyKey());
+            fields(o.getFields());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetCustomPropertyRequest
+         */
+        public GetCustomPropertyRequest build() {
+            GetCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetNamespaceRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetNamespaceRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetNamespaceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * Specifies the fields to return in a namespace response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a namespace response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        TimeUpdated("timeUpdated"),
+        CreatedById("createdById"),
+        UpdatedById("updatedById"),
+        Properties("properties"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetNamespaceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetNamespaceRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            fields(o.getFields());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetNamespaceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetNamespaceRequest
+         */
+        public GetNamespaceRequest build() {
+            GetNamespaceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetPatternRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/GetPatternRequest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetPatternRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
+     * Specifies the fields to return in a pattern response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a pattern response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        CatalogId("catalogId"),
+        Expression("expression"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        TimeUpdated("timeUpdated"),
+        CreatedById("createdById"),
+        UpdatedById("updatedById"),
+        Properties("properties"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetPatternRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPatternRequest o) {
+            catalogId(o.getCatalogId());
+            patternKey(o.getPatternKey());
+            fields(o.getFields());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetPatternRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetPatternRequest
+         */
+        public GetPatternRequest build() {
+            GetPatternRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAggregatedPhysicalEntitiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAggregatedPhysicalEntitiesRequest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListAggregatedPhysicalEntitiesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique data asset key.
+     */
+    private String dataAssetKey;
+
+    /**
+     * Unique entity key.
+     */
+    private String entityKey;
+
+    /**
+     * Specifies the fields to return in an entity response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in an entity response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        DataAssetKey("dataAssetKey"),
+        TimeCreated("timeCreated"),
+        TimeUpdated("timeUpdated"),
+        CreatedById("createdById"),
+        UpdatedById("updatedById"),
+        LifecycleState("lifecycleState"),
+        ExternalKey("externalKey"),
+        TimeExternal("timeExternal"),
+        TimeStatusUpdated("timeStatusUpdated"),
+        IsLogical("isLogical"),
+        IsPartition("isPartition"),
+        FolderKey("folderKey"),
+        FolderName("folderName"),
+        TypeKey("typeKey"),
+        Path("path"),
+        HarvestStatus("harvestStatus"),
+        LastJobKey("lastJobKey"),
+        Uri("uri"),
+        Properties("properties"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAggregatedPhysicalEntitiesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAggregatedPhysicalEntitiesRequest o) {
+            catalogId(o.getCatalogId());
+            dataAssetKey(o.getDataAssetKey());
+            entityKey(o.getEntityKey());
+            fields(o.getFields());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAggregatedPhysicalEntitiesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAggregatedPhysicalEntitiesRequest
+         */
+        public ListAggregatedPhysicalEntitiesRequest build() {
+            ListAggregatedPhysicalEntitiesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListCustomPropertiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListCustomPropertiesRequest.java
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListCustomPropertiesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
+     * Return the custom properties which has specified data types
+     *
+     */
+    private java.util.List<com.oracle.bmc.datacatalog.model.CustomPropertyDataType> dataTypes;
+
+    /**
+     * A filter to return only resources that match the entire type name given. The match is not case sensitive
+     */
+    private java.util.List<TypeName> typeName;
+
+    /**
+     * A filter to return only resources that match the entire type name given. The match is not case sensitive
+     **/
+    public enum TypeName {
+        DataAsset("DATA_ASSET"),
+        AutonomousDataWarehouse("AUTONOMOUS_DATA_WAREHOUSE"),
+        Hive("HIVE"),
+        Kafka("KAFKA"),
+        Mysql("MYSQL"),
+        OracleObjectStorage("ORACLE_OBJECT_STORAGE"),
+        AutonomousTransactionProcessing("AUTONOMOUS_TRANSACTION_PROCESSING"),
+        Oracle("ORACLE"),
+        Postgresql("POSTGRESQL"),
+        MicrosoftAzureSqlDatabase("MICROSOFT_AZURE_SQL_DATABASE"),
+        MicrosoftSqlServer("MICROSOFT_SQL_SERVER"),
+        IbmDb2("IBM_DB2"),
+        DataEntity("DATA_ENTITY"),
+        LogicalEntity("LOGICAL_ENTITY"),
+        Table("TABLE"),
+        View("VIEW"),
+        Attribute("ATTRIBUTE"),
+        Folder("FOLDER"),
+        Connection("CONNECTION"),
+        Glossary("GLOSSARY"),
+        Term("TERM"),
+        Category("CATEGORY"),
+        File("FILE"),
+        Bucket("BUCKET"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, TypeName> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TypeName v : TypeName.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        TypeName(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TypeName create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid TypeName: " + key);
+        }
+    };
+    /**
+     * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+     */
+    private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
+
+    /**
+     * Time that the resource was created. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeCreated;
+
+    /**
+     * Time that the resource was updated. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the resource.
+     */
+    private String createdById;
+
+    /**
+     * OCID of the user who updated the resource.
+     */
+    private String updatedById;
+
+    /**
+     * Specifies the fields to return in a custom property summary response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a custom property summary response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        DataType("dataType"),
+        NamespaceName("namespaceName"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for USAGECOUNT and DISPLAYNAME is Ascending
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for USAGECOUNT and DISPLAYNAME is Ascending
+     *
+     **/
+    public enum SortBy {
+        Displayname("DISPLAYNAME"),
+        Usagecount("USAGECOUNT"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListCustomPropertiesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListCustomPropertiesRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
+            dataTypes(o.getDataTypes());
+            typeName(o.getTypeName());
+            lifecycleState(o.getLifecycleState());
+            timeCreated(o.getTimeCreated());
+            timeUpdated(o.getTimeUpdated());
+            createdById(o.getCreatedById());
+            updatedById(o.getUpdatedById());
+            fields(o.getFields());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListCustomPropertiesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListCustomPropertiesRequest
+         */
+        public ListCustomPropertiesRequest build() {
+            ListCustomPropertiesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListDerivedLogicalEntitiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListDerivedLogicalEntitiesRequest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListDerivedLogicalEntitiesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDerivedLogicalEntitiesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDerivedLogicalEntitiesRequest o) {
+            catalogId(o.getCatalogId());
+            patternKey(o.getPatternKey());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDerivedLogicalEntitiesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDerivedLogicalEntitiesRequest
+         */
+        public ListDerivedLogicalEntitiesRequest build() {
+            ListDerivedLogicalEntitiesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
@@ -65,6 +65,11 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String externalKey;
 
     /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
      * Last modified timestamp of this object in the external system.
      */
     private java.util.Date timeExternal;
@@ -300,6 +305,7 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
             createdById(o.getCreatedById());
             updatedById(o.getUpdatedById());
             externalKey(o.getExternalKey());
+            patternKey(o.getPatternKey());
             timeExternal(o.getTimeExternal());
             timeStatusUpdated(o.getTimeStatusUpdated());
             isLogical(o.getIsLogical());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListNamespacesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListNamespacesRequest.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListNamespacesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
+     * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+     */
+    private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
+
+    /**
+     * Time that the resource was created. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeCreated;
+
+    /**
+     * Time that the resource was updated. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the resource.
+     */
+    private String createdById;
+
+    /**
+     * OCID of the user who updated the resource.
+     */
+    private String updatedById;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Specifies the fields to return in a namespace summary response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a namespace summary response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListNamespacesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListNamespacesRequest o) {
+            catalogId(o.getCatalogId());
+            displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
+            lifecycleState(o.getLifecycleState());
+            timeCreated(o.getTimeCreated());
+            timeUpdated(o.getTimeUpdated());
+            createdById(o.getCreatedById());
+            updatedById(o.getUpdatedById());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            fields(o.getFields());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListNamespacesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListNamespacesRequest
+         */
+        public ListNamespacesRequest build() {
+            ListNamespacesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListPatternsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListPatternsRequest.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListPatternsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only resources that match display name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayNameContains=Cu.*
+     * The above would match all folders with display name that starts with \"Cu\".
+     *
+     */
+    private String displayNameContains;
+
+    /**
+     * A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+     */
+    private com.oracle.bmc.datacatalog.model.LifecycleState lifecycleState;
+
+    /**
+     * Time that the resource was created. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeCreated;
+
+    /**
+     * Time that the resource was updated. An [RFC3339](https://tools.ietf.org/html/rfc3339) formatted datetime string.
+     */
+    private java.util.Date timeUpdated;
+
+    /**
+     * OCID of the user who created the resource.
+     */
+    private String createdById;
+
+    /**
+     * OCID of the user who updated the resource.
+     */
+    private String updatedById;
+
+    /**
+     * Specifies the fields to return in a pattern summary response.
+     *
+     */
+    private java.util.List<Fields> fields;
+
+    /**
+     * Specifies the fields to return in a pattern summary response.
+     *
+     **/
+    public enum Fields {
+        Key("key"),
+        DisplayName("displayName"),
+        Description("description"),
+        CatalogId("catalogId"),
+        Expression("expression"),
+        LifecycleState("lifecycleState"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Fields> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Fields v : Fields.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Fields(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Fields create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Fields: " + key);
+        }
+    };
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for TIMECREATED is descending. Default order for DISPLAYNAME is ascending. If no value is specified TIMECREATED is default.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListPatternsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPatternsRequest o) {
+            catalogId(o.getCatalogId());
+            displayName(o.getDisplayName());
+            displayNameContains(o.getDisplayNameContains());
+            lifecycleState(o.getLifecycleState());
+            timeCreated(o.getTimeCreated());
+            timeUpdated(o.getTimeUpdated());
+            createdById(o.getCreatedById());
+            updatedById(o.getUpdatedById());
+            fields(o.getFields());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListPatternsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListPatternsRequest
+         */
+        public ListPatternsRequest build() {
+            ListPatternsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/RemoveDataSelectorPatternsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/RemoveDataSelectorPatternsRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class RemoveDataSelectorPatternsRequest
+        extends com.oracle.bmc.requests.BmcRequest<DataSelectorPatternDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique data asset key.
+     */
+    private String dataAssetKey;
+
+    /**
+     * The information used to remove the data selector patterns.
+     */
+    private DataSelectorPatternDetails dataSelectorPatternDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public DataSelectorPatternDetails getBody$() {
+        return dataSelectorPatternDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveDataSelectorPatternsRequest, DataSelectorPatternDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveDataSelectorPatternsRequest o) {
+            catalogId(o.getCatalogId());
+            dataAssetKey(o.getDataAssetKey());
+            dataSelectorPatternDetails(o.getDataSelectorPatternDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveDataSelectorPatternsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveDataSelectorPatternsRequest
+         */
+        public RemoveDataSelectorPatternsRequest build() {
+            RemoveDataSelectorPatternsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(DataSelectorPatternDetails body) {
+            dataSelectorPatternDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdateCustomPropertyRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdateCustomPropertyRequest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateCustomPropertyRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateCustomPropertyDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * Unique Custom Property key
+     */
+    private String customPropertyKey;
+
+    /**
+     * The information to be updated in the custom property.
+     */
+    private UpdateCustomPropertyDetails updateCustomPropertyDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateCustomPropertyDetails getBody$() {
+        return updateCustomPropertyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateCustomPropertyRequest, UpdateCustomPropertyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateCustomPropertyRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            customPropertyKey(o.getCustomPropertyKey());
+            updateCustomPropertyDetails(o.getUpdateCustomPropertyDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateCustomPropertyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateCustomPropertyRequest
+         */
+        public UpdateCustomPropertyRequest build() {
+            UpdateCustomPropertyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateCustomPropertyDetails body) {
+            updateCustomPropertyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdateNamespaceRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdateNamespaceRequest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateNamespaceRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateNamespaceDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique namespace identifier.
+     */
+    private String namespaceId;
+
+    /**
+     * The information to be updated in the namespace.
+     */
+    private UpdateNamespaceDetails updateNamespaceDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateNamespaceDetails getBody$() {
+        return updateNamespaceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateNamespaceRequest, UpdateNamespaceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateNamespaceRequest o) {
+            catalogId(o.getCatalogId());
+            namespaceId(o.getNamespaceId());
+            updateNamespaceDetails(o.getUpdateNamespaceDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateNamespaceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateNamespaceRequest
+         */
+        public UpdateNamespaceRequest build() {
+            UpdateNamespaceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateNamespaceDetails body) {
+            updateNamespaceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdatePatternRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/UpdatePatternRequest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdatePatternRequest extends com.oracle.bmc.requests.BmcRequest<UpdatePatternDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
+     * The information to be updated in the pattern.
+     */
+    private UpdatePatternDetails updatePatternDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdatePatternDetails getBody$() {
+        return updatePatternDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdatePatternRequest, UpdatePatternDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePatternRequest o) {
+            catalogId(o.getCatalogId());
+            patternKey(o.getPatternKey());
+            updatePatternDetails(o.getUpdatePatternDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdatePatternRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdatePatternRequest
+         */
+        public UpdatePatternRequest build() {
+            UpdatePatternRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdatePatternDetails body) {
+            updatePatternDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ValidatePatternRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ValidatePatternRequest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ValidatePatternRequest
+        extends com.oracle.bmc.requests.BmcRequest<ValidatePatternDetails> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Unique pattern key.
+     */
+    private String patternKey;
+
+    /**
+     * The information used to validate the pattern.
+     */
+    private ValidatePatternDetails validatePatternDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ValidatePatternDetails getBody$() {
+        return validatePatternDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ValidatePatternRequest, ValidatePatternDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ValidatePatternRequest o) {
+            catalogId(o.getCatalogId());
+            patternKey(o.getPatternKey());
+            validatePatternDetails(o.getValidatePatternDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ValidatePatternRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ValidatePatternRequest
+         */
+        public ValidatePatternRequest build() {
+            ValidatePatternRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ValidatePatternDetails body) {
+            validatePatternDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/AddDataSelectorPatternsResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/AddDataSelectorPatternsResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AddDataSelectorPatternsResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DataAsset instance.
+     */
+    private DataAsset dataAsset;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddDataSelectorPatternsResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dataAsset(o.getDataAsset());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/AssociateCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/AssociateCustomPropertyResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AssociateCustomPropertyResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Type instance.
+     */
+    private Type type;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AssociateCustomPropertyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            type(o.getType());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreateCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreateCustomPropertyResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateCustomPropertyResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned CustomProperty instance.
+     */
+    private CustomProperty customProperty;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateCustomPropertyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            customProperty(o.getCustomProperty());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreateNamespaceResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreateNamespaceResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateNamespaceResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Namespace instance.
+     */
+    private Namespace namespace;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateNamespaceResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            namespace(o.getNamespace());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreatePatternResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/CreatePatternResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreatePatternResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pattern instance.
+     */
+    private Pattern pattern;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePatternResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pattern(o.getPattern());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeleteCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeleteCustomPropertyResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteCustomPropertyResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteCustomPropertyResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeleteNamespaceResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeleteNamespaceResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteNamespaceResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteNamespaceResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeletePatternResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DeletePatternResponse.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeletePatternResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePatternResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DisassociateCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/DisassociateCustomPropertyResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DisassociateCustomPropertyResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Type instance.
+     */
+    private Type type;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisassociateCustomPropertyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            type(o.getType());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetCustomPropertyResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetCustomPropertyResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned CustomProperty instance.
+     */
+    private CustomProperty customProperty;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetCustomPropertyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            customProperty(o.getCustomProperty());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetNamespaceResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetNamespaceResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetNamespaceResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Namespace instance.
+     */
+    private Namespace namespace;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetNamespaceResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            namespace(o.getNamespace());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetPatternResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/GetPatternResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetPatternResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pattern instance.
+     */
+    private Pattern pattern;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPatternResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pattern(o.getPattern());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListAggregatedPhysicalEntitiesResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListAggregatedPhysicalEntitiesResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListAggregatedPhysicalEntitiesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned EntityCollection instance.
+     */
+    private EntityCollection entityCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAggregatedPhysicalEntitiesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            entityCollection(o.getEntityCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListCustomPropertiesResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListCustomPropertiesResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListCustomPropertiesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned CustomPropertyCollection instance.
+     */
+    private CustomPropertyCollection customPropertyCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListCustomPropertiesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            customPropertyCollection(o.getCustomPropertyCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListDerivedLogicalEntitiesResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListDerivedLogicalEntitiesResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListDerivedLogicalEntitiesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned EntityCollection instance.
+     */
+    private EntityCollection entityCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDerivedLogicalEntitiesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            entityCollection(o.getEntityCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListNamespacesResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListNamespacesResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListNamespacesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned NamespaceCollection instance.
+     */
+    private NamespaceCollection namespaceCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListNamespacesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            namespaceCollection(o.getNamespaceCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListPatternsResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ListPatternsResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListPatternsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned PatternCollection instance.
+     */
+    private PatternCollection patternCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPatternsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            patternCollection(o.getPatternCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/RemoveDataSelectorPatternsResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/RemoveDataSelectorPatternsResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class RemoveDataSelectorPatternsResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DataAsset instance.
+     */
+    private DataAsset dataAsset;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveDataSelectorPatternsResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dataAsset(o.getDataAsset());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdateCustomPropertyResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdateCustomPropertyResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateCustomPropertyResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned CustomProperty instance.
+     */
+    private CustomProperty customProperty;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateCustomPropertyResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            customProperty(o.getCustomProperty());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdateNamespaceResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdateNamespaceResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateNamespaceResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Namespace instance.
+     */
+    private Namespace namespace;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateNamespaceResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            namespace(o.getNamespace());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdatePatternResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/UpdatePatternResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdatePatternResponse {
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pattern instance.
+     */
+    private Pattern pattern;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePatternResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pattern(o.getPattern());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ValidatePatternResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/ValidatePatternResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ValidatePatternResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ValidatePatternResult instance.
+     */
+    private ValidatePatternResult validatePatternResult;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ValidatePatternResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            validatePatternResult(o.getValidatePatternResult());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagement.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagement.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.logging.requests.*;
 import com.oracle.bmc.logging.responses.*;
 
 /**
- * loggingManagementControlplane API specification
+ * Use the Logging Management API to create, read, list, update, and delete log groups, log objects, and agent configurations.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200531")
 public interface LoggingManagement extends AutoCloseable {
@@ -46,7 +46,7 @@ public interface LoggingManagement extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Moves a log group into a different compartment within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves a log group into a different compartment within the same tenancy.  When provided, the If-Match is checked against the resource ETag values.
      * For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      * @param request The request object containing the details to send
@@ -57,7 +57,7 @@ public interface LoggingManagement extends AutoCloseable {
             ChangeLogGroupCompartmentRequest request);
 
     /**
-     * Moves a log into a different log group within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves a log into a different log group within the same tenancy.  When provided, the If-Match is checked against the ETag values of the resource.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -77,7 +77,7 @@ public interface LoggingManagement extends AutoCloseable {
             ChangeLogSavedSearchCompartmentRequest request);
 
     /**
-     * Moves unified agent configuration into a different compartment within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves the unified agent configuration into a different compartment within the same tenancy.  When provided, the If-Match is checked against the ETag values of the resource.
      * For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      * @param request The request object containing the details to send
@@ -88,8 +88,8 @@ public interface LoggingManagement extends AutoCloseable {
             ChangeUnifiedAgentConfigurationCompartmentRequest request);
 
     /**
-     * Creates a log within specified log group. This call fails if log group is already created
-     * with same displayName or (service, resource, category) triplet.
+     * Creates a log within the specified log group. This call fails if a log group has already been created
+     * with the same displayName or (service, resource, category) triplet.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -98,8 +98,8 @@ public interface LoggingManagement extends AutoCloseable {
     CreateLogResponse createLog(CreateLogRequest request);
 
     /**
-     * Create new log group with unique display name. This call fails
-     * if log group is already created with same displayName in the compartment.
+     * Create a new log group with a unique display name. This call fails
+     * if the log group is already created with the same displayName in the compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -117,7 +117,7 @@ public interface LoggingManagement extends AutoCloseable {
     CreateLogSavedSearchResponse createLogSavedSearch(CreateLogSavedSearchRequest request);
 
     /**
-     * Create unified agent config registration
+     * Create unified agent configuration registration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -150,7 +150,7 @@ public interface LoggingManagement extends AutoCloseable {
     DeleteLogSavedSearchResponse deleteLogSavedSearch(DeleteLogSavedSearchRequest request);
 
     /**
-     * Delete unified agent configuration
+     * Delete unified agent configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -168,7 +168,7 @@ public interface LoggingManagement extends AutoCloseable {
     DeleteWorkRequestResponse deleteWorkRequest(DeleteWorkRequestRequest request);
 
     /**
-     * Gets the log object config for log object OCID.
+     * Gets the log object configuration for the log object OCID.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -201,7 +201,7 @@ public interface LoggingManagement extends AutoCloseable {
     GetLogSavedSearchResponse getLogSavedSearch(GetLogSavedSearchRequest request);
 
     /**
-     * Get unified agent configuration for an id
+     * Get the unified agent configuration for an ID.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -252,7 +252,7 @@ public interface LoggingManagement extends AutoCloseable {
     ListLogsResponse listLogs(ListLogsRequest request);
 
     /**
-     * Lists all services supporting logging.
+     * Lists all services that support logging.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -260,7 +260,7 @@ public interface LoggingManagement extends AutoCloseable {
     ListServicesResponse listServices(ListServicesRequest request);
 
     /**
-     * Lists all unified agent configurations in the specified compartment
+     * Lists all unified agent configurations in the specified compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -296,8 +296,8 @@ public interface LoggingManagement extends AutoCloseable {
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
 
     /**
-     * Updates existing log object with the associated config. This call
-     *       fails if log object does not exist.
+     * Updates the existing log object with the associated configuration. This call
+     *       fails if the log object does not exist.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -306,8 +306,8 @@ public interface LoggingManagement extends AutoCloseable {
     UpdateLogResponse updateLog(UpdateLogRequest request);
 
     /**
-     * Updates existing log group with the associated config. This call
-     *       fails if log group does not exist.
+     * Updates the existing log group with the associated configuration. This call
+     *       fails if the log group does not exist.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -326,7 +326,7 @@ public interface LoggingManagement extends AutoCloseable {
 
     /**
      * Update an existing unified agent configuration. This call
-     *       fails if log group does not exist.
+     *       fails if the log group does not exist.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagementAsync.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagementAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.logging.requests.*;
 import com.oracle.bmc.logging.responses.*;
 
 /**
- * loggingManagementControlplane API specification
+ * Use the Logging Management API to create, read, list, update, and delete log groups, log objects, and agent configurations.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200531")
 public interface LoggingManagementAsync extends AutoCloseable {
@@ -46,7 +46,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Moves a log group into a different compartment within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves a log group into a different compartment within the same tenancy.  When provided, the If-Match is checked against the resource ETag values.
      * For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      *
@@ -64,7 +64,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Moves a log into a different log group within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves a log into a different log group within the same tenancy.  When provided, the If-Match is checked against the ETag values of the resource.
      *
      *
      * @param request The request object containing the details to send
@@ -101,7 +101,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Moves unified agent configuration into a different compartment within the same tenancy.  When provided, If-Match is checked against ETag values of the resource.
+     * Moves the unified agent configuration into a different compartment within the same tenancy.  When provided, the If-Match is checked against the ETag values of the resource.
      * For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      *
@@ -121,8 +121,8 @@ public interface LoggingManagementAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Creates a log within specified log group. This call fails if log group is already created
-     * with same displayName or (service, resource, category) triplet.
+     * Creates a log within the specified log group. This call fails if a log group has already been created
+     * with the same displayName or (service, resource, category) triplet.
      *
      *
      * @param request The request object containing the details to send
@@ -137,8 +137,8 @@ public interface LoggingManagementAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<CreateLogRequest, CreateLogResponse> handler);
 
     /**
-     * Create new log group with unique display name. This call fails
-     * if log group is already created with same displayName in the compartment.
+     * Create a new log group with a unique display name. This call fails
+     * if the log group is already created with the same displayName in the compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -171,7 +171,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Create unified agent config registration
+     * Create unified agent configuration registration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -234,7 +234,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Delete unified agent configuration
+     * Delete unified agent configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -269,7 +269,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the log object config for log object OCID.
+     * Gets the log object configuration for the log object OCID.
      *
      *
      * @param request The request object containing the details to send
@@ -330,7 +330,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Get unified agent configuration for an id
+     * Get the unified agent configuration for an ID.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -425,7 +425,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListLogsRequest, ListLogsResponse> handler);
 
     /**
-     * Lists all services supporting logging.
+     * Lists all services that support logging.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -440,7 +440,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists all unified agent configurations in the specified compartment
+     * Lists all unified agent configurations in the specified compartment.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -508,8 +508,8 @@ public interface LoggingManagementAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates existing log object with the associated config. This call
-     *       fails if log object does not exist.
+     * Updates the existing log object with the associated configuration. This call
+     *       fails if the log object does not exist.
      *
      *
      * @param request The request object containing the details to send
@@ -524,8 +524,8 @@ public interface LoggingManagementAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateLogRequest, UpdateLogResponse> handler);
 
     /**
-     * Updates existing log group with the associated config. This call
-     *       fails if log group does not exist.
+     * Updates the existing log group with the associated configuration. This call
+     *       fails if the log group does not exist.
      *
      *
      * @param request The request object containing the details to send
@@ -559,7 +559,7 @@ public interface LoggingManagementAsync extends AutoCloseable {
 
     /**
      * Update an existing unified agent configuration. This call
-     *       fails if log group does not exist.
+     *       fails if the log group does not exist.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagementWaiters.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/LoggingManagementWaiters.java
@@ -215,6 +215,108 @@ public class LoggingManagementWaiters {
      * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetLogSavedSearchRequest, GetLogSavedSearchResponse>
+            forLogSavedSearch(
+                    GetLogSavedSearchRequest request,
+                    com.oracle.bmc.logging.model.LogSavedSearchLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forLogSavedSearch(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetLogSavedSearchRequest, GetLogSavedSearchResponse>
+            forLogSavedSearch(
+                    GetLogSavedSearchRequest request,
+                    com.oracle.bmc.logging.model.LogSavedSearchLifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forLogSavedSearch(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetLogSavedSearchRequest, GetLogSavedSearchResponse>
+            forLogSavedSearch(
+                    GetLogSavedSearchRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.logging.model.LogSavedSearchLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forLogSavedSearch(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for LogSavedSearch.
+    private com.oracle.bmc.waiter.Waiter<GetLogSavedSearchRequest, GetLogSavedSearchResponse>
+            forLogSavedSearch(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetLogSavedSearchRequest request,
+                    final com.oracle.bmc.logging.model.LogSavedSearchLifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.logging.model.LogSavedSearchLifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetLogSavedSearchRequest, GetLogSavedSearchResponse>() {
+                            @Override
+                            public GetLogSavedSearchResponse apply(
+                                    GetLogSavedSearchRequest request) {
+                                return client.getLogSavedSearch(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetLogSavedSearchResponse>() {
+                            @Override
+                            public boolean apply(GetLogSavedSearchResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getLogSavedSearch().getLifecycleState());
+                            }
+                        },
+                        false),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<
                     GetUnifiedAgentConfigurationRequest, GetUnifiedAgentConfigurationResponse>
             forUnifiedAgentConfiguration(

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Category.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Category.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * categories for resources.
+ * Categories for resources.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -78,19 +78,19 @@ public class Category {
     }
 
     /**
-     * Category name
+     * Category name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Category display name
+     * Category display name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Parameters category supports.
+     * Parameters the category supports.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parameters")
     java.util.List<Parameter> parameters;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeLogGroupCompartmentDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeLogGroupCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Contains details indicating which compartment the resource should move to
+ * Contains details indicating which compartment the resource should move to.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class ChangeLogGroupCompartmentDetails {
     }
 
     /**
-     * The of the compartment into which the resource should be moved.
+     * The compartment into which the resource should be moved.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeLogLogGroupDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeLogLogGroupDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Contains details indicating which log group the log should move to
+ * Contains details indicating which log group the log should move to.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeUnifiedAgentConfigurationCompartmentDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ChangeUnifiedAgentConfigurationCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Contains details indicating which compartment the resource should move to
+ * Contains details indicating which compartment the resource should move to.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class ChangeUnifiedAgentConfigurationCompartmentDetails {
     }
 
     /**
-     * The ocid the compartment into which the resource should be moved.
+     * The OCID the compartment into which the resource should be moved.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogDetails.java
@@ -129,14 +129,14 @@ public class CreateLogDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     public enum LogType {
         Custom("CUSTOM"),
@@ -171,7 +171,7 @@ public class CreateLogDetails {
         }
     };
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logType")
     LogType logType;
@@ -205,7 +205,7 @@ public class CreateLogDetails {
     Configuration configuration;
 
     /**
-     * Log retention duration in days.
+     * Log retention duration in 30-day increments (30, 60, 90 and so on).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionDuration")
     Integer retentionDuration;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogGroupDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogGroupDetails.java
@@ -111,7 +111,7 @@ public class CreateLogGroupDetails {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogSavedSearchDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateLogSavedSearchDetails.java
@@ -63,15 +63,6 @@ public class CreateLogSavedSearchDetails {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-        private Boolean isQuickStart;
-
-        public Builder isQuickStart(Boolean isQuickStart) {
-            this.isQuickStart = isQuickStart;
-            this.__explicitlySet__.add("isQuickStart");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -97,13 +88,7 @@ public class CreateLogSavedSearchDetails {
         public CreateLogSavedSearchDetails build() {
             CreateLogSavedSearchDetails __instance__ =
                     new CreateLogSavedSearchDetails(
-                            compartmentId,
-                            name,
-                            description,
-                            query,
-                            isQuickStart,
-                            definedTags,
-                            freeformTags);
+                            compartmentId, name, description, query, definedTags, freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -115,7 +100,6 @@ public class CreateLogSavedSearchDetails {
                             .name(o.getName())
                             .description(o.getDescription())
                             .query(o.getQuery())
-                            .isQuickStart(o.getIsQuickStart())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -138,7 +122,7 @@ public class CreateLogSavedSearchDetails {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -157,12 +141,6 @@ public class CreateLogSavedSearchDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("query")
     String query;
-
-    /**
-     * True if the LogSavedSearch should be show as quickstart in the UI
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-    Boolean isQuickStart;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateUnifiedAgentConfigurationDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/CreateUnifiedAgentConfigurationDetails.java
@@ -143,7 +143,7 @@ public class CreateUnifiedAgentConfigurationDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/GrokPattern.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/GrokPattern.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * grok pattern object
+ * grok pattern object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -101,31 +101,31 @@ public class GrokPattern {
     }
 
     /**
-     * The grok pattern
+     * The grok pattern.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pattern")
     String pattern;
 
     /**
-     * The name key to tag this grok pattern
+     * The name key to tag this grok pattern.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Specify time field for event time. If the event doesn't have this field, current time is used.
+     * Specify the time field for the event time. If the event doesn't have this field, the current time is used.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldTimeKey")
     String fieldTimeKey;
 
     /**
-     * Process value using specified format. This is available only when time_type is string.
+     * Process value using the specified format. This is available only when time_type is a string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldTimeFormat")
     String fieldTimeFormat;
 
     /**
-     * Use specified timezone. One can parse/format the time value in the specified timezone.
+     * Use the specified time zone. The time value can be parsed or formatted in the specified time zone.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldTimeZone")
     String fieldTimeZone;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Log.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Log.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Represents a Log object
+ * Represents a log object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -224,14 +224,14 @@ public class Log {
     String logGroupId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LogType {
@@ -277,7 +277,7 @@ public class Log {
         }
     };
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logType")
     LogType logType;
@@ -311,7 +311,7 @@ public class Log {
     Configuration configuration;
 
     /**
-     * The state of an pipeline.
+     * The pipeline state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LogLifecycleState lifecycleState;
@@ -329,7 +329,7 @@ public class Log {
     java.util.Date timeLastModified;
 
     /**
-     * Log retention duration in days.
+     * Log retention duration in 30-day increments (30, 60, 90 and so on).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionDuration")
     Integer retentionDuration;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroup.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroup.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Represents a LogGroup object
+ * Represents a LogGroup object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -163,7 +163,7 @@ public class LogGroup {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -177,7 +177,7 @@ public class LogGroup {
     String description;
 
     /**
-     * The state of the log group object.
+     * The log group object state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LogGroupLifecycleState lifecycleState;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroupLifecycleState.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroupLifecycleState.java
@@ -5,11 +5,11 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * The state of the log group object. The states workflow is:
- *    1. *CREATING* Log group is being created, back end service contacted
- *    2. *ACTIVE* Logg group is active
- *    3. *UPDATING* Object configuration change requested, but backend service haven't confirmed the update
- *    4. *INACTIVE* Log group is disabled
+ * The log group object state. The states workflow is:
+ *    1. *CREATING* Log group is being created, backend service contacted.
+ *    2. *ACTIVE* Log group is active.
+ *    3. *UPDATING* Object configuration change requested, but the backend service has not confirmed the update.
+ *    4. *INACTIVE* Log group is disabled.
  *    5. *DELETING* Log group is being deleted.
  *
  **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroupSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogGroupSummary.java
@@ -97,6 +97,15 @@ public class LogGroupSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LogGroupLifecycleState lifecycleState;
+
+        public Builder lifecycleState(LogGroupLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -110,7 +119,8 @@ public class LogGroupSummary {
                             definedTags,
                             freeformTags,
                             timeCreated,
-                            timeLastModified);
+                            timeLastModified,
+                            lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -125,7 +135,8 @@ public class LogGroupSummary {
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags())
                             .timeCreated(o.getTimeCreated())
-                            .timeLastModified(o.getTimeLastModified());
+                            .timeLastModified(o.getTimeLastModified())
+                            .lifecycleState(o.getLifecycleState());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -152,7 +163,7 @@ public class LogGroupSummary {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -195,6 +206,12 @@ public class LogGroupSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLastModified")
     java.util.Date timeLastModified;
+
+    /**
+     * The log group object state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LogGroupLifecycleState lifecycleState;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogIncludedSearch.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogIncludedSearch.java
@@ -149,7 +149,7 @@ public class LogIncludedSearch {
     String id;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogIncludedSearchSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogIncludedSearchSummary.java
@@ -100,7 +100,7 @@ public class LogIncludedSearchSummary {
     String id;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogLifecycleState.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogLifecycleState.java
@@ -5,11 +5,11 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * The state of the log object. The states workflow is:
- *    1. *CREATING* Object is being created, back end service contacted
- *    2. *ACTIVE* Logging is active
- *    3. *UPDATING* Object configuration change requested, but backend service haven't confirmed the update
- *    4. *INACTIVE* Logging is disabled
+ * The log object state. The states workflow is:
+ *    1. *CREATING* Object is being created, backend service contacted.
+ *    2. *ACTIVE* Logging is active.
+ *    3. *UPDATING* Object configuration change requested, but the backend service has not confirmed the update.
+ *    4. *INACTIVE* Logging is disabled.
  *    5. *DELETING* Log object is being deleted.
  *
  **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearch.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearch.java
@@ -88,15 +88,6 @@ public class LogSavedSearch {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-        private Boolean isQuickStart;
-
-        public Builder isQuickStart(Boolean isQuickStart) {
-            this.isQuickStart = isQuickStart;
-            this.__explicitlySet__.add("isQuickStart");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -116,6 +107,15 @@ public class LogSavedSearch {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LogSavedSearchLifecycleState lifecycleState;
+
+        public Builder lifecycleState(LogSavedSearchLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -129,9 +129,9 @@ public class LogSavedSearch {
                             timeLastModified,
                             description,
                             query,
-                            isQuickStart,
                             definedTags,
-                            freeformTags);
+                            freeformTags,
+                            lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -146,9 +146,9 @@ public class LogSavedSearch {
                             .timeLastModified(o.getTimeLastModified())
                             .description(o.getDescription())
                             .query(o.getQuery())
-                            .isQuickStart(o.getIsQuickStart())
                             .definedTags(o.getDefinedTags())
-                            .freeformTags(o.getFreeformTags());
+                            .freeformTags(o.getFreeformTags())
+                            .lifecycleState(o.getLifecycleState());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -175,7 +175,7 @@ public class LogSavedSearch {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -208,12 +208,6 @@ public class LogSavedSearch {
     String query;
 
     /**
-     * True if the LogSavedSearch should be show as quickstart in the UI
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-    Boolean isQuickStart;
-
-    /**
      * Defined tags for this resource. Each key is predefined and scoped to a
      * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
      * <p>
@@ -231,6 +225,13 @@ public class LogSavedSearch {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
+
+    /**
+     * The state of the LogSavedSearch
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LogSavedSearchLifecycleState lifecycleState;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchLifecycleState.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchLifecycleState.java
@@ -6,15 +6,23 @@ package com.oracle.bmc.logging.model;
 
 /**
  * The state of the LogSavedSearch
- *    1. *ACTIVE* LogSavedSearch is active and can be used by other users
- *    2. *DELETED* LogSavedSearch is deleted and cannot be used by other users
+ *   1. CREATING
+ *   2. ACTIVE   LogSavedSearch is active and can be used by other users
+ *   3. UPDATING
+ *   4. INACTIVE
+ *   5. DELETING
+ *   6. FAILED
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200531")
 @lombok.extern.slf4j.Slf4j
 public enum LogSavedSearchLifecycleState {
+    Creating("CREATING"),
     Active("ACTIVE"),
-    Deleted("DELETED"),
+    Updating("UPDATING"),
+    Inactive("INACTIVE"),
+    Deleting("DELETING"),
+    Failed("FAILED"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchSummary.java
@@ -63,21 +63,49 @@ public class LogSavedSearchSummary {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-        private Boolean isQuickStart;
-
-        public Builder isQuickStart(Boolean isQuickStart) {
-            this.isQuickStart = isQuickStart;
-            this.__explicitlySet__.add("isQuickStart");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("timeLastModified")
         private java.util.Date timeLastModified;
 
         public Builder timeLastModified(java.util.Date timeLastModified) {
             this.timeLastModified = timeLastModified;
             this.__explicitlySet__.add("timeLastModified");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("query")
+        private String query;
+
+        public Builder query(String query) {
+            this.query = query;
+            this.__explicitlySet__.add("query");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
             return this;
         }
 
@@ -100,8 +128,11 @@ public class LogSavedSearchSummary {
                             compartmentId,
                             name,
                             timeCreated,
-                            isQuickStart,
                             timeLastModified,
+                            description,
+                            query,
+                            definedTags,
+                            freeformTags,
                             lifecycleState);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -114,8 +145,11 @@ public class LogSavedSearchSummary {
                             .compartmentId(o.getCompartmentId())
                             .name(o.getName())
                             .timeCreated(o.getTimeCreated())
-                            .isQuickStart(o.getIsQuickStart())
                             .timeLastModified(o.getTimeLastModified())
+                            .description(o.getDescription())
+                            .query(o.getQuery())
+                            .definedTags(o.getDefinedTags())
+                            .freeformTags(o.getFreeformTags())
                             .lifecycleState(o.getLifecycleState());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -143,7 +177,7 @@ public class LogSavedSearchSummary {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -157,16 +191,42 @@ public class LogSavedSearchSummary {
     java.util.Date timeCreated;
 
     /**
-     * True if the LogSavedSearch should be show as quickstart in the UI
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-    Boolean isQuickStart;
-
-    /**
      * Time the resource was last modified.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLastModified")
     java.util.Date timeLastModified;
+
+    /**
+     * Description for this resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The search query that is saved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("query")
+    String query;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
 
     /**
      * The state of the LogSavedSearch

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchSummaryCollection.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSavedSearchSummaryCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * A collection of LogSavedSearchSummary items
+ * A collection of LogSavedSearchSummary items.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/LogSummary.java
@@ -207,7 +207,7 @@ public class LogSummary {
     String logGroupId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -221,12 +221,12 @@ public class LogSummary {
     Boolean isEnabled;
 
     /**
-     * The state of an pipeline.
+     * The pipeline state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LogLifecycleState lifecycleState;
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum LogType {
@@ -272,7 +272,7 @@ public class LogSummary {
         }
     };
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logType")
     LogType logType;
@@ -312,7 +312,7 @@ public class LogSummary {
     java.util.Date timeLastModified;
 
     /**
-     * Log retention duration in days.
+     * Log retention duration in 30-day increments (30, 60, 90 and so on).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionDuration")
     Integer retentionDuration;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Parameter.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Parameter.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Parameters that a category of resource supports.
+ * Parameters that a resource category supports.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -134,7 +134,7 @@ public class Parameter {
     Type type;
 
     /**
-     * Java regex pattern to validate parameter value.
+     * Java regex pattern to validate a parameter value.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pattern")
     String pattern;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ResourceType.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ResourceType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Type of Resource that Service provides.
+ * Type of resource that a service provides.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -74,7 +74,7 @@ public class ResourceType {
     String name;
 
     /**
-     * categories for resources.
+     * Categories for resources.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("categories")
     java.util.List<Category> categories;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ServiceSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/ServiceSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Summary of Services that are integrated with public logging
+ * Summary of services that are integrated with public logging.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -134,13 +134,13 @@ public class ServiceSummary {
     String tenantId;
 
     /**
-     * Apollo project namespace if any.
+     * Apollo project namespace, if any.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("namespace")
     String namespace;
 
     /**
-     * Service id as set in Service Principal.
+     * Service ID as set in Service Principal.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("servicePrincipalName")
     String servicePrincipalName;
@@ -152,19 +152,19 @@ public class ServiceSummary {
     String endpoint;
 
     /**
-     * User friendly service name.
+     * User-friendly service name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Service id.
+     * Service ID.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Type of Resource that a Service provides.
+     * Type of resource that a service provides.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceTypes")
     java.util.List<ResourceType> resourceTypes;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Source.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/Source.java
@@ -37,7 +37,7 @@ package com.oracle.bmc.logging.model;
 public class Source {
 
     /**
-     * The source of the log.
+     * The log source.
      * * **OCISERVICE:** Oracle Service.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentApache2Parser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentApache2Parser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * apache 2 log parser
+ * Apache 2 log parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentApacheErrorParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentApacheErrorParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * apache error log parser
+ * Apache error log parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfiguration.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfiguration.java
@@ -211,7 +211,7 @@ public class UnifiedAgentConfiguration {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -256,7 +256,7 @@ public class UnifiedAgentConfiguration {
     java.util.Date timeLastModified;
 
     /**
-     * The state of an pipeline.
+     * The pipeline state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LogLifecycleState lifecycleState;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfigurationCollection.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfigurationCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Results of a UnifiedAgentConfiguration search. Contains UnifiedAgentConfigurationSummary items
+ * Results of a UnifiedAgentConfiguration search. Contains UnifiedAgentConfigurationSummary items.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfigurationSummary.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentConfigurationSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Unified Agent configuration summary object returned by list API.
+ * Unified Agent configuration summary object returned by the list API.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -199,7 +199,7 @@ public class UnifiedAgentConfigurationSummary {
     String compartmentId;
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -244,7 +244,7 @@ public class UnifiedAgentConfigurationSummary {
     java.util.Date timeLastModified;
 
     /**
-     * The state of an pipeline.
+     * The pipeline state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LogLifecycleState lifecycleState;
@@ -256,7 +256,7 @@ public class UnifiedAgentConfigurationSummary {
     Boolean isEnabled;
 
     /**
-     * Type of unified agent service configuration.
+     * Type of Unified Agent service configuration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("configurationType")
     UnifiedAgentServiceConfigurationTypes configurationType;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentCsvParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentCsvParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * CSV Parser
+ * CSV Parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentGrokParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentGrokParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * grok parser
+ * grok parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentLoggingDestination.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentLoggingDestination.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * logging destination object.
+ * Logging destination object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentLoggingSource.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentLoggingSource.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * logging source object.
+ * Logging source object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -47,7 +47,7 @@ public class UnifiedAgentLoggingSource {
     String name;
 
     /**
-     * unified schema logging source Type
+     * Unified schema logging source type.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum SourceType {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentMultilineGrokParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentMultilineGrokParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * multiline grok parser
+ * Multiline grok parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentMultilineParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentMultilineParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * multiline parser
+ * Multiline parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentNoneParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentNoneParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * this parser signifies a non parser and puts entire log line in a message_key.
+ * This parser signifies a non-parser, and puts the entire log line in a message_key.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentParser.java
@@ -85,31 +85,31 @@ package com.oracle.bmc.logging.model;
 public class UnifiedAgentParser {
 
     /**
-     * Specify time field for event time. If the event doesn't have this field, current time is used.
+     * Specify time field for the event time. If the event doesn't have this field, the current time is used.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldTimeKey")
     String fieldTimeKey;
 
     /**
-     * Specify types for converting field into other type.
+     * Specify types for converting a field into another type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("types")
     java.util.Map<String, String> types;
 
     /**
-     * Specify null value pattern
+     * Specify the null value pattern.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nullValuePattern")
     String nullValuePattern;
 
     /**
-     * If true, empty string field is replaced with nil
+     * If true, an empty string field is replaced with nil.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isNullEmptyString")
     Boolean isNullEmptyString;
 
     /**
-     * If true, use Fluent::EventTime.now(current time) as a timestamp when time_key is specified
+     * If true, use Fluent::EventTime.now(current time) as a timestamp when time_key is specified.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEstimateCurrentEvent")
     Boolean isEstimateCurrentEvent;
@@ -121,13 +121,13 @@ public class UnifiedAgentParser {
     Boolean isKeepTimeKey;
 
     /**
-     * Specify timeout for parse processing. This is mainly for detecting wrong regexp pattern.
+     * Specify the timeout for parse processing. This is mainly for detecting an incorrect regexp pattern.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeoutInMilliseconds")
     Integer timeoutInMilliseconds;
 
     /**
-     * type of fluent parser.
+     * Type of fluent parser.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum ParserType {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentRegexParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentRegexParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * regexp parser
+ * regexp parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentServiceConfigurationTypes.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentServiceConfigurationTypes.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Type of unified agent service configuration.
+ * Type of Unified Agent service configuration.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200531")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentSyslogParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentSyslogParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Syslog Parser
+ * Syslog Parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentTailLogSource.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentTailLogSource.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * tail log source object.
+ * Tail log source object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentTsvParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentTsvParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * TSV Parser
+ * TSV Parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentWindowsEventSource.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedAgentWindowsEventSource.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * windows events log source object.
+ * Windows events log source object.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedJSONParser.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UnifiedJSONParser.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * json parser.
+ * JSON parser.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateConfigurationDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateConfigurationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * The updateable configuration properties
+ * The updatable configuration properties.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Update Log Object properties
+ * Update log object properties.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -118,7 +118,7 @@ public class UpdateLogDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -151,7 +151,7 @@ public class UpdateLogDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Log retention duration in days.
+     * Log retention duration in 30-day increments (30, 60, 90 and so on).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("retentionDuration")
     Integer retentionDuration;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogGroupDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogGroupDetails.java
@@ -94,7 +94,7 @@ public class UpdateLogGroupDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogSavedSearchDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateLogSavedSearchDetails.java
@@ -54,15 +54,6 @@ public class UpdateLogSavedSearchDetails {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-        private Boolean isQuickStart;
-
-        public Builder isQuickStart(Boolean isQuickStart) {
-            this.isQuickStart = isQuickStart;
-            this.__explicitlySet__.add("isQuickStart");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -88,7 +79,7 @@ public class UpdateLogSavedSearchDetails {
         public UpdateLogSavedSearchDetails build() {
             UpdateLogSavedSearchDetails __instance__ =
                     new UpdateLogSavedSearchDetails(
-                            name, description, query, isQuickStart, definedTags, freeformTags);
+                            name, description, query, definedTags, freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -99,7 +90,6 @@ public class UpdateLogSavedSearchDetails {
                     name(o.getName())
                             .description(o.getDescription())
                             .query(o.getQuery())
-                            .isQuickStart(o.getIsQuickStart())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -116,7 +106,7 @@ public class UpdateLogSavedSearchDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/
@@ -135,12 +125,6 @@ public class UpdateLogSavedSearchDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("query")
     String query;
-
-    /**
-     * True if the LogSavedSearch should be show as quickstart in the UI
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("isQuickStart")
-    Boolean isQuickStart;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateUnifiedAgentConfigurationDetails.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/UpdateUnifiedAgentConfigurationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.logging.model;
 
 /**
- * Update Object for Unified Agent configuration.
+ * Update Object for the Unified Agent configuration.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -132,7 +132,7 @@ public class UpdateUnifiedAgentConfigurationDetails {
     }
 
     /**
-     * The display name of a user-friendly name. It has to be unique within enclosing resource,
+     * The user-friendly display name. This must be unique within the enclosing resource,
      * and it's changeable. Avoid entering confidential information.
      *
      **/

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequest.java
@@ -150,7 +150,7 @@ public class WorkRequest {
     }
 
     /**
-     * The OCID of the work request.
+     * The work request OCID.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -168,7 +168,7 @@ public class WorkRequest {
     OperationStatus status;
 
     /**
-     * The OCID of the work request\u2019s compartment.
+     * The work request\u2019s compartment OCID.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestError.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestError.java
@@ -78,8 +78,8 @@ public class WorkRequestError {
     }
 
     /**
-     * A machine-usable code for the error that occured. Error codes are listed on
-     * (https://docs.us-phoenix-1.oraclecloud.com/Content/API/References/apierrors.htm)
+     * A machine-usable code for the error that occured. Error codes are listed at
+     * https://docs.us-phoenix-1.oraclecloud.com/Content/API/References/apierrors.htm.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("code")
@@ -92,7 +92,7 @@ public class WorkRequestError {
     String message;
 
     /**
-     * The time the error occured. An RFC3339 formatted datetime string.
+     * The time the error occured. An RFC3339-formatted date and time string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
     java.util.Date timestamp;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestLog.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestLog.java
@@ -74,7 +74,7 @@ public class WorkRequestLog {
     String message;
 
     /**
-     * The time the log message was written. An RFC3339 formatted datetime string
+     * The time the log message was written. An RFC3339-formatted date and time string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
     java.util.Date timestamp;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestResource.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/model/WorkRequestResource.java
@@ -101,7 +101,7 @@ public class WorkRequestResource {
     /**
      * The way in which this resource is affected by the work tracked in the work request.
      * A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
-     * work is complete for that resource at which point it will transition to CREATED, UPDATED,
+     * work is complete for that resource, at which point it will transition to CREATED, UPDATED,
      * or DELETED, respectively.
      *
      **/
@@ -109,13 +109,13 @@ public class WorkRequestResource {
     ActionTypes actionType;
 
     /**
-     * The identifier of the resource the work request affects.
+     * The resource identifier the work request affects.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("identifier")
     String identifier;
 
     /**
-     * The URI path that the user can do a GET on to access the resource metadata
+     * The URI path that the user can do a GET on to access the resource metadata.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
     String entityUri;

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ChangeLogSavedSearchCompartmentRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ChangeLogSavedSearchCompartmentRequest.java
@@ -19,13 +19,13 @@ public class ChangeLogSavedSearchCompartmentRequest
     private String logSavedSearchId;
 
     /**
-     * Contains details indicating which compartment the resource should move to
+     * Contains details indicating which compartment the resource should move to.
      */
     private ChangeLogSavedSearchCompartmentDetails changeLogSavedSearchCompartmentDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ChangeUnifiedAgentConfigurationCompartmentRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ChangeUnifiedAgentConfigurationCompartmentRequest.java
@@ -14,19 +14,19 @@ public class ChangeUnifiedAgentConfigurationCompartmentRequest
                 ChangeUnifiedAgentConfigurationCompartmentDetails> {
 
     /**
-     * The OCID of the unified agent configuration.
+     * The OCID of the Unified Agent configuration.
      */
     private String unifiedAgentConfigurationId;
 
     /**
-     * Request to change the compartment of a given resource
+     * Request to change the compartment of a given resource.
      */
     private ChangeUnifiedAgentConfigurationCompartmentDetails
             changeUnifiedAgentConfigurationCompartmentDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogGroupRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogGroupRequest.java
@@ -19,7 +19,7 @@ public class CreateLogGroupRequest
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogRequest.java
@@ -17,13 +17,13 @@ public class CreateLogRequest extends com.oracle.bmc.requests.BmcRequest<CreateL
     private String logGroupId;
 
     /**
-     * Log object config details.
+     * Log object configuration details.
      */
     private CreateLogDetails createLogDetails;
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogSavedSearchRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateLogSavedSearchRequest.java
@@ -19,7 +19,7 @@ public class CreateLogSavedSearchRequest
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateUnifiedAgentConfigurationRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/CreateUnifiedAgentConfigurationRequest.java
@@ -13,7 +13,7 @@ public class CreateUnifiedAgentConfigurationRequest
         extends com.oracle.bmc.requests.BmcRequest<CreateUnifiedAgentConfigurationDetails> {
 
     /**
-     * Unified Agent configuration creation object.
+     * Unified agent configuration creation object.
      */
     private CreateUnifiedAgentConfigurationDetails createUnifiedAgentConfigurationDetails;
 
@@ -26,7 +26,7 @@ public class CreateUnifiedAgentConfigurationRequest
 
     /**
      * A token that uniquely identifies a request so it can be retried in case
-     * of a timeout or server error without risk of executing that same action
+     * of a timeout or server error, without risk of executing that same action
      * again. Retry tokens expire after 24 hours, but can be invalidated
      * before then due to conflicting operations (e.g., if a resource has been
      * deleted and purged from the system, then a retry of the original

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/DeleteUnifiedAgentConfigurationRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/DeleteUnifiedAgentConfigurationRequest.java
@@ -13,7 +13,7 @@ public class DeleteUnifiedAgentConfigurationRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the unified agent configuration.
+     * The OCID of the Unified Agent configuration.
      */
     private String unifiedAgentConfigurationId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/DeleteWorkRequestRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/DeleteWorkRequestRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.logging.model.*;
 public class DeleteWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The ID of the asynchronous request.
+     * The asynchronous request ID.
      */
     private String workRequestId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetLogIncludedSearchRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetLogIncludedSearchRequest.java
@@ -13,7 +13,7 @@ public class GetLogIncludedSearchRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetUnifiedAgentConfigurationRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetUnifiedAgentConfigurationRequest.java
@@ -13,7 +13,7 @@ public class GetUnifiedAgentConfigurationRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the unified agent configuration.
+     * The OCID of the Unified Agent configuration.
      */
     private String unifiedAgentConfigurationId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetWorkRequestRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/GetWorkRequestRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.logging.model.*;
 public class GetWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The ID of the asynchronous request.
+     * The asynchronous request ID.
      */
     private String workRequestId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogGroupsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogGroupsRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.logging.model.*;
 public class ListLogGroupsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */
@@ -86,13 +86,13 @@ public class ListLogGroupsRequest extends com.oracle.bmc.requests.BmcRequest<jav
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogIncludedSearchesRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogIncludedSearchesRequest.java
@@ -13,7 +13,7 @@ public class ListLogIncludedSearchesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */
@@ -88,13 +88,13 @@ public class ListLogIncludedSearchesRequest
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogSavedSearchesRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogSavedSearchesRequest.java
@@ -13,7 +13,7 @@ public class ListLogSavedSearchesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */
@@ -88,13 +88,13 @@ public class ListLogSavedSearchesRequest
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListLogsRequest.java
@@ -17,12 +17,12 @@ public class ListLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
     private String logGroupId;
 
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      */
     private LogType logType;
 
     /**
-     * The logType that the log object is for, custom or service.
+     * The logType that the log object is for, whether custom or service.
      **/
     public enum LogType {
         Custom("CUSTOM"),
@@ -57,12 +57,12 @@ public class ListLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         }
     };
     /**
-     * Service created the log object
+     * Service that created the log object.
      */
     private String sourceService;
 
     /**
-     * Log object resource
+     * Log object resource.
      */
     private String sourceResource;
 
@@ -134,13 +134,13 @@ public class ListLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListUnifiedAgentConfigurationsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListUnifiedAgentConfigurationsRequest.java
@@ -13,7 +13,7 @@ public class ListUnifiedAgentConfigurationsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */
@@ -103,13 +103,13 @@ public class ListUnifiedAgentConfigurationsRequest
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestErrorsRequest.java
@@ -13,7 +13,7 @@ public class ListWorkRequestErrorsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The ID of the asynchronous request.
+     * The asynchronous request ID.
      */
     private String workRequestId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestLogsRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.logging.model.*;
 public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The ID of the asynchronous request.
+     * The asynchronous request ID.
      */
     private String workRequestId;
 

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestsRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/ListWorkRequestsRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.logging.model.*;
 public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Compartment OCID to list resources in. Please see compartmentIdInSubtree
+     * Compartment OCID to list resources in. See compartmentIdInSubtree
      *      for nested compartments traversal.
      *
      */
@@ -50,13 +50,13 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private Integer limit;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'
+     * The sort order to use, whether 'asc' or 'desc'.
      *
      **/
     public enum SortOrder {

--- a/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/UpdateUnifiedAgentConfigurationRequest.java
+++ b/bmc-logging/src/main/java/com/oracle/bmc/logging/requests/UpdateUnifiedAgentConfigurationRequest.java
@@ -13,7 +13,7 @@ public class UpdateUnifiedAgentConfigurationRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateUnifiedAgentConfigurationDetails> {
 
     /**
-     * The OCID of the unified agent configuration.
+     * The OCID of the Unified Agent configuration.
      */
     private String unifiedAgentConfigurationId;
 

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/Logging.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/Logging.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.loggingingestion.requests.*;
 import com.oracle.bmc.loggingingestion.responses.*;
 
 /**
- * PublicLoggingDataplane API specification
+ * Use the Logging Ingestion API to ingest your application logs.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200831")
 public interface Logging extends AutoCloseable {
@@ -46,7 +46,7 @@ public interface Logging extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * This Api allows ingesting logs associated with a logId. Success
+     * This API allows ingesting logs associated with a logId. A success
      * response implies the data has been accepted.
      *
      * @param request The request object containing the details to send

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/LoggingAsync.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/LoggingAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.loggingingestion.requests.*;
 import com.oracle.bmc.loggingingestion.responses.*;
 
 /**
- * PublicLoggingDataplane API specification
+ * Use the Logging Ingestion API to ingest your application logs.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200831")
 public interface LoggingAsync extends AutoCloseable {
@@ -46,7 +46,7 @@ public interface LoggingAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * This Api allows ingesting logs associated with a logId. Success
+     * This API allows ingesting logs associated with a logId. A success
      * response implies the data has been accepted.
      *
      *

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntry.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntry.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loggingingestion.model;
 
 /**
- * Contains the content of the log with associated timestamp and id. Each
+ * Contains the log content with the associated timestamp and ID. Each
  * entry should be less than 1 MB size.
  *
  * <br/>
@@ -79,7 +79,7 @@ public class LogEntry {
     }
 
     /**
-     * The content of the log entry.
+     * The log entry content.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("data")
     String data;
@@ -93,9 +93,8 @@ public class LogEntry {
     String id;
 
     /**
-     * Optional. The timestamp associated with the log entry. Defaults to
-     * PutLogsDetails.defaultlogentrytime if unspecified. An RFC3339 formatted
-     * datetime string.
+     * Optional. The timestamp associated with the log entry. An RFC3339-formatted date-time string.
+     * If unspecified, defaults to PutLogsDetails.defaultlogentrytime.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("time")

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntryBatch.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntryBatch.java
@@ -107,8 +107,8 @@ public class LogEntryBatch {
     java.util.List<LogEntry> entries;
 
     /**
-     * Source of the logs that generated the message. It could be the
-     * instance name, hostname or the source used to read the event.
+     * Source of the logs that generated the message. This could be the
+     * instance name, hostname, or the source used to read the event. For example, \"ServerA\".
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("source")
@@ -116,25 +116,25 @@ public class LogEntryBatch {
 
     /**
      * This field signifies the type of logs being ingested.
-     * For example: ServerA.requestLogs
+     * For example: ServerA.requestLogs.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     String type;
 
     /**
-     * This optional field is useful for specifying the specific subresource
+     * This optional field is useful for specifying the specific sub-resource
      * or input file used to read the event.
-     * For example: \"/var/log/application.log\"
+     * For example: \"/var/log/application.log\".
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subject")
     String subject;
 
     /**
-     * The timestamp for all log entries in this request. This can be
+     * The timestamp for all log entries in this batch. This can be
      * considered as the default timestamp for each entry, unless it is
-     * overwritten by the entry time. An RFC3339 formatted datetime
+     * overwritten by the entry time. An RFC3339-formatted date-time
      * string.
      *
      **/

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/requests/PutLogsRequest.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/requests/PutLogsRequest.java
@@ -23,7 +23,7 @@ public class PutLogsRequest extends com.oracle.bmc.requests.BmcRequest<PutLogsDe
 
     /**
      * Effective timestamp, for when the agent started processing the log
-     * segment being sent. An RFC3339 formatted datetime string.
+     * segment being sent. An RFC3339-formatted date-time string.
      *
      */
     private java.util.Date timestampOpcAgentProcessing;

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.24.0</version>
+    <version>1.25.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.24.0</version>
+      <version>1.25.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.24.0</version>
+  <version>1.25.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -45,7 +45,7 @@
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <commons-codec.version>1.13</commons-codec.version>
     <commons-lang3.version>3.8.1</commons-lang3.version>
-    <commons-io.version>2.6</commons-io.version>
+    <commons-io.version>2.8.0</commons-io.version>
     <!-- Update resilience4jVersion and io.vavr.version together -->
     <resilience4jVersion>1.2.0</resilience4jVersion>
     <io.vavr.version>0.10.2</io.vavr.version>


### PR DESCRIPTION
### Added

- Support for API definitions in the API Gateway service

- Support for pattern-based logical entities, namespace-bound custom properties, and faceted search in the Data Catalog service

- Support for autonomous Data Guard on autonomous infrastructure in the Database service

- Support for creating a Data Guard association on an existing standby database home in the Database service

- Support for upgrading cloud VM cluster grid infrastructure in the Database service





### Breaking Changes

- Attribute `isQuickStart` & method `isQuickStart(Boolean isQuickStart)` in models `CreateLogSavedSearchDetails`, `LogSavedSearchSummary`,`UpdateLogSavedSearchDetails` and `LogSavedSearch` is removed from the Logging Management service

- Lifecycle State `DELETED` is removed from the Logging Management service