### PR TITLE
Releasing version 1.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.25.4 - 2020-11-10
+### Added
+- Support for the 21C autonomous database version in the Database service
+- Support for creating a Data Guard association with a standby database from a database software image in the Database service
+- Support for specifying a TDE wallet password when creating a database or database system in the Database service
+- Support for enabling access control lists for autonomous databases on Exadata Cloud At Customer in the Database service
+- Support for private DNS resolvers, resolver endpoints, and views in the DNS service
+- Support for getting a VCN and resolver association in the Networking service
+- Support for additional parameters when updating subnets and VLANs in the Networking service
+- Support for analytics clusters (database accelerators) in the MySQL Database service
+- Support for migrations to Java Cloud Service and Oracle Weblogic Server instances that use existing databases in the Application Migration service
+- Support for specifying reserved IPs when creating load balancers in the Load Balancing service
+
 ## 1.25.3 - 2020-11-03
 ### Added
 - Support for calling Oracle Cloud Infrastructure services in the uk-cardiff-1 region

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigration.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigration.java
@@ -8,7 +8,10 @@ import com.oracle.bmc.applicationmigration.requests.*;
 import com.oracle.bmc.applicationmigration.responses.*;
 
 /**
- * API for the Application Migration service. Use this API to migrate applications from Oracle Cloud Infrastructure - Classic to Oracle Cloud Infrastructure.
+ * Application Migration simplifies the migration of applications from Oracle Cloud Infrastructure Classic to Oracle Cloud Infrastructure.
+ * You can use Application Migration API to migrate applications, such as Oracle Java Cloud Service, SOA Cloud Service, and Integration Classic
+ * instances, to Oracle Cloud Infrastructure. For more information, see
+ * [Overview of Application Migration](https://docs.cloud.oracle.com/iaas/application-migration/appmigrationoverview.htm).
  *
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
@@ -47,7 +50,11 @@ public interface ApplicationMigration extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Cancels the specified work request
+     * Cancels the specified work request. When you cancel a work request, it causes the in-progress task to be canceled.
+     * For example, if the create migration work request is in the accepted or in progress state for a long time, you can cancel the work request.
+     * <p>
+     * When you cancel a work request, the state of the work request changes to cancelling, and then to the cancelled state.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -55,7 +62,9 @@ public interface ApplicationMigration extends AutoCloseable {
     CancelWorkRequestResponse cancelWorkRequest(CancelWorkRequestRequest request);
 
     /**
-     * Moves a Migration into a different compartment.
+     * Moves the specified migration into a different compartment within the same tenancy. For information about moving resources between compartments,
+     * see [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -64,7 +73,9 @@ public interface ApplicationMigration extends AutoCloseable {
             ChangeMigrationCompartmentRequest request);
 
     /**
-     * Moves a Source into a different compartment.
+     * Moves the specified source into a different compartment within the same tenancy. For information about moving resources
+     * between compartments, see [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -72,8 +83,27 @@ public interface ApplicationMigration extends AutoCloseable {
     ChangeSourceCompartmentResponse changeSourceCompartment(ChangeSourceCompartmentRequest request);
 
     /**
-     * Creates an application migration in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * Creates a migration. A migration represents the end-to-end workflow of moving an application from a source environment to Oracle Cloud
+     * Infrastructure. Each migration moves a single application to Oracle Cloud Infrastructure. For more information,
+     * see [Manage Migrations](https://docs.cloud.oracle.com/iaas/application-migration/manage_migrations.htm).
+     * <p>
+     * When you create a migration, provide the required information to let Application Migration access the source environment.
+     * Application Migration uses this information to access the application in the source environment and discover application artifacts.
+     * <p>
+     * All Oracle Cloud Infrastructure resources, including migrations, get an Oracle-assigned, unique ID called an Oracle Cloud Identifier (OCID).
+     * When you create a resource, you can find its OCID in the response. You can also retrieve a resource's OCID by using a List API operation on
+     * that resource type, or by viewing the resource in the Console. For more information, see Resource Identifiers.
+     * <p>
+     * After you send your request, a migration is created in the compartment that contains the source. The new migration's lifecycle state
+     * will temporarily be <code>CREATING</code> and the state of the migration will be <code>DISCOVERING_APPLICATION</code>. During this phase,
+     * Application Migration sets the template for the <code>serviceConfig</code> and <code>applicationConfig</code> fields of the migration.
+     * When this operation is complete, the state of the migration changes to <code>MISSING_CONFIG_VALUES</code>.
+     * Next, you'll need to update the migration to provide configuration values. Before updating the
+     * migration, ensure that its state has changed to <code>MISSING_CONFIG_VALUES</code>.
+     * <p>
+     * To track the progress of this operation, you can monitor the status of the Create Migration and Discover Application work requests
+     * by using the <code>{@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in
+     * the console.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -82,8 +112,23 @@ public interface ApplicationMigration extends AutoCloseable {
     CreateMigrationResponse createMigration(CreateMigrationRequest request);
 
     /**
-     * Creates a migration source in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * Creates a source in the specified compartment. In Application Migration, a source refers to the environment from which the application
+     * is being migrated. For more information, see [Manage Sources](https://docs.cloud.oracle.com/iaas/application-migration/manage_sources.htm).
+     * <p>
+     * All Oracle Cloud Infrastructure resources, including sources, get an Oracle-assigned, unique ID called an Oracle Cloud Identifier (OCID).
+     * When you create a resource, you can find its OCID in the response. You can also retrieve a resource's OCID by using a List API operation
+     * on that resource type, or by viewing the resource in the Console.
+     * <p>
+     * After you send your request, a source is created in the specified compartment. The new source's lifecycle state will temporarily be
+     * <code>CREATING</code>. Application Migration connects to the source environment with the authentication credentials that you have provided.
+     * If the connection is established, the status of the source changes to <code>ACTIVE</code> and Application Migration fetches the list of
+     * applications that are available for migration in the source environment.
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Create Source work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * <p>
+     * Ensure that the state of the source has changed to <code>ACTIVE</code>, before you retrieve the list of applications from
+     * the source environment using the <code>{@link #listSourceApplications(ListSourceApplicationsRequest) listSourceApplications}</code> REST API call.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -92,7 +137,12 @@ public interface ApplicationMigration extends AutoCloseable {
     CreateSourceResponse createSource(CreateSourceRequest request);
 
     /**
-     * Deletes the specified Application object.
+     * Deletes the specified migration.
+     * <p>
+     * If you have migrated the application or for any other reason if you no longer require a migration, then you can delete the
+     * relevant migration. You can delete a migration, irrespective of its state. If any work request is being processed for the migration
+     * that you want to delete, then the associated work requests are cancelled and then the migration is deleted.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -100,7 +150,12 @@ public interface ApplicationMigration extends AutoCloseable {
     DeleteMigrationResponse deleteMigration(DeleteMigrationRequest request);
 
     /**
-     * Deletes the specified Source object.
+     * Deletes the specified source.
+     * <p>
+     * Before deleting a source, you must delete all the migrations associated with the source.
+     * If you have migrated all the required applications in a source or for any other reason you no longer require a source, then you can
+     * delete the relevant source.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -108,7 +163,7 @@ public interface ApplicationMigration extends AutoCloseable {
     DeleteSourceResponse deleteSource(DeleteSourceRequest request);
 
     /**
-     * Gets an application migration using the ID.
+     * Retrieves details of the specified migration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -116,7 +171,8 @@ public interface ApplicationMigration extends AutoCloseable {
     GetMigrationResponse getMigration(GetMigrationRequest request);
 
     /**
-     * Gets a migration source using the source ID.
+     * Retrieves details of the specified source. Specify the OCID of the source for which you want to retrieve details.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -124,7 +180,7 @@ public interface ApplicationMigration extends AutoCloseable {
     GetSourceResponse getSource(GetSourceRequest request);
 
     /**
-     * Gets the details of a work request.
+     * Gets the details of the specified work request.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -132,7 +188,7 @@ public interface ApplicationMigration extends AutoCloseable {
     GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
 
     /**
-     * Returns a list of migrations in a given compartment.
+     * Retrieves details of all the migrations that are available in the specified compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -141,7 +197,9 @@ public interface ApplicationMigration extends AutoCloseable {
     ListMigrationsResponse listMigrations(ListMigrationsRequest request);
 
     /**
-     * Returns a list of applications running in the source environment. This list is generated dynamically by interrogating the source and changes as applications are started or stopped in that environment.
+     * Retrieves details of all the applications associated with the specified source.
+     * This list is generated dynamically by interrogating the source and the list changes as applications are started or
+     * stopped in the source environment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -150,7 +208,10 @@ public interface ApplicationMigration extends AutoCloseable {
     ListSourceApplicationsResponse listSourceApplications(ListSourceApplicationsRequest request);
 
     /**
-     * Returns a list of migration sources in a specified compartment.
+     * Retrieves details of all the sources that are available in the specified compartment and match the specified query criteria.
+     * If you don't specify any query criteria, then details of all the sources are displayed.
+     * To filter the retrieved results, you can pass one or more of the following query parameters, by appending them to the URI
+     * as shown in the following example.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -159,7 +220,7 @@ public interface ApplicationMigration extends AutoCloseable {
     ListSourcesResponse listSources(ListSourcesRequest request);
 
     /**
-     * Gets the errors for a work request.
+     * Retrieves details of the errors encountered while executing an operation that is tracked by the specified work request.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -168,7 +229,7 @@ public interface ApplicationMigration extends AutoCloseable {
     ListWorkRequestErrorsResponse listWorkRequestErrors(ListWorkRequestErrorsRequest request);
 
     /**
-     * Gets the logs for a work request.
+     * Retrieves logs for the specified work request.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -177,7 +238,7 @@ public interface ApplicationMigration extends AutoCloseable {
     ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request);
 
     /**
-     * Lists the work requests in a compartment or for a specified resource.
+     * Retrieves details of all the work requests and match the specified query criteria. To filter the retrieved results, you can pass one or more of the following query parameters, by appending them to the URI as shown in the following example.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -186,7 +247,17 @@ public interface ApplicationMigration extends AutoCloseable {
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
 
     /**
-     * Validates target configuration and migrates a PaaS application running in a Source environment into the customers Oracle Cloud Infrastructure tenancy. This an optional action and only required if automatic start of migration was not selected when creating the migration.
+     * Starts migrating the specified application to Oracle Cloud Infrastructure.
+     * <p>
+     * Before sending this request, ensure that you have provided configuration details to update the migration and the state of the migration
+     * is <code>READY</code>.
+     * <p>
+     * After you send this request, the migration's state will temporarily be <code>MIGRATING</code>.
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Migrate Application work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * When this work request is processed successfully, Application Migration creates the required resources in the target environment
+     * and the state of the migration changes to <code>MIGRATION_SUCCEEDED</code>.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -195,7 +266,36 @@ public interface ApplicationMigration extends AutoCloseable {
     MigrateApplicationResponse migrateApplication(MigrateApplicationRequest request);
 
     /**
-     * Update the configuration for an application migration.
+     * Updates the configuration details for the specified migration.
+     * <p>
+     * When you create a migration, Application Migration sets the template for the <code>serviceConfig</code> and <code>applicationConfig</code>
+     * attributes of the migration.
+     * When you update the migration, you must provide values for these fields to specify configuration information for the application in the
+     * target environment.
+     * <p>
+     *
+     * <p>
+     * Before updating the migration, complete the following tasks:
+     * <ol>
+     * <li>Identify the migration that you want to update and ensure that the migration is in the <code>MISSING_CONFIG_VALUES</code> state.</li>
+     * <li>Get details of the migration using the <code>GetMigration</code> command. This returns the  template for the <code>serviceConfig</code>
+     * and <code>applicationConfig</code> attributes of the migration.</li>
+     * <li>You must fill out the required details for the <code>serviceConfig</code> and <code>applicationConfig</code> attributes.
+     * The <code>isRequired</code> attribute of a configuration property indicates whether it is mandatory to provide a value.</li>
+     * <li>You can provide values for the optional configuration properties or you can delete the optional properties for which you do not
+     * provide values. Note that you cannot add any property that is not present in the template.</li>
+     * </ol>
+     * <p>
+     * To update the migration, pass the configuration values in the request body. The information that you must provide depends on the type
+     * of application that you are migrating. For reference information about configuration fields, see
+     * [Provide Configuration Information](https://docs.cloud.oracle.com/iaas/application-migration/manage_migrations.htm#provide_configuration_details).
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Update Migration work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * <p>
+     * When the migration has been updated, the state of the migration changes to <code>READY</code>. After updating the migration,
+     * you can start the migration whenever you are ready.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -203,7 +303,11 @@ public interface ApplicationMigration extends AutoCloseable {
     UpdateMigrationResponse updateMigration(UpdateMigrationRequest request);
 
     /**
-     * Update source details.
+     * You can update the authorization details to access the source environment from which you want to migrate applications to Oracle Cloud
+     * Infrastructure. You can also update the description and tags of a source.
+     * <p>
+     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationAsync.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationAsync.java
@@ -8,7 +8,10 @@ import com.oracle.bmc.applicationmigration.requests.*;
 import com.oracle.bmc.applicationmigration.responses.*;
 
 /**
- * API for the Application Migration service. Use this API to migrate applications from Oracle Cloud Infrastructure - Classic to Oracle Cloud Infrastructure.
+ * Application Migration simplifies the migration of applications from Oracle Cloud Infrastructure Classic to Oracle Cloud Infrastructure.
+ * You can use Application Migration API to migrate applications, such as Oracle Java Cloud Service, SOA Cloud Service, and Integration Classic
+ * instances, to Oracle Cloud Infrastructure. For more information, see
+ * [Overview of Application Migration](https://docs.cloud.oracle.com/iaas/application-migration/appmigrationoverview.htm).
  *
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
@@ -47,7 +50,11 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Cancels the specified work request
+     * Cancels the specified work request. When you cancel a work request, it causes the in-progress task to be canceled.
+     * For example, if the create migration work request is in the accepted or in progress state for a long time, you can cancel the work request.
+     * <p>
+     * When you cancel a work request, the state of the work request changes to cancelling, and then to the cancelled state.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -63,7 +70,9 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Moves a Migration into a different compartment.
+     * Moves the specified migration into a different compartment within the same tenancy. For information about moving resources between compartments,
+     * see [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -79,7 +88,9 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Moves a Source into a different compartment.
+     * Moves the specified source into a different compartment within the same tenancy. For information about moving resources
+     * between compartments, see [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -95,8 +106,27 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates an application migration in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * Creates a migration. A migration represents the end-to-end workflow of moving an application from a source environment to Oracle Cloud
+     * Infrastructure. Each migration moves a single application to Oracle Cloud Infrastructure. For more information,
+     * see [Manage Migrations](https://docs.cloud.oracle.com/iaas/application-migration/manage_migrations.htm).
+     * <p>
+     * When you create a migration, provide the required information to let Application Migration access the source environment.
+     * Application Migration uses this information to access the application in the source environment and discover application artifacts.
+     * <p>
+     * All Oracle Cloud Infrastructure resources, including migrations, get an Oracle-assigned, unique ID called an Oracle Cloud Identifier (OCID).
+     * When you create a resource, you can find its OCID in the response. You can also retrieve a resource's OCID by using a List API operation on
+     * that resource type, or by viewing the resource in the Console. For more information, see Resource Identifiers.
+     * <p>
+     * After you send your request, a migration is created in the compartment that contains the source. The new migration's lifecycle state
+     * will temporarily be <code>CREATING</code> and the state of the migration will be <code>DISCOVERING_APPLICATION</code>. During this phase,
+     * Application Migration sets the template for the <code>serviceConfig</code> and <code>applicationConfig</code> fields of the migration.
+     * When this operation is complete, the state of the migration changes to <code>MISSING_CONFIG_VALUES</code>.
+     * Next, you'll need to update the migration to provide configuration values. Before updating the
+     * migration, ensure that its state has changed to <code>MISSING_CONFIG_VALUES</code>.
+     * <p>
+     * To track the progress of this operation, you can monitor the status of the Create Migration and Discover Application work requests
+     * by using the <code>{@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in
+     * the console.
      *
      *
      * @param request The request object containing the details to send
@@ -112,8 +142,23 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a migration source in the specified compartment.
-     * Specify the compartment using the compartment ID.
+     * Creates a source in the specified compartment. In Application Migration, a source refers to the environment from which the application
+     * is being migrated. For more information, see [Manage Sources](https://docs.cloud.oracle.com/iaas/application-migration/manage_sources.htm).
+     * <p>
+     * All Oracle Cloud Infrastructure resources, including sources, get an Oracle-assigned, unique ID called an Oracle Cloud Identifier (OCID).
+     * When you create a resource, you can find its OCID in the response. You can also retrieve a resource's OCID by using a List API operation
+     * on that resource type, or by viewing the resource in the Console.
+     * <p>
+     * After you send your request, a source is created in the specified compartment. The new source's lifecycle state will temporarily be
+     * <code>CREATING</code>. Application Migration connects to the source environment with the authentication credentials that you have provided.
+     * If the connection is established, the status of the source changes to <code>ACTIVE</code> and Application Migration fetches the list of
+     * applications that are available for migration in the source environment.
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Create Source work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * <p>
+     * Ensure that the state of the source has changed to <code>ACTIVE</code>, before you retrieve the list of applications from
+     * the source environment using the <code>{@link #listSourceApplications(ListSourceApplicationsRequest, Consumer, Consumer) listSourceApplications}</code> REST API call.
      *
      *
      * @param request The request object containing the details to send
@@ -129,7 +174,12 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes the specified Application object.
+     * Deletes the specified migration.
+     * <p>
+     * If you have migrated the application or for any other reason if you no longer require a migration, then you can delete the
+     * relevant migration. You can delete a migration, irrespective of its state. If any work request is being processed for the migration
+     * that you want to delete, then the associated work requests are cancelled and then the migration is deleted.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -144,7 +194,12 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes the specified Source object.
+     * Deletes the specified source.
+     * <p>
+     * Before deleting a source, you must delete all the migrations associated with the source.
+     * If you have migrated all the required applications in a source or for any other reason you no longer require a source, then you can
+     * delete the relevant source.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -159,7 +214,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets an application migration using the ID.
+     * Retrieves details of the specified migration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -174,7 +229,8 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets a migration source using the source ID.
+     * Retrieves details of the specified source. Specify the OCID of the source for which you want to retrieve details.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -188,7 +244,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetSourceRequest, GetSourceResponse> handler);
 
     /**
-     * Gets the details of a work request.
+     * Gets the details of the specified work request.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -203,7 +259,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns a list of migrations in a given compartment.
+     * Retrieves details of all the migrations that are available in the specified compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -219,7 +275,9 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns a list of applications running in the source environment. This list is generated dynamically by interrogating the source and changes as applications are started or stopped in that environment.
+     * Retrieves details of all the applications associated with the specified source.
+     * This list is generated dynamically by interrogating the source and the list changes as applications are started or
+     * stopped in the source environment.
      *
      *
      * @param request The request object containing the details to send
@@ -236,7 +294,10 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns a list of migration sources in a specified compartment.
+     * Retrieves details of all the sources that are available in the specified compartment and match the specified query criteria.
+     * If you don't specify any query criteria, then details of all the sources are displayed.
+     * To filter the retrieved results, you can pass one or more of the following query parameters, by appending them to the URI
+     * as shown in the following example.
      *
      *
      * @param request The request object containing the details to send
@@ -251,7 +312,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListSourcesRequest, ListSourcesResponse> handler);
 
     /**
-     * Gets the errors for a work request.
+     * Retrieves details of the errors encountered while executing an operation that is tracked by the specified work request.
      *
      *
      * @param request The request object containing the details to send
@@ -268,7 +329,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the logs for a work request.
+     * Retrieves logs for the specified work request.
      *
      *
      * @param request The request object containing the details to send
@@ -285,7 +346,7 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists the work requests in a compartment or for a specified resource.
+     * Retrieves details of all the work requests and match the specified query criteria. To filter the retrieved results, you can pass one or more of the following query parameters, by appending them to the URI as shown in the following example.
      *
      *
      * @param request The request object containing the details to send
@@ -301,7 +362,17 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Validates target configuration and migrates a PaaS application running in a Source environment into the customers Oracle Cloud Infrastructure tenancy. This an optional action and only required if automatic start of migration was not selected when creating the migration.
+     * Starts migrating the specified application to Oracle Cloud Infrastructure.
+     * <p>
+     * Before sending this request, ensure that you have provided configuration details to update the migration and the state of the migration
+     * is <code>READY</code>.
+     * <p>
+     * After you send this request, the migration's state will temporarily be <code>MIGRATING</code>.
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Migrate Application work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * When this work request is processed successfully, Application Migration creates the required resources in the target environment
+     * and the state of the migration changes to <code>MIGRATION_SUCCEEDED</code>.
      *
      *
      * @param request The request object containing the details to send
@@ -318,7 +389,36 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update the configuration for an application migration.
+     * Updates the configuration details for the specified migration.
+     * <p>
+     * When you create a migration, Application Migration sets the template for the <code>serviceConfig</code> and <code>applicationConfig</code>
+     * attributes of the migration.
+     * When you update the migration, you must provide values for these fields to specify configuration information for the application in the
+     * target environment.
+     * <p>
+     *
+     * <p>
+     * Before updating the migration, complete the following tasks:
+     * <ol>
+     * <li>Identify the migration that you want to update and ensure that the migration is in the <code>MISSING_CONFIG_VALUES</code> state.</li>
+     * <li>Get details of the migration using the <code>GetMigration</code> command. This returns the  template for the <code>serviceConfig</code>
+     * and <code>applicationConfig</code> attributes of the migration.</li>
+     * <li>You must fill out the required details for the <code>serviceConfig</code> and <code>applicationConfig</code> attributes.
+     * The <code>isRequired</code> attribute of a configuration property indicates whether it is mandatory to provide a value.</li>
+     * <li>You can provide values for the optional configuration properties or you can delete the optional properties for which you do not
+     * provide values. Note that you cannot add any property that is not present in the template.</li>
+     * </ol>
+     * <p>
+     * To update the migration, pass the configuration values in the request body. The information that you must provide depends on the type
+     * of application that you are migrating. For reference information about configuration fields, see
+     * [Provide Configuration Information](https://docs.cloud.oracle.com/iaas/application-migration/manage_migrations.htm#provide_configuration_details).
+     * <p>
+     * To track the progress of the operation, you can monitor the status of the Update Migration work request by using the
+     * <code>{@link #getWorkRequest(GetWorkRequestRequest, Consumer, Consumer) getWorkRequest}</code> REST API operation on the work request or by viewing the status of the work request in the console.
+     * <p>
+     * When the migration has been updated, the state of the migration changes to <code>READY</code>. After updating the migration,
+     * you can start the migration whenever you are ready.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -333,7 +433,11 @@ public interface ApplicationMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update source details.
+     * You can update the authorization details to access the source environment from which you want to migrate applications to Oracle Cloud
+     * Infrastructure. You can also update the description and tags of a source.
+     * <p>
+     **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationAsyncClient.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationAsyncClient.java
@@ -973,6 +973,7 @@ public class ApplicationMigrationAsyncClient implements ApplicationMigrationAsyn
                 MigrateApplicationConverter.fromRequest(client, interceptedRequest);
         final com.google.common.base.Function<javax.ws.rs.core.Response, MigrateApplicationResponse>
                 transformer = MigrateApplicationConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
 
         com.oracle.bmc.responses.AsyncHandler<MigrateApplicationRequest, MigrateApplicationResponse>
                 handlerToUse = handler;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationClient.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationClient.java
@@ -931,6 +931,7 @@ public class ApplicationMigrationClient implements ApplicationMigration {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationWaiters.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/ApplicationMigrationWaiters.java
@@ -20,6 +20,202 @@ public class ApplicationMigrationWaiters {
     private final ApplicationMigration client;
 
     /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
+            GetMigrationRequest request,
+            com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forMigration(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
+            GetMigrationRequest request,
+            com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forMigration(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
+            GetMigrationRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forMigration(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Migration.
+    private com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetMigrationRequest request,
+            final com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates...
+                    targetStates) {
+        final java.util.Set<com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetMigrationRequest, GetMigrationResponse>() {
+                            @Override
+                            public GetMigrationResponse apply(GetMigrationRequest request) {
+                                return client.getMigration(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetMigrationResponse>() {
+                            @Override
+                            public boolean apply(GetMigrationResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getMigration().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSourceRequest, GetSourceResponse> forSource(
+            GetSourceRequest request,
+            com.oracle.bmc.applicationmigration.model.SourceLifecycleStates... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forSource(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSourceRequest, GetSourceResponse> forSource(
+            GetSourceRequest request,
+            com.oracle.bmc.applicationmigration.model.SourceLifecycleStates targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forSource(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSourceRequest, GetSourceResponse> forSource(
+            GetSourceRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.applicationmigration.model.SourceLifecycleStates... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forSource(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Source.
+    private com.oracle.bmc.waiter.Waiter<GetSourceRequest, GetSourceResponse> forSource(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetSourceRequest request,
+            final com.oracle.bmc.applicationmigration.model.SourceLifecycleStates... targetStates) {
+        final java.util.Set<com.oracle.bmc.applicationmigration.model.SourceLifecycleStates>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<GetSourceRequest, GetSourceResponse>() {
+                            @Override
+                            public GetSourceResponse apply(GetSourceRequest request) {
+                                return client.getSource(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetSourceResponse>() {
+                            @Override
+                            public boolean apply(GetSourceResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getSource().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.applicationmigration.model.SourceLifecycleStates
+                                        .Deleted)),
+                request);
+    }
+
+    /**
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using default configuration.
      *
      * @param request the request to send

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/internal/http/MigrateApplicationConverter.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/internal/http/MigrateApplicationConverter.java
@@ -49,6 +49,14 @@ public class MigrateApplicationConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
         return ib;
     }
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/AuthorizationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/AuthorizationDetails.java
@@ -5,7 +5,9 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Base model for different source authorization methods
+ * Details of the source environment from which you want to migrate applications to Oracle Cloud Infrastructure. It also contains access
+ * credentials.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ChangeCompartmentDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ChangeCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Provides the updated compartment OCID
+ * Moves the resource to the specified compartment.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class ChangeCompartmentDetails {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
-     * into which the resource should be moved.
+     * to move the resource to.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ConfigurationField.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ConfigurationField.java
@@ -5,7 +5,9 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Information required to migrate an application. Populated by the service as the source application is introspected
+ * Provide configuration information about the application in the target environment. Application Migration migrates the application to
+ * the target environment only after you provide this information. The information that you must provide varies depending on the type of
+ * application that you are migrating.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -125,7 +127,7 @@ public class ConfigurationField {
     }
 
     /**
-     * The name of the configuration field
+     * The name of the configuration field.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
@@ -137,32 +139,32 @@ public class ConfigurationField {
     String group;
 
     /**
-     * The configuration field type
+     * The type of the configuration field.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     String type;
 
     /**
-     * The value of the field
+     * The value of the field.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("value")
     String value;
 
     /**
-     * Help text to guide the customer in setting the configuration value
+     * Help text to guide the user in setting the configuration value.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Indicates whether or not the field is required (defaults to true)
+     * Indicates whether or not the field is required (defaults to `true`).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isRequired")
     Boolean isRequired;
 
     /**
-     * Indicates whether or not the field may be modified (defaults to true)
+     * Indicates whether or not the field may be modified (defaults to `true`).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isMutable")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateMigrationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateMigrationDetails.java
@@ -5,7 +5,16 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * An application being migrated from a source environment to OCI.
+ * While creating a migration, specify the source and the application that you want migrate.
+ * Each migration moves a single application from a specified source to a specified Oracle Cloud Infrastructure tenancy.
+ * If required, provide the credentials of the application administrator in the source environment.
+ * Application Migration uses this information to access the application, as well as discover application artifacts,
+ * such as the complete domain configuration along with data sources and other dependencies.
+ * <p>
+ * You must also assign a name and provide a description for the migration.
+ * This helps you to identify the appropriate source environment when you have multiple sources defined.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -81,6 +90,16 @@ public class CreateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
+        private TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+        public Builder preCreatedTargetDatabaseType(
+                TargetDatabaseTypes preCreatedTargetDatabaseType) {
+            this.preCreatedTargetDatabaseType = preCreatedTargetDatabaseType;
+            this.__explicitlySet__.add("preCreatedTargetDatabaseType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
         private java.util.Map<String, ConfigurationField> serviceConfig;
 
@@ -131,6 +150,7 @@ public class CreateMigrationDetails {
                             sourceId,
                             applicationName,
                             discoveryDetails,
+                            preCreatedTargetDatabaseType,
                             serviceConfig,
                             applicationConfig,
                             freeformTags,
@@ -148,6 +168,7 @@ public class CreateMigrationDetails {
                             .sourceId(o.getSourceId())
                             .applicationName(o.getApplicationName())
                             .discoveryDetails(o.getDiscoveryDetails())
+                            .preCreatedTargetDatabaseType(o.getPreCreatedTargetDatabaseType())
                             .serviceConfig(o.getServiceConfig())
                             .applicationConfig(o.getApplicationConfig())
                             .freeformTags(o.getFreeformTags())
@@ -166,32 +187,32 @@ public class CreateMigrationDetails {
     }
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the source.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the application.
+     * User-friendly name of the application. This will be the name of the migrated application in Oracle Cloud Infrastructure.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Description of the application.
+     * Description of the application that you are migrating.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * Unique identifier (OCID) of the application source.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
     String sourceId;
 
     /**
-     * Name of the application being migrated from the source.
+     * Name of the application that you want to migrate from the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationName")
     String applicationName;
@@ -200,22 +221,34 @@ public class CreateMigrationDetails {
     DiscoveryDetails discoveryDetails;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * The pre-existing database type to be used in this migration. Currently, Application migration only supports Oracle Cloud
+     * Infrastrure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
+    TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+    /**
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
     java.util.Map<String, ConfigurationField> serviceConfig;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationConfig")
     java.util.Map<String, ConfigurationField> applicationConfig;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -223,7 +256,7 @@ public class CreateMigrationDetails {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateSourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateSourceDetails.java
@@ -5,8 +5,13 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * The Source object. Sources represent external locations from which
- * applications may be imported into an OCI tenancy.
+ * The configuration details for creating a source.
+ * <p>
+ * When you create a source, provide the required information to let Application Migration access the source environment.
+ * You must also assign a name and provide a description for the source. This helps you to identify the appropriate source environment when you
+ * have multiple sources defined.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -133,20 +138,20 @@ public class CreateSourceDetails {
     }
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the source.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the source.
+     * Name of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Description of the source.
+     * Description of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -158,8 +163,8 @@ public class CreateSourceDetails {
     AuthorizationDetails authorizationDetails;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -167,7 +172,7 @@ public class CreateSourceDetails {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/DiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/DiscoveryDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Base model for different application discovery requirements
+ * Base model for different application discovery requirements.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/IcsDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/IcsDiscoveryDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source ICS instance
+ * Credentials to access the Oracle Integration Cloud Service application in the source environment. Application Migration connects
+ * to the application in the source environment with the supplied credentials.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -87,13 +88,13 @@ public class IcsDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The ICS instance admin user
+     * Application administrator username to access the Oracle Integration Cloud Service application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstanceUser")
     String serviceInstanceUser;
 
     /**
-     * The ICS instance admin password
+     * Password for this user.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstancePassword")
     String serviceInstancePassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/InternalAuthorizationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/InternalAuthorizationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source Oracle Cloud Infrastructure - Classic environment.
+ * Credentials to access Oracle Cloud Infrastructure - Classic, which is the source environment from which you want to migrate the application.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/InternalSourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/InternalSourceDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies configuration specific to the source environment.
+ * Details about the Oracle Cloud Infrastructure - Classic account, the source environment from which you want to migrate the application.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -74,7 +74,7 @@ public class InternalSourceDetails extends SourceDetails {
     }
 
     /**
-     * The tradition cloud account name
+     * The identity domain ID of your traditional Oracle Cloud Infrastructure - Classic account.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("accountName")
     String accountName;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/JcsDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/JcsDiscoveryDetails.java
@@ -5,7 +5,9 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source JCS instance
+ * Credentials to access the Oracle Java Cloud Service application in the source environment. When you create and update a migration,
+ * Application Migration connects to the application in the source environment with the supplied credentials and exports the domain
+ * configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -86,13 +88,13 @@ public class JcsDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The JCS instance weblogic admin user
+     * WebLogic administrator username for the Oracle Java Cloud Service application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("weblogicUser")
     String weblogicUser;
 
     /**
-     * The JCS instance weblogic admin password
+     * The password of the WebLogic administrator for the Oracle Java Cloud Service application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("weblogicPassword")
     String weblogicPassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Migration.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Migration.java
@@ -5,7 +5,13 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * An application being migrated from a source environment to OCI.
+ * The properties that define a migration. A migration represents the end-to-end workflow of moving an application from a source
+ * environment to Oracle Cloud Infrastructure. Each migration moves a single application to Oracle Cloud Infrastructure.
+ * For more information, see [Manage Migrations](https://docs.cloud.oracle.com/iaas/application-migration/manage_migrations.htm).
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator.
+ * If you're an administrator who needs to write policies to give users access, see
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -97,6 +103,16 @@ public class Migration {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
+        private TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+        public Builder preCreatedTargetDatabaseType(
+                TargetDatabaseTypes preCreatedTargetDatabaseType) {
+            this.preCreatedTargetDatabaseType = preCreatedTargetDatabaseType;
+            this.__explicitlySet__.add("preCreatedTargetDatabaseType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
         private java.util.Map<String, ConfigurationField> serviceConfig;
 
@@ -176,6 +192,7 @@ public class Migration {
                             sourceId,
                             applicationName,
                             applicationType,
+                            preCreatedTargetDatabaseType,
                             serviceConfig,
                             applicationConfig,
                             lifecycleState,
@@ -198,6 +215,7 @@ public class Migration {
                             .sourceId(o.getSourceId())
                             .applicationName(o.getApplicationName())
                             .applicationType(o.getApplicationType())
+                            .preCreatedTargetDatabaseType(o.getPreCreatedTargetDatabaseType())
                             .serviceConfig(o.getServiceConfig())
                             .applicationConfig(o.getApplicationConfig())
                             .lifecycleState(o.getLifecycleState())
@@ -219,20 +237,20 @@ public class Migration {
     }
 
     /**
-     * Unique identifier (OCID) for the application
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the migration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the migration.
+     * User-friendly name of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -244,19 +262,19 @@ public class Migration {
     String description;
 
     /**
-     * The date and time at which the migration was created.
+     * The date and time at which the migration was created, in the format defined by RFC3339.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * Unique identifier (OCID) of the application source.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source with which this migration is associated.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
     String sourceId;
 
     /**
-     * Name of the application being migrated from the source.
+     * Name of the application which is being migrated. This is the name of the application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationName")
     String applicationName;
@@ -268,40 +286,52 @@ public class Migration {
     MigrationTypes applicationType;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * The pre-existing database type to be used in this migration. Currently, Application migration only supports Oracle Cloud
+     * Infrastrure databases and this option is currently available only for `JAVA_CLOUD_SERVICE` and `WEBLOGIC_CLOUD_SERVICE` target instance types.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
+    TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+    /**
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
     java.util.Map<String, ConfigurationField> serviceConfig;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationConfig")
     java.util.Map<String, ConfigurationField> applicationConfig;
 
     /**
-     * The current state of the Migration
+     * The current state of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     MigrationLifecycleStates lifecycleState;
 
     /**
-     * Details about the current lifecycle state
+     * Details about the current lifecycle state of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
 
     /**
-     * The current state of the overall Migration process
+     * The current state of the overall migration process.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("migrationState")
     MigrationStates migrationState;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -309,7 +339,7 @@ public class Migration {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationLifecycleStates.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationLifecycleStates.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.applicationmigration.model;
  * Resource lifecycle state
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
 public enum MigrationLifecycleStates {
     Creating("CREATING"),
     Active("ACTIVE"),
@@ -16,7 +17,12 @@ public enum MigrationLifecycleStates {
     Succeeded("SUCCEEDED"),
     Deleting("DELETING"),
     Deleted("DELETED"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, MigrationLifecycleStates> map;
@@ -24,7 +30,9 @@ public enum MigrationLifecycleStates {
     static {
         map = new java.util.HashMap<>();
         for (MigrationLifecycleStates v : MigrationLifecycleStates.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -42,6 +50,9 @@ public enum MigrationLifecycleStates {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid MigrationLifecycleStates: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'MigrationLifecycleStates', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationStates.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationStates.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.applicationmigration.model;
  * Migration process state
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
 public enum MigrationStates {
     DiscoveringApplication("DISCOVERING_APPLICATION"),
     DiscoveryFailed("DISCOVERY_FAILED"),
@@ -16,7 +17,12 @@ public enum MigrationStates {
     Migrating("MIGRATING"),
     MigrationFailed("MIGRATION_FAILED"),
     MigrationSucceeded("MIGRATION_SUCCEEDED"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, MigrationStates> map;
@@ -24,7 +30,9 @@ public enum MigrationStates {
     static {
         map = new java.util.HashMap<>();
         for (MigrationStates v : MigrationStates.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -42,6 +50,9 @@ public enum MigrationStates {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid MigrationStates: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'MigrationStates', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationSummary.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * An application being migrated from a source environment to OCI.
+ * Details about the migration. Each migration moves a single application from a specified source to Oracle Cloud Infrastructure.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -196,20 +196,20 @@ public class MigrationSummary {
     }
 
     /**
-     * Unique identifier (OCID) for the application
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the migration.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the migration.
+     * User-friendly name of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -221,19 +221,19 @@ public class MigrationSummary {
     String description;
 
     /**
-     * The date and time at which the migration was created.
+     * The date and time at which the migration was created, in the format defined by RFC3339.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * Unique identifier (OCID) of the source.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
     String sourceId;
 
     /**
-     * Name of the application being migrated from the source.
+     * Name of the application which is being migrated from the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationName")
     String applicationName;
@@ -245,26 +245,26 @@ public class MigrationSummary {
     MigrationTypes applicationType;
 
     /**
-     * The current state of the Migration
+     * The current state of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     MigrationLifecycleStates lifecycleState;
 
     /**
-     * Details about the current lifecycle state
+     * Details about the current lifecycle state.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
 
     /**
-     * The current state of the overall Migration process
+     * The current state of the overall migration process.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("migrationState")
     MigrationStates migrationState;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -272,7 +272,7 @@ public class MigrationSummary {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationTypes.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/MigrationTypes.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * The type of application service to be migrated.
+ * The type of application to be migrated.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
 @lombok.extern.slf4j.Slf4j

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OacDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OacDiscoveryDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source OAC instance
+ * Details about the Oracle Analytics Cloud - Classic application in the source environment.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -87,13 +87,13 @@ public class OacDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The OAC instance admin user
+     * This field is currently not supported. You must enter a value, such as <code>unused</code>. However, the value that you enter is ignored.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstanceUser")
     String serviceInstanceUser;
 
     /**
-     * The OAC instance admin password
+     * This field is currently not supported. You must enter a value, such as <code>unused</code>. However, the value that you enter is ignored.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstancePassword")
     String serviceInstancePassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OcicAuthorizationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OcicAuthorizationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source Oracle Cloud Infrastructure - Classic environment.
+ * Credentials to access Oracle Cloud Infrastructure - Classic, which is the source environment from which you want to migrate the application.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OcicSourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OcicSourceDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies configuration specific to the source environment.
+ * Details about the Oracle Cloud Infrastructure Classic account, the source environment from which you want to migrate the application.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -84,13 +84,18 @@ public class OcicSourceDetails extends SourceDetails {
     }
 
     /**
-     * The Oracle Cloud Infrastructure - Classic region name (e.g. us2-z11 or uscom-central-1)
+     * The Oracle Cloud Infrastructure - Classic region from which you want to migrate your applications. For example, uscom-east-1 or uscom-central-1.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")
     String region;
 
     /**
-     * The compute account id
+     * If you are using a Oracle Cloud Infrastructure - Classic account with Identity Cloud Service (IDCS), enter the service instance ID.
+     * For example, if Compute-567890123 is the account name of your Oracle Cloud Infrastructure Classic Compute service entitlement,
+     * then enter 567890123.
+     * <p>
+     * If you are using a traditional Oracle Cloud Infrastructure - Classic account, enter your identity domain ID.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeAccount")
     String computeAccount;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OicDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OicDiscoveryDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source OIC instance
+ * Credentials to access the Oracle Integration application in the source environment. Application Migration connects to the
+ * application in the source environment with the supplied credentials.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -87,13 +88,13 @@ public class OicDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The OIC instance admin user
+     * Application administrator username to access the Oracle Integration Classic instance in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstanceUser")
     String serviceInstanceUser;
 
     /**
-     * The OIC instance admin password
+     * Password for this user.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstancePassword")
     String serviceInstancePassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OperationStatus.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OperationStatus.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.applicationmigration.model;
  * Possible operation status.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
 public enum OperationStatus {
     Accepted("ACCEPTED"),
     InProgress("IN_PROGRESS"),
@@ -15,7 +16,12 @@ public enum OperationStatus {
     Succeeded("SUCCEEDED"),
     Canceling("CANCELING"),
     Canceled("CANCELED"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, OperationStatus> map;
@@ -23,7 +29,9 @@ public enum OperationStatus {
     static {
         map = new java.util.HashMap<>();
         for (OperationStatus v : OperationStatus.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -41,6 +49,9 @@ public enum OperationStatus {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid OperationStatus: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'OperationStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OperationTypes.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OperationTypes.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.applicationmigration.model;
  * Possible operation types.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
 public enum OperationTypes {
     CreateSource("CREATE_SOURCE"),
     UpdateSource("UPDATE_SOURCE"),
@@ -20,7 +21,12 @@ public enum OperationTypes {
     MigrateApplication("MIGRATE_APPLICATION"),
     ChangeSourceCompartment("CHANGE_SOURCE_COMPARTMENT"),
     ChangeMigrationCompartment("CHANGE_MIGRATION_COMPARTMENT"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, OperationTypes> map;
@@ -28,7 +34,9 @@ public enum OperationTypes {
     static {
         map = new java.util.HashMap<>();
         for (OperationTypes v : OperationTypes.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -46,6 +54,9 @@ public enum OperationTypes {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid OperationTypes: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'OperationTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/PcsDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/PcsDiscoveryDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source PCS instance
+ * Credentials to access the Oracle Process Cloud Service application in the source environment. Application Migration connects to the
+ * application in the source environment with the supplied credentials.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -87,13 +88,13 @@ public class PcsDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The PCS instance admin user
+     * Application administrator username to access the Oracle Process Cloud Service application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstanceUser")
     String serviceInstanceUser;
 
     /**
-     * The PCS instance admin password
+     * Password for this user.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceInstancePassword")
     String serviceInstancePassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SoacsDiscoveryDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SoacsDiscoveryDetails.java
@@ -5,7 +5,9 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Specifies the credentials to access the source SOACS instance
+ * Credentials to access the Oracle SOA Cloud Service application in the source environment. When you create and update a migration,
+ * Application Migration connects to the application in the source environment with the supplied credentials and exports the domain
+ * configuration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -86,13 +88,13 @@ public class SoacsDiscoveryDetails extends DiscoveryDetails {
     }
 
     /**
-     * The SOACS instance weblogic admin user
+     * WebLogic administrator username for the Oracle SOA Cloud Service application in the source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("weblogicUser")
     String weblogicUser;
 
     /**
-     * The SOACS instance weblogic admin password
+     * Password for this user.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("weblogicPassword")
     String weblogicPassword;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Source.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Source.java
@@ -5,8 +5,12 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * The Source object. Sources represent external locations from which
- * applications may be imported into an OCI tenancy.
+ * The properties that define a source. Source refers to the source environment from which you migrate an application to Oracle Cloud
+ * Infrastructure. For more information, see [Manage Sources](https://docs.cloud.oracle.com/iaas/application-migration/manage_sources.htm).
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized, talk to an administrator. If you're
+ * an administrator who needs to write policies to give users access, see [Getting Started with
+ * Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -164,44 +168,44 @@ public class Source {
     }
 
     /**
-     * Unique identifier (OCID) for the source
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the source.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the source.
+     * Name of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Description of the source.
+     * Description of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The date and time at which the source was created
+     * The date and time at which the source was created, in the format defined by RFC3339.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The current state of the Source
+     * The current state of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     SourceLifecycleStates lifecycleState;
 
     /**
-     * Details about the current lifecycle state
+     * Details about the current lifecycle state of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
@@ -210,8 +214,8 @@ public class Source {
     SourceDetails sourceDetails;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -219,7 +223,7 @@ public class Source {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceApplication.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceApplication.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * An application running in the source environment that is available for export.
+ * Details about an application running in the source environment that you can migrate to Oracle Cloud Infrastructure.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -104,31 +104,31 @@ public class SourceApplication {
     }
 
     /**
-     * The name of the application
+     * The name of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * The type of application
+     * The type of application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     MigrationTypes type;
 
     /**
-     * Unique identifier (OCID) for the Source to which the application belongs
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source to which the application belongs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
     String sourceId;
 
     /**
-     * The version of the application server
+     * The version of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("version")
     String version;
 
     /**
-     * The current application running state
+     * The current state of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("state")
     String state;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceApplicationSummary.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceApplicationSummary.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * An application running in the source environment that is available for export.
+ * The properties that define an application, that is running in the source environment and which can be migrated to Oracle
+ * Cloud Infrastructure.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -104,31 +105,31 @@ public class SourceApplicationSummary {
     }
 
     /**
-     * The name of the application
+     * The name of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * The type of application
+     * The type of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     MigrationTypes type;
 
     /**
-     * Unique identifier (OCID) for the Source to which the application belongs
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source to which the application belongs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
     String sourceId;
 
     /**
-     * The version of the application server
+     * The version of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("version")
     String version;
 
     /**
-     * The current application running state
+     * The current state of the application.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("state")
     String state;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceDetails.java
@@ -5,7 +5,14 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Base model for different source environment types
+ * Specify one of the following values depending for the 'type' attribute based on the application that you want to migrate.
+ * <p>
+ * Specify `OCIC` if you want to migrate Oracle Java Cloud Service, Oracle Analytics Cloud - Classic, Oracle Integration, and Oracle
+ * SOA Cloud Service applications from Oracle Cloud Infrastructure - Classic.
+ * <p>
+ * Specify `INTERNAL_COMPUTE` if you have a traditional Oracle Cloud Infrastructure - Classic account and you want to migrate Oracle
+ * Process Cloud Service or Oracle Integration Cloud Service applications.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceLifecycleStates.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceLifecycleStates.java
@@ -8,6 +8,7 @@ package com.oracle.bmc.applicationmigration.model;
  * Resource lifecycle state
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
 public enum SourceLifecycleStates {
     Creating("CREATING"),
     Deleting("DELETING"),
@@ -15,7 +16,12 @@ public enum SourceLifecycleStates {
     Active("ACTIVE"),
     Inactive("INACTIVE"),
     Deleted("DELETED"),
-    ;
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
 
     private final String value;
     private static java.util.Map<String, SourceLifecycleStates> map;
@@ -23,7 +29,9 @@ public enum SourceLifecycleStates {
     static {
         map = new java.util.HashMap<>();
         for (SourceLifecycleStates v : SourceLifecycleStates.values()) {
-            map.put(v.getValue(), v);
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
         }
     }
 
@@ -41,6 +49,9 @@ public enum SourceLifecycleStates {
         if (map.containsKey(key)) {
             return map.get(key);
         }
-        throw new IllegalArgumentException("Invalid SourceLifecycleStates: " + key);
+        LOG.warn(
+                "Received unknown value '{}' for enum 'SourceLifecycleStates', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
     }
 }

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceSummary.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceSummary.java
@@ -5,8 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * The Source object. Sources represent external locations from which
- * applications may be imported into an OCI tenancy.
+ * Details of the source. In Application Migration, a source refers to the environment from which the application is migrated to Oracle Cloud Infrastructure.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -164,57 +163,57 @@ public class SourceSummary {
     }
 
     /**
-     * Unique identifier (OCID) for the source
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The type of source environment
+     * The type of source environment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     SourceTypes type;
 
     /**
-     * Unique idenfifier (OCID) for the compartment where the Source is located.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the source.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * Human-readable name of the source.
+     * Name of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Description of the source.
+     * Description of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The date and time at which the source was created.
+     * The date and time at which the source was created, in the format defined by RFC3339.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The current state of the Source
+     * The current state of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     SourceLifecycleStates lifecycleState;
 
     /**
-     * Details about the current lifecycle state
+     * Details about the current lifecycle state of the source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -222,7 +221,7 @@ public class SourceSummary {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/TargetDatabaseTypes.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/TargetDatabaseTypes.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.applicationmigration.model;
+
+/**
+ * The type of the target database associated with the target instance.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.extern.slf4j.Slf4j
+public enum TargetDatabaseTypes {
+    DatabaseSystem("DATABASE_SYSTEM"),
+    NotSet("NOT_SET"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, TargetDatabaseTypes> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (TargetDatabaseTypes v : TargetDatabaseTypes.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    TargetDatabaseTypes(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TargetDatabaseTypes create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'TargetDatabaseTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateMigrationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateMigrationDetails.java
@@ -5,7 +5,11 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * Update the details and configuration of a migration.
+ * Provide configuration information about the application in the target environment. Application Migration migrates the
+ * application to the target environment only after you provide this information. The information that you must provide varies
+ * depending on the type of application that you are migrating.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -133,7 +137,7 @@ public class UpdateMigrationDetails {
     }
 
     /**
-     * Human-readable name of the migration.
+     * User-friendly name of the migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
@@ -148,22 +152,26 @@ public class UpdateMigrationDetails {
     DiscoveryDetails discoveryDetails;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
     java.util.Map<String, ConfigurationField> serviceConfig;
 
     /**
-     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the CreateMigration operation.
+     * Configuration required to migrate the application. In addition to the key and value, additional fields are provided
+     * to describe type type and purpose of each field. Only the value for each key is required when passing configuration to the
+     * CreateMigration operation.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applicationConfig")
     java.util.Map<String, ConfigurationField> applicationConfig;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -171,7 +179,7 @@ public class UpdateMigrationDetails {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateSourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateSourceDetails.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * The Source object. Sources represent external locations from which
- * applications may be imported into an OCI tenancy.
+ * You can update the authorization details to access the source environment from which you want to migrate applications to
+ * Oracle Cloud Infrastructure. You can also update the description and tags of a source.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -122,13 +122,13 @@ public class UpdateSourceDetails {
     }
 
     /**
-     * Human-readable name of the source.
+     * Name of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * Description of the source.
+     * Description of the source. This helps you to identify the appropriate source environment when you have multiple sources defined.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -140,8 +140,8 @@ public class UpdateSourceDetails {
     AuthorizationDetails authorizationDetails;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: `{\"bar-key\": \"value\"}`
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Department\": \"Finance\"}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
@@ -149,7 +149,7 @@ public class UpdateSourceDetails {
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm). Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequest.java
@@ -181,7 +181,7 @@ public class WorkRequest {
     java.util.List<WorkRequestResource> resources;
 
     /**
-     * The amount of work done relative to the total amount of work.
+     * The percentage completion of the operation relative to the total amount of work that is tracked by this work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
     Float percentComplete;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestError.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestError.java
@@ -84,7 +84,7 @@ public class WorkRequestError {
     String code;
 
     /**
-     * A human-readable error string.
+     * A user-friendly error string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     String message;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestLogEntry.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestLogEntry.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.applicationmigration.model;
 
 /**
- * A log message from executing an operation that is tracked by a work request.
+ * A log message about the execution of an operation that is tracked by a work request.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -70,7 +70,7 @@ public class WorkRequestLogEntry {
     }
 
     /**
-     * A human-readable log message.
+     * A user-friendly log message.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     String message;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestResource.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestResource.java
@@ -151,7 +151,7 @@ public class WorkRequestResource {
     ActionType actionType;
 
     /**
-     * The resource type the work request affects.
+     * The resource type that the work request affects, source or migration.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entityType")
     String entityType;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestSummary.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/WorkRequestSummary.java
@@ -167,7 +167,7 @@ public class WorkRequestSummary {
     String compartmentId;
 
     /**
-     * The percentage complete of the operation tracked by this work request.
+     * The percentage completion of the operation tracked by this work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
     Float percentComplete;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/CancelWorkRequestRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/CancelWorkRequestRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class CancelWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 
@@ -25,7 +25,7 @@ public class CancelWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ChangeMigrationCompartmentRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ChangeMigrationCompartmentRequest.java
@@ -13,7 +13,7 @@ public class ChangeMigrationCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeCompartmentDetails> {
 
     /**
-     * The application OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      */
     private String migrationId;
 
@@ -24,7 +24,7 @@ public class ChangeMigrationCompartmentRequest
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ChangeSourceCompartmentRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ChangeSourceCompartmentRequest.java
@@ -13,7 +13,7 @@ public class ChangeSourceCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeCompartmentDetails> {
 
     /**
-     * The source OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      */
     private String sourceId;
 
@@ -24,7 +24,7 @@ public class ChangeSourceCompartmentRequest
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/DeleteMigrationRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/DeleteMigrationRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class DeleteMigrationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The application OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      */
     private String migrationId;
 
@@ -25,7 +25,7 @@ public class DeleteMigrationRequest extends com.oracle.bmc.requests.BmcRequest<j
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/DeleteSourceRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/DeleteSourceRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class DeleteSourceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The source OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      */
     private String sourceId;
 
@@ -25,7 +25,7 @@ public class DeleteSourceRequest extends com.oracle.bmc.requests.BmcRequest<java
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetMigrationRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetMigrationRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class GetMigrationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The application OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      */
     private String migrationId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetSourceRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetSourceRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class GetSourceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The source OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      */
     private String sourceId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetWorkRequestRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/GetWorkRequestRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class GetWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListMigrationsRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListMigrationsRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListMigrationsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The compartment OCID on which to filter.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a compartment. Retrieves details of objects in the specified compartment.
      */
     private String compartmentId;
 
@@ -24,7 +24,7 @@ public class ListMigrationsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String opcRequestId;
 
     /**
-     * The OCID on which to query for an application.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) on which to query for a migration.
      *
      */
     private String id;
@@ -101,9 +101,9 @@ public class ListMigrationsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
-     * The lifecycle state on which to filter.
+     * This field is not supported. Do not use.
      */
-    private MigrationLifecycleStates lifecycleState;
+    private com.oracle.bmc.applicationmigration.model.MigrationLifecycleStates lifecycleState;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListSourceApplicationsRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListSourceApplicationsRequest.java
@@ -13,12 +13,12 @@ public class ListSourceApplicationsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The source OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      */
     private String sourceId;
 
     /**
-     * The compartment OCID on which to filter.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a compartment. Retrieves details of objects in the specified compartment.
      */
     private String compartmentId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListSourcesRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListSourcesRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListSourcesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The compartment OCID on which to filter.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a compartment. Retrieves details of objects in the specified compartment.
      */
     private String compartmentId;
 
@@ -24,7 +24,7 @@ public class ListSourcesRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String opcRequestId;
 
     /**
-     * The OCID on which to query for a source.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) on which to query for a source.
      *
      */
     private String id;
@@ -101,9 +101,9 @@ public class ListSourcesRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String displayName;
 
     /**
-     * The lifecycle state on which to filter.
+     * Retrieves details of sources in the specified lifecycle state.
      */
-    private SourceLifecycleStates lifecycleState;
+    private com.oracle.bmc.applicationmigration.model.SourceLifecycleStates lifecycleState;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestErrorsRequest.java
@@ -13,7 +13,7 @@ public class ListWorkRequestErrorsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestLogsRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestsRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/ListWorkRequestsRequest.java
@@ -12,12 +12,12 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The compartment OCID on which to filter.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a compartment. Retrieves details of objects in the specified compartment.
      */
     private String compartmentId;
 
     /**
-     * The OCID of the resource.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) for a resource. Retrieves details of the specified resource.
      */
     private String resourceId;
 

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/MigrateApplicationRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/MigrateApplicationRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class MigrateApplicationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The application OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      */
     private String migrationId;
 
@@ -22,6 +22,24 @@ public class MigrateApplicationRequest extends com.oracle.bmc.requests.BmcReques
      *
      */
     private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of retrying the same action. Retry tokens expire after
+     * 24 hours, but can be invalidated before then due to conflicting operations. For example,
+     * if a resource has been deleted and purged from the system, then a retry of the original
+     * creation request may be rejected.
+     *
+     */
+    private String opcRetryToken;
 
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
@@ -60,6 +78,8 @@ public class MigrateApplicationRequest extends com.oracle.bmc.requests.BmcReques
         public Builder copy(MigrateApplicationRequest o) {
             migrationId(o.getMigrationId());
             opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/UpdateMigrationRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/UpdateMigrationRequest.java
@@ -13,7 +13,7 @@ public class UpdateMigrationRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateMigrationDetails> {
 
     /**
-     * The application OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the migration.
      */
     private String migrationId;
 
@@ -42,7 +42,7 @@ public class UpdateMigrationRequest
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/UpdateSourceRequest.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/requests/UpdateSourceRequest.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class UpdateSourceRequest extends com.oracle.bmc.requests.BmcRequest<UpdateSourceDetails> {
 
     /**
-     * The source OCID
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the source.
      */
     private String sourceId;
 
@@ -31,7 +31,7 @@ public class UpdateSourceRequest extends com.oracle.bmc.requests.BmcRequest<Upda
 
     /**
      * For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
-     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+     * parameter to the value of the etag from a previous `GET` or `POST` response for that resource. The resource
      * will be updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListMigrationsResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListMigrationsResponse.java
@@ -19,9 +19,9 @@ public class ListMigrationsResponse {
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListSourceApplicationsResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListSourceApplicationsResponse.java
@@ -19,9 +19,9 @@ public class ListSourceApplicationsResponse {
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListSourcesResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListSourcesResponse.java
@@ -19,9 +19,9 @@ public class ListSourcesResponse {
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestErrorsResponse.java
@@ -12,9 +12,9 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListWorkRequestErrorsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestLogsResponse.java
@@ -12,9 +12,9 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListWorkRequestLogsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestsResponse.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/responses/ListWorkRequestsResponse.java
@@ -12,9 +12,9 @@ import com.oracle.bmc.applicationmigration.model.*;
 public class ListWorkRequestsResponse {
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
-     * then a partial list might have been returned. Include this value as the `page` parameter for the
-     * subsequent GET request to get the next batch of items.
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * Include this value as the `page` parameter for the subsequent GET request to get the next batch of items.
      *
      */
     private String opcNextPage;

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,396 +19,396 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/RetryTokenUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/RetryTokenUtils.java
@@ -15,6 +15,13 @@ public class RetryTokenUtils {
     private RetryTokenUtils() {}
 
     public static void addRetryToken(WrappedInvocationBuilder ib) {
+
+        boolean isOpcRetryTokenAlreadySet = ib.getHeaders().containsKey(OPC_RETRY_TOKEN_HEADER);
+
+        if (isOpcRetryTokenAlreadySet) {
+            return;
+        }
+
         ib.header(OPC_RETRY_TOKEN_HEADER, generateRetryToken());
     }
 

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -73,6 +73,20 @@ public interface VirtualNetwork extends AutoCloseable {
     AddPublicIpPoolCapacityResponse addPublicIpPoolCapacity(AddPublicIpPoolCapacityRequest request);
 
     /**
+     * Add a CIDR to a VCN. The new CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR provided is valid
+     * b. The new CIDR range should not overlap with any existing CIDRs
+     * c. The new CIDR should not exceed the max limit of CIDRs per VCNs
+     * d. The new CIDR range does not overlap with any peered VCNs
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AddVcnCidrResponse addVcnCidr(AddVcnCidrRequest request);
+
+    /**
      * initiate route advertisements for the Byoip Range prefix.
      * the prefix must be in PROVISIONED state
      *
@@ -819,10 +833,17 @@ public interface VirtualNetwork extends AutoCloseable {
      * Creates a new virtual cloud network (VCN). For more information, see
      * [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
      * <p>
-     * For the VCN you must specify a single, contiguous IPv4 CIDR block. Oracle recommends using one of the
-     * private IP address ranges specified in [RFC 1918](https://tools.ietf.org/html/rfc1918) (10.0.0.0/8,
-     * 172.16/12, and 192.168/16). Example: 172.16.0.0/16. The CIDR block can range from /16 to /30, and it
-     * must not overlap with your on-premises network. You can't change the size of the VCN after creation.
+     * To create the VCN, you may specify a list of IPv4 CIDR blocks. The CIDRs must maintain
+     * the following rules -
+     * <p>
+     * a. The list of CIDRs provided are valid
+     * b. There is no overlap between different CIDRs
+     * c. The list of CIDRs does not exceed the max limit of CIDRs per VCN
+     * <p>
+     * Oracle recommends using one of the private IP address ranges specified in [RFC 1918]
+     * (https://tools.ietf.org/html/rfc1918) (10.0.0.0/8, 172.16/12, and 192.168/16). Example:
+     * 172.16.0.0/16. The CIDR blocks can range from /16 to /30, and they must not overlap with
+     * your on-premises network.
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the VCN to
      * reside. Consult an Oracle Cloud Infrastructure administrator in your organization if you're not sure which
@@ -1681,6 +1702,15 @@ public interface VirtualNetwork extends AutoCloseable {
     GetVcnResponse getVcn(GetVcnRequest request);
 
     /**
+     * Get the associated DNS resolver information with a vcn
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetVcnDnsResolverAssociationResponse getVcnDnsResolverAssociation(
+            GetVcnDnsResolverAssociationRequest request);
+
+    /**
      * Gets the specified virtual circuit's information.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2144,6 +2174,22 @@ public interface VirtualNetwork extends AutoCloseable {
     ListVlansResponse listVlans(ListVlansRequest request);
 
     /**
+     * Update a CIDR from a VCN. The new CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR provided is valid
+     * b. The new CIDR range should not overlap with any existing CIDRs
+     * c. The new CIDR should not exceed the max limit of CIDRs per VCNs
+     * d. The new CIDR range does not overlap with any peered VCNs
+     * e. The new CIDR should overlap with any existing route rule within a VCN
+     * f. All existing subnet CIDRs are subsets of the updated CIDR ranges
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ModifyVcnCidrResponse modifyVcnCidr(ModifyVcnCidrRequest request);
+
+    /**
      * Removes one or more security rules from the specified network security group.
      *
      * @param request The request object containing the details to send
@@ -2162,6 +2208,16 @@ public interface VirtualNetwork extends AutoCloseable {
      */
     RemovePublicIpPoolCapacityResponse removePublicIpPoolCapacity(
             RemovePublicIpPoolCapacityRequest request);
+
+    /**
+     * Remove a CIDR from a VCN. The CIDR being removed should not have
+     * any resources allocated from it.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    RemoveVcnCidrResponse removeVcnCidr(RemoveVcnCidrRequest request);
 
     /**
      * Updates the specified Byoip Range.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -90,6 +90,26 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Add a CIDR to a VCN. The new CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR provided is valid
+     * b. The new CIDR range should not overlap with any existing CIDRs
+     * c. The new CIDR should not exceed the max limit of CIDRs per VCNs
+     * d. The new CIDR range does not overlap with any peered VCNs
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AddVcnCidrResponse> addVcnCidr(
+            AddVcnCidrRequest request,
+            com.oracle.bmc.responses.AsyncHandler<AddVcnCidrRequest, AddVcnCidrResponse> handler);
+
+    /**
      * initiate route advertisements for the Byoip Range prefix.
      * the prefix must be in PROVISIONED state
      *
@@ -1215,10 +1235,17 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * Creates a new virtual cloud network (VCN). For more information, see
      * [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
      * <p>
-     * For the VCN you must specify a single, contiguous IPv4 CIDR block. Oracle recommends using one of the
-     * private IP address ranges specified in [RFC 1918](https://tools.ietf.org/html/rfc1918) (10.0.0.0/8,
-     * 172.16/12, and 192.168/16). Example: 172.16.0.0/16. The CIDR block can range from /16 to /30, and it
-     * must not overlap with your on-premises network. You can't change the size of the VCN after creation.
+     * To create the VCN, you may specify a list of IPv4 CIDR blocks. The CIDRs must maintain
+     * the following rules -
+     * <p>
+     * a. The list of CIDRs provided are valid
+     * b. There is no overlap between different CIDRs
+     * c. The list of CIDRs does not exceed the max limit of CIDRs per VCN
+     * <p>
+     * Oracle recommends using one of the private IP address ranges specified in [RFC 1918]
+     * (https://tools.ietf.org/html/rfc1918) (10.0.0.0/8, 172.16/12, and 192.168/16). Example:
+     * 172.16.0.0/16. The CIDR blocks can range from /16 to /30, and they must not overlap with
+     * your on-premises network.
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the VCN to
      * reside. Consult an Oracle Cloud Infrastructure administrator in your organization if you're not sure which
@@ -2571,6 +2598,23 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetVcnRequest, GetVcnResponse> handler);
 
     /**
+     * Get the associated DNS resolver information with a vcn
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVcnDnsResolverAssociationResponse> getVcnDnsResolverAssociation(
+            GetVcnDnsResolverAssociationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetVcnDnsResolverAssociationRequest,
+                            GetVcnDnsResolverAssociationResponse>
+                    handler);
+
+    /**
      * Gets the specified virtual circuit's information.
      *
      * @param request The request object containing the details to send
@@ -3333,6 +3377,29 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListVlansRequest, ListVlansResponse> handler);
 
     /**
+     * Update a CIDR from a VCN. The new CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR provided is valid
+     * b. The new CIDR range should not overlap with any existing CIDRs
+     * c. The new CIDR should not exceed the max limit of CIDRs per VCNs
+     * d. The new CIDR range does not overlap with any peered VCNs
+     * e. The new CIDR should overlap with any existing route rule within a VCN
+     * f. All existing subnet CIDRs are subsets of the updated CIDR ranges
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ModifyVcnCidrResponse> modifyVcnCidr(
+            ModifyVcnCidrRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ModifyVcnCidrRequest, ModifyVcnCidrResponse>
+                    handler);
+
+    /**
      * Removes one or more security rules from the specified network security group.
      *
      *
@@ -3366,6 +3433,23 @@ public interface VirtualNetworkAsync extends AutoCloseable {
             RemovePublicIpPoolCapacityRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             RemovePublicIpPoolCapacityRequest, RemovePublicIpPoolCapacityResponse>
+                    handler);
+
+    /**
+     * Remove a CIDR from a VCN. The CIDR being removed should not have
+     * any resources allocated from it.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveVcnCidrResponse> removeVcnCidr(
+            RemoveVcnCidrRequest request,
+            com.oracle.bmc.responses.AsyncHandler<RemoveVcnCidrRequest, RemoveVcnCidrResponse>
                     handler);
 
     /**

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsyncClient.java
@@ -415,6 +415,44 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AddVcnCidrResponse> addVcnCidr(
+            AddVcnCidrRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<AddVcnCidrRequest, AddVcnCidrResponse>
+                    handler) {
+        LOG.trace("Called async addVcnCidr");
+        final AddVcnCidrRequest interceptedRequest = AddVcnCidrConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddVcnCidrConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, AddVcnCidrResponse>
+                transformer = AddVcnCidrConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<AddVcnCidrRequest, AddVcnCidrResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                AddVcnCidrRequest, AddVcnCidrResponse>,
+                        java.util.concurrent.Future<AddVcnCidrResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    AddVcnCidrRequest, AddVcnCidrResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<AdvertiseByoipRangeResponse> advertiseByoipRange(
             AdvertiseByoipRangeRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -5154,6 +5192,50 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetVcnDnsResolverAssociationResponse>
+            getVcnDnsResolverAssociation(
+                    GetVcnDnsResolverAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetVcnDnsResolverAssociationRequest,
+                                    GetVcnDnsResolverAssociationResponse>
+                            handler) {
+        LOG.trace("Called async getVcnDnsResolverAssociation");
+        final GetVcnDnsResolverAssociationRequest interceptedRequest =
+                GetVcnDnsResolverAssociationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVcnDnsResolverAssociationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVcnDnsResolverAssociationResponse>
+                transformer = GetVcnDnsResolverAssociationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetVcnDnsResolverAssociationRequest,
+                                GetVcnDnsResolverAssociationResponse>,
+                        java.util.concurrent.Future<GetVcnDnsResolverAssociationResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetVirtualCircuitResponse> getVirtualCircuit(
             GetVirtualCircuitRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -6782,6 +6864,45 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ModifyVcnCidrResponse> modifyVcnCidr(
+            ModifyVcnCidrRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ModifyVcnCidrRequest, ModifyVcnCidrResponse>
+                    handler) {
+        LOG.trace("Called async modifyVcnCidr");
+        final ModifyVcnCidrRequest interceptedRequest =
+                ModifyVcnCidrConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ModifyVcnCidrConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ModifyVcnCidrResponse>
+                transformer = ModifyVcnCidrConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<ModifyVcnCidrRequest, ModifyVcnCidrResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ModifyVcnCidrRequest, ModifyVcnCidrResponse>,
+                        java.util.concurrent.Future<ModifyVcnCidrResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ModifyVcnCidrRequest, ModifyVcnCidrResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RemoveNetworkSecurityGroupSecurityRulesResponse>
             removeNetworkSecurityGroupSecurityRules(
                     RemoveNetworkSecurityGroupSecurityRulesRequest request,
@@ -6862,6 +6983,45 @@ public class VirtualNetworkAsyncClient implements VirtualNetworkAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     RemovePublicIpPoolCapacityRequest, RemovePublicIpPoolCapacityResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RemoveVcnCidrResponse> removeVcnCidr(
+            RemoveVcnCidrRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<RemoveVcnCidrRequest, RemoveVcnCidrResponse>
+                    handler) {
+        LOG.trace("Called async removeVcnCidr");
+        final RemoveVcnCidrRequest interceptedRequest =
+                RemoveVcnCidrConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveVcnCidrConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, RemoveVcnCidrResponse>
+                transformer = RemoveVcnCidrConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<RemoveVcnCidrRequest, RemoveVcnCidrResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemoveVcnCidrRequest, RemoveVcnCidrResponse>,
+                        java.util.concurrent.Future<RemoveVcnCidrResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemoveVcnCidrRequest, RemoveVcnCidrResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkClient.java
@@ -513,6 +513,38 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public AddVcnCidrResponse addVcnCidr(AddVcnCidrRequest request) {
+        LOG.trace("Called addVcnCidr");
+        final AddVcnCidrRequest interceptedRequest = AddVcnCidrConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddVcnCidrConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AddVcnCidrResponse> transformer =
+                AddVcnCidrConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAddVcnCidrDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public AdvertiseByoipRangeResponse advertiseByoipRange(AdvertiseByoipRangeRequest request) {
         LOG.trace("Called advertiseByoipRange");
         final AdvertiseByoipRangeRequest interceptedRequest =
@@ -4117,6 +4149,36 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public GetVcnDnsResolverAssociationResponse getVcnDnsResolverAssociation(
+            GetVcnDnsResolverAssociationRequest request) {
+        LOG.trace("Called getVcnDnsResolverAssociation");
+        final GetVcnDnsResolverAssociationRequest interceptedRequest =
+                GetVcnDnsResolverAssociationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVcnDnsResolverAssociationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVcnDnsResolverAssociationResponse>
+                transformer = GetVcnDnsResolverAssociationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetVirtualCircuitResponse getVirtualCircuit(GetVirtualCircuitRequest request) {
         LOG.trace("Called getVirtualCircuit");
         final GetVirtualCircuitRequest interceptedRequest =
@@ -5265,6 +5327,39 @@ public class VirtualNetworkClient implements VirtualNetwork {
     }
 
     @Override
+    public ModifyVcnCidrResponse modifyVcnCidr(ModifyVcnCidrRequest request) {
+        LOG.trace("Called modifyVcnCidr");
+        final ModifyVcnCidrRequest interceptedRequest =
+                ModifyVcnCidrConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ModifyVcnCidrConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ModifyVcnCidrResponse>
+                transformer = ModifyVcnCidrConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getModifyVcnCidrDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RemoveNetworkSecurityGroupSecurityRulesResponse removeNetworkSecurityGroupSecurityRules(
             RemoveNetworkSecurityGroupSecurityRulesRequest request) {
         LOG.trace("Called removeNetworkSecurityGroupSecurityRules");
@@ -5330,6 +5425,39 @@ public class VirtualNetworkClient implements VirtualNetwork {
                                                 ib,
                                                 retriedRequest
                                                         .getRemovePublicIpPoolCapacityDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RemoveVcnCidrResponse removeVcnCidr(RemoveVcnCidrRequest request) {
+        LOG.trace("Called removeVcnCidr");
+        final RemoveVcnCidrRequest interceptedRequest =
+                RemoveVcnCidrConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveVcnCidrConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RemoveVcnCidrResponse>
+                transformer = RemoveVcnCidrConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getRemoveVcnCidrDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkWaiters.java
@@ -41,6 +41,61 @@ public class VirtualNetworkWaiters {
      * @param request the request to send
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<AddVcnCidrRequest, AddVcnCidrResponse> forAddVcnCidr(
+            AddVcnCidrRequest request) {
+        return forAddVcnCidr(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<AddVcnCidrRequest, AddVcnCidrResponse> forAddVcnCidr(
+            AddVcnCidrRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<AddVcnCidrResponse>() {
+                    @Override
+                    public AddVcnCidrResponse call() throws Exception {
+                        final AddVcnCidrResponse response = client.addVcnCidr(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<ChangeDrgCompartmentRequest, ChangeDrgCompartmentResponse>
             forChangeDrgCompartment(ChangeDrgCompartmentRequest request) {
         return forChangeDrgCompartment(
@@ -2671,6 +2726,119 @@ public class VirtualNetworkWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>
+            forVcnDnsResolverAssociation(
+                    GetVcnDnsResolverAssociationRequest request,
+                    com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forVcnDnsResolverAssociation(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>
+            forVcnDnsResolverAssociation(
+                    GetVcnDnsResolverAssociationRequest request,
+                    com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forVcnDnsResolverAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>
+            forVcnDnsResolverAssociation(
+                    GetVcnDnsResolverAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forVcnDnsResolverAssociation(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for VcnDnsResolverAssociation.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetVcnDnsResolverAssociationRequest, GetVcnDnsResolverAssociationResponse>
+            forVcnDnsResolverAssociation(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetVcnDnsResolverAssociationRequest request,
+                    final com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetVcnDnsResolverAssociationRequest,
+                                GetVcnDnsResolverAssociationResponse>() {
+                            @Override
+                            public GetVcnDnsResolverAssociationResponse apply(
+                                    GetVcnDnsResolverAssociationRequest request) {
+                                return client.getVcnDnsResolverAssociation(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetVcnDnsResolverAssociationResponse>() {
+                            @Override
+                            public boolean apply(GetVcnDnsResolverAssociationResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getVcnDnsResolverAssociation()
+                                                .getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.core.model.VcnDnsResolverAssociation.LifecycleState
+                                        .Terminated)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetVirtualCircuitRequest, GetVirtualCircuitResponse>
             forVirtualCircuit(
                     GetVirtualCircuitRequest request,
@@ -2952,6 +3120,118 @@ public class VirtualNetworkWaiters {
                         },
                         targetStatesSet.contains(
                                 com.oracle.bmc.core.model.Vnic.LifecycleState.Terminated)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<ModifyVcnCidrRequest, ModifyVcnCidrResponse>
+            forModifyVcnCidr(ModifyVcnCidrRequest request) {
+        return forModifyVcnCidr(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<ModifyVcnCidrRequest, ModifyVcnCidrResponse>
+            forModifyVcnCidr(
+                    ModifyVcnCidrRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<ModifyVcnCidrResponse>() {
+                    @Override
+                    public ModifyVcnCidrResponse call() throws Exception {
+                        final ModifyVcnCidrResponse response = client.modifyVcnCidr(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<RemoveVcnCidrRequest, RemoveVcnCidrResponse>
+            forRemoveVcnCidr(RemoveVcnCidrRequest request) {
+        return forRemoveVcnCidr(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<RemoveVcnCidrRequest, RemoveVcnCidrResponse>
+            forRemoveVcnCidr(
+                    RemoveVcnCidrRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<RemoveVcnCidrResponse>() {
+                    @Override
+                    public RemoveVcnCidrResponse call() throws Exception {
+                        final RemoveVcnCidrResponse response = client.removeVcnCidr(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
                 request);
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/AddVcnCidrConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/AddVcnCidrConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class AddVcnCidrConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.AddVcnCidrRequest interceptRequest(
+            com.oracle.bmc.core.requests.AddVcnCidrRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.AddVcnCidrRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVcnId(), "vcnId must not be blank");
+        Validate.notNull(request.getAddVcnCidrDetails(), "addVcnCidrDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vcns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVcnId()))
+                        .path("actions")
+                        .path("addCidr");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.core.responses.AddVcnCidrResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.core.responses.AddVcnCidrResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.AddVcnCidrResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.AddVcnCidrResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.AddVcnCidrResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.AddVcnCidrResponse.Builder builder =
+                                        com.oracle.bmc.core.responses.AddVcnCidrResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.AddVcnCidrResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetVcnDnsResolverAssociationConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetVcnDnsResolverAssociationConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVcnDnsResolverAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.GetVcnDnsResolverAssociationRequest interceptRequest(
+            com.oracle.bmc.core.requests.GetVcnDnsResolverAssociationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.GetVcnDnsResolverAssociationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVcnId(), "vcnId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vcns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVcnId()))
+                        .path("dnsResolverAssociation");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.GetVcnDnsResolverAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.GetVcnDnsResolverAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses
+                                        .GetVcnDnsResolverAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses
+                                            .GetVcnDnsResolverAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.GetVcnDnsResolverAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VcnDnsResolverAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VcnDnsResolverAssociation.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VcnDnsResolverAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.GetVcnDnsResolverAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .GetVcnDnsResolverAssociationResponse
+                                                        .builder();
+
+                                builder.vcnDnsResolverAssociation(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.GetVcnDnsResolverAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ModifyVcnCidrConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ModifyVcnCidrConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ModifyVcnCidrConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ModifyVcnCidrRequest interceptRequest(
+            com.oracle.bmc.core.requests.ModifyVcnCidrRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ModifyVcnCidrRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVcnId(), "vcnId must not be blank");
+        Validate.notNull(request.getModifyVcnCidrDetails(), "modifyVcnCidrDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vcns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVcnId()))
+                        .path("actions")
+                        .path("modifyCidr");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.core.responses.ModifyVcnCidrResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.ModifyVcnCidrResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.ModifyVcnCidrResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.ModifyVcnCidrResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ModifyVcnCidrResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.ModifyVcnCidrResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses.ModifyVcnCidrResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.ModifyVcnCidrResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/RemoveVcnCidrConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/RemoveVcnCidrConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class RemoveVcnCidrConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.RemoveVcnCidrRequest interceptRequest(
+            com.oracle.bmc.core.requests.RemoveVcnCidrRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.RemoveVcnCidrRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVcnId(), "vcnId must not be blank");
+        Validate.notNull(request.getRemoveVcnCidrDetails(), "removeVcnCidrDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vcns")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVcnId()))
+                        .path("actions")
+                        .path("removeCidr");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.core.responses.RemoveVcnCidrResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.RemoveVcnCidrResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.RemoveVcnCidrResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.RemoveVcnCidrResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.RemoveVcnCidrResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.RemoveVcnCidrResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses.RemoveVcnCidrResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.RemoveVcnCidrResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AddVcnCidrDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AddVcnCidrDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains a new CIDR which will be added to the VCN.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AddVcnCidrDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AddVcnCidrDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+        private String cidrBlock;
+
+        public Builder cidrBlock(String cidrBlock) {
+            this.cidrBlock = cidrBlock;
+            this.__explicitlySet__.add("cidrBlock");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AddVcnCidrDetails build() {
+            AddVcnCidrDetails __instance__ = new AddVcnCidrDetails(cidrBlock);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AddVcnCidrDetails o) {
+            Builder copiedBuilder = cidrBlock(o.getCidrBlock());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The CIDR IP address that needs to be added.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+    String cidrBlock;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
@@ -33,6 +33,15 @@ public class CreateVcnDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlocks")
+        private java.util.List<String> cidrBlocks;
+
+        public Builder cidrBlocks(java.util.List<String> cidrBlocks) {
+            this.cidrBlocks = cidrBlocks;
+            this.__explicitlySet__.add("cidrBlocks");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -104,6 +113,7 @@ public class CreateVcnDetails {
             CreateVcnDetails __instance__ =
                     new CreateVcnDetails(
                             cidrBlock,
+                            cidrBlocks,
                             compartmentId,
                             ipv6CidrBlock,
                             definedTags,
@@ -119,6 +129,7 @@ public class CreateVcnDetails {
         public Builder copy(CreateVcnDetails o) {
             Builder copiedBuilder =
                     cidrBlock(o.getCidrBlock())
+                            .cidrBlocks(o.getCidrBlocks())
                             .compartmentId(o.getCompartmentId())
                             .ipv6CidrBlock(o.getIpv6CidrBlock())
                             .definedTags(o.getDefinedTags())
@@ -140,12 +151,26 @@ public class CreateVcnDetails {
     }
 
     /**
-     * The CIDR IP address block of the VCN.
+     * Deprecated. Instead use 'cidrBlocks'. It is an error to set both cidrBlock and
+     * cidrBlocks.
      * Example: `10.0.0.0/16`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
     String cidrBlock;
+
+    /**
+     * List of IPv4 CIDR blocks associated with the VCN. The CIDRs must maintain the following
+     * rules -
+     * <p>
+     * a. The list of CIDRs provided are valid
+     * b. There is no overlap between different CIDRs
+     * c. The number of CIDRs should not exceed the max limit of CIDRs per VCN
+     * d. It is an error to set both cidrBlock and cidrBlocks.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlocks")
+    java.util.List<String> cidrBlocks;
 
     /**
      * The OCID of the compartment to contain the VCN.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVlanDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVlanDetails.java
@@ -177,6 +177,7 @@ public class CreateVlanDetails {
      * hosts outside the VLAN. The CIDR must maintain the following rules -
      * <p>
      * a. The CIDR block is valid and correctly formatted.
+     * b. The new range is within one of the parent VCN ranges.
      * <p>
      * Example: `192.0.2.0/24`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ModifyVcnCidrDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ModifyVcnCidrDetails.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains the original CIDR that needs to be updated and the
+ * new CIDR which will replace the original CIDR.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ModifyVcnCidrDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ModifyVcnCidrDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("originalCidrBlock")
+        private String originalCidrBlock;
+
+        public Builder originalCidrBlock(String originalCidrBlock) {
+            this.originalCidrBlock = originalCidrBlock;
+            this.__explicitlySet__.add("originalCidrBlock");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("newCidrBlock")
+        private String newCidrBlock;
+
+        public Builder newCidrBlock(String newCidrBlock) {
+            this.newCidrBlock = newCidrBlock;
+            this.__explicitlySet__.add("newCidrBlock");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ModifyVcnCidrDetails build() {
+            ModifyVcnCidrDetails __instance__ =
+                    new ModifyVcnCidrDetails(originalCidrBlock, newCidrBlock);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ModifyVcnCidrDetails o) {
+            Builder copiedBuilder =
+                    originalCidrBlock(o.getOriginalCidrBlock()).newCidrBlock(o.getNewCidrBlock());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The CIDR IP address that needs to be updated.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("originalCidrBlock")
+    String originalCidrBlock;
+
+    /**
+     * The new CIDR IP address which will replace the orginal one.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("newCidrBlock")
+    String newCidrBlock;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RemoveVcnCidrDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RemoveVcnCidrDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains the CIDR which will be removed from the VCN.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RemoveVcnCidrDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RemoveVcnCidrDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+        private String cidrBlock;
+
+        public Builder cidrBlock(String cidrBlock) {
+            this.cidrBlock = cidrBlock;
+            this.__explicitlySet__.add("cidrBlock");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RemoveVcnCidrDetails build() {
+            RemoveVcnCidrDetails __instance__ = new RemoveVcnCidrDetails(cidrBlock);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RemoveVcnCidrDetails o) {
+            Builder copiedBuilder = cidrBlock(o.getCidrBlock());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The CIDR IP address that needs to be removed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+    String cidrBlock;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
@@ -419,6 +419,7 @@ public class Subnet {
         Available("AVAILABLE"),
         Terminating("TERMINATING"),
         Terminated("TERMINATED"),
+        Updating("UPDATING"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSubnetDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSubnetDetails.java
@@ -81,6 +81,15 @@ public class UpdateSubnetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+        private String cidrBlock;
+
+        public Builder cidrBlock(String cidrBlock) {
+            this.cidrBlock = cidrBlock;
+            this.__explicitlySet__.add("cidrBlock");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -92,7 +101,8 @@ public class UpdateSubnetDetails {
                             displayName,
                             freeformTags,
                             routeTableId,
-                            securityListIds);
+                            securityListIds,
+                            cidrBlock);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -105,7 +115,8 @@ public class UpdateSubnetDetails {
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .routeTableId(o.getRouteTableId())
-                            .securityListIds(o.getSecurityListIds());
+                            .securityListIds(o.getSecurityListIds())
+                            .cidrBlock(o.getCidrBlock());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -170,6 +181,21 @@ public class UpdateSubnetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("securityListIds")
     java.util.List<String> securityListIds;
+
+    /**
+     * The CIDR IP address block of the Subnet. The CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR block is valid and correctly formatted.
+     * b. The new range is within one of the parent VCN ranges.
+     * c. The old and new CIDR ranges both use the same base address. Example: 10.0.0.0/25 and 10.0.0.0/24.
+     * d. The new CIDR range contains all previously allocated private IP addresses in the old CIDR range.
+     * e. No previously allocated IP address overlaps the broadcast address (the last IP of a subnet CIDR range) of the new CIDR range.
+     * <p>
+     * Example: `172.16.0.0/16`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+    String cidrBlock;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVlanDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVlanDetails.java
@@ -72,13 +72,27 @@ public class UpdateVlanDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+        private String cidrBlock;
+
+        public Builder cidrBlock(String cidrBlock) {
+            this.cidrBlock = cidrBlock;
+            this.__explicitlySet__.add("cidrBlock");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateVlanDetails build() {
             UpdateVlanDetails __instance__ =
                     new UpdateVlanDetails(
-                            definedTags, displayName, freeformTags, nsgIds, routeTableId);
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            nsgIds,
+                            routeTableId,
+                            cidrBlock);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +104,8 @@ public class UpdateVlanDetails {
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .nsgIds(o.getNsgIds())
-                            .routeTableId(o.getRouteTableId());
+                            .routeTableId(o.getRouteTableId())
+                            .cidrBlock(o.getCidrBlock());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -148,6 +163,19 @@ public class UpdateVlanDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
     String routeTableId;
+
+    /**
+     * The CIDR IP address block of the Vlan. The CIDR must maintain the following rules -
+     * <p>
+     * a. The CIDR block is valid and correctly formatted.
+     * b. The new range is within one of the parent VCN ranges.
+     * c. The old and new CIDR ranges both use the same base address. Example: 10.0.0.0/25 and 10.0.0.0/24.
+     * d. The new CIDR range contains all previously allocated private IP addresses in the old CIDR range.
+     * e. No previously allocated IP address overlaps the broadcast address (the last IP of a subnet CIDR range) of the new CIDR range.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
+    String cidrBlock;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
@@ -42,6 +42,15 @@ public class Vcn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cidrBlocks")
+        private java.util.List<String> cidrBlocks;
+
+        public Builder cidrBlocks(java.util.List<String> cidrBlocks) {
+            this.cidrBlocks = cidrBlocks;
+            this.__explicitlySet__.add("cidrBlocks");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -176,6 +185,7 @@ public class Vcn {
             Vcn __instance__ =
                     new Vcn(
                             cidrBlock,
+                            cidrBlocks,
                             compartmentId,
                             defaultDhcpOptionsId,
                             defaultRouteTableId,
@@ -198,6 +208,7 @@ public class Vcn {
         public Builder copy(Vcn o) {
             Builder copiedBuilder =
                     cidrBlock(o.getCidrBlock())
+                            .cidrBlocks(o.getCidrBlocks())
                             .compartmentId(o.getCompartmentId())
                             .defaultDhcpOptionsId(o.getDefaultDhcpOptionsId())
                             .defaultRouteTableId(o.getDefaultRouteTableId())
@@ -226,13 +237,20 @@ public class Vcn {
     }
 
     /**
-     * The CIDR IP address block of the VCN.
+     * Deprecated. The first CIDR IP address from cidrBlocks.
      * <p>
      * Example: `172.16.0.0/16`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cidrBlock")
     String cidrBlock;
+
+    /**
+     * The list of IPv4 CIDR blocks the VCN will use.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cidrBlocks")
+    java.util.List<String> cidrBlocks;
 
     /**
      * The OCID of the compartment containing the VCN.
@@ -347,6 +365,7 @@ public class Vcn {
         Available("AVAILABLE"),
         Terminating("TERMINATING"),
         Terminated("TERMINATED"),
+        Updating("UPDATING"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDnsResolverAssociation.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDnsResolverAssociation.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The information about the VCN and the DNS resolver in the association.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VcnDnsResolverAssociation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VcnDnsResolverAssociation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+        private String vcnId;
+
+        public Builder vcnId(String vcnId) {
+            this.vcnId = vcnId;
+            this.__explicitlySet__.add("vcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dnsResolverId")
+        private String dnsResolverId;
+
+        public Builder dnsResolverId(String dnsResolverId) {
+            this.dnsResolverId = dnsResolverId;
+            this.__explicitlySet__.add("dnsResolverId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VcnDnsResolverAssociation build() {
+            VcnDnsResolverAssociation __instance__ =
+                    new VcnDnsResolverAssociation(vcnId, dnsResolverId, lifecycleState);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VcnDnsResolverAssociation o) {
+            Builder copiedBuilder =
+                    vcnId(o.getVcnId())
+                            .dnsResolverId(o.getDnsResolverId())
+                            .lifecycleState(o.getLifecycleState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the VCN in the association.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
+    String vcnId;
+
+    /**
+     * The OCID of the DNS resolver in the association.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dnsResolverId")
+    String dnsResolverId;
+    /**
+     * The current state of the association.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the association.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddVcnCidrRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AddVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<AddVcnCidrDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * Details object for deleting a VCN CIDR.
+     */
+    private AddVcnCidrDetails addVcnCidrDetails;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public AddVcnCidrDetails getBody$() {
+        return addVcnCidrDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AddVcnCidrRequest, AddVcnCidrDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddVcnCidrRequest o) {
+            vcnId(o.getVcnId());
+            addVcnCidrDetails(o.getAddVcnCidrDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AddVcnCidrRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AddVcnCidrRequest
+         */
+        public AddVcnCidrRequest build() {
+            AddVcnCidrRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(AddVcnCidrDetails body) {
+            addVcnCidrDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnDnsResolverAssociationRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnDnsResolverAssociationRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetVcnDnsResolverAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetVcnDnsResolverAssociationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVcnDnsResolverAssociationRequest o) {
+            vcnId(o.getVcnId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVcnDnsResolverAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVcnDnsResolverAssociationRequest
+         */
+        public GetVcnDnsResolverAssociationRequest build() {
+            GetVcnDnsResolverAssociationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ModifyVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ModifyVcnCidrRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ModifyVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<ModifyVcnCidrDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * Details object for updating a VCN CIDR.
+     */
+    private ModifyVcnCidrDetails modifyVcnCidrDetails;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ModifyVcnCidrDetails getBody$() {
+        return modifyVcnCidrDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ModifyVcnCidrRequest, ModifyVcnCidrDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ModifyVcnCidrRequest o) {
+            vcnId(o.getVcnId());
+            modifyVcnCidrDetails(o.getModifyVcnCidrDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ModifyVcnCidrRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ModifyVcnCidrRequest
+         */
+        public ModifyVcnCidrRequest build() {
+            ModifyVcnCidrRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ModifyVcnCidrDetails body) {
+            modifyVcnCidrDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveVcnCidrRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class RemoveVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<RemoveVcnCidrDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
+
+    /**
+     * Details object for removing a VCN CIDR.
+     */
+    private RemoveVcnCidrDetails removeVcnCidrDetails;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public RemoveVcnCidrDetails getBody$() {
+        return removeVcnCidrDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveVcnCidrRequest, RemoveVcnCidrDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveVcnCidrRequest o) {
+            vcnId(o.getVcnId());
+            removeVcnCidrDetails(o.getRemoveVcnCidrDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveVcnCidrRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveVcnCidrRequest
+         */
+        public RemoveVcnCidrRequest build() {
+            RemoveVcnCidrRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(RemoveVcnCidrDetails body) {
+            removeVcnCidrDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/AddVcnCidrResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/AddVcnCidrResponse.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AddVcnCidrResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddVcnCidrResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetVcnDnsResolverAssociationResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetVcnDnsResolverAssociationResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetVcnDnsResolverAssociationResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VcnDnsResolverAssociation instance.
+     */
+    private VcnDnsResolverAssociation vcnDnsResolverAssociation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVcnDnsResolverAssociationResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vcnDnsResolverAssociation(o.getVcnDnsResolverAssociation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ModifyVcnCidrResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ModifyVcnCidrResponse.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ModifyVcnCidrResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ModifyVcnCidrResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/RemoveVcnCidrResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/RemoveVcnCidrResponse.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class RemoveVcnCidrResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveVcnCidrResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -309,6 +309,15 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -562,6 +571,7 @@ public class AutonomousDatabase {
                             dbVersion,
                             isPreview,
                             dbWorkload,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isAutoScalingEnabled,
                             dataSafeStatus,
@@ -626,6 +636,7 @@ public class AutonomousDatabase {
                             .dbVersion(o.getDbVersion())
                             .isPreview(o.getIsPreview())
                             .dbWorkload(o.getDbWorkload())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .dataSafeStatus(o.getDataSafeStatus())
@@ -1084,12 +1095,29 @@ public class AutonomousDatabase {
     DbWorkload dbWorkload;
 
     /**
-     * The client IP access control list (ACL). This feature is available for databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) only.
-     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Indicates if the database-level access control is enabled.
+     * If disabled, database access is defined by the network security rules.
+     * If enabled, database access is restricted to the IP addresses defined by the rules specified with the `whitelistedIps` property. While specifying `whitelistedIps` rules is optional,
+     *  if database-level access control is enabled and no rules are specified, the database will become inaccessible. The rules can be added later using the `UpdateAutonomousDatabase` API operation or edit option in console.
+     * When creating a database clone, the desired access control setting should be specified. By default, database-level access control will be disabled for the clone.
      * <p>
-     * To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+     * This property is applicable only to Autonomous Databases on the Exadata Cloud@Customer platform.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+    Boolean isAccessControlEnabled;
+
+    /**
+     * The client IP access control list (ACL). This feature is available for autonomous databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) and on Exadata Cloud@Customer.
+     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance.
+     * <p>
+     * For shared Exadata infrastructure, this is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Use a semicolon (;) as a deliminator between the VCN-specific subnets or IPs.
      * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
+     * For Exadata Cloud@Customer, this is an array of IP addresses or CIDR (Classless Inter-Domain Routing) notations.
+     * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"1.1.2.25\"]`
+     * <p>
+     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -311,6 +311,15 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -564,6 +573,7 @@ public class AutonomousDatabaseSummary {
                             dbVersion,
                             isPreview,
                             dbWorkload,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isAutoScalingEnabled,
                             dataSafeStatus,
@@ -628,6 +638,7 @@ public class AutonomousDatabaseSummary {
                             .dbVersion(o.getDbVersion())
                             .isPreview(o.getIsPreview())
                             .dbWorkload(o.getDbWorkload())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .dataSafeStatus(o.getDataSafeStatus())
@@ -1086,12 +1097,29 @@ public class AutonomousDatabaseSummary {
     DbWorkload dbWorkload;
 
     /**
-     * The client IP access control list (ACL). This feature is available for databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) only.
-     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Indicates if the database-level access control is enabled.
+     * If disabled, database access is defined by the network security rules.
+     * If enabled, database access is restricted to the IP addresses defined by the rules specified with the `whitelistedIps` property. While specifying `whitelistedIps` rules is optional,
+     *  if database-level access control is enabled and no rules are specified, the database will become inaccessible. The rules can be added later using the `UpdateAutonomousDatabase` API operation or edit option in console.
+     * When creating a database clone, the desired access control setting should be specified. By default, database-level access control will be disabled for the clone.
      * <p>
-     * To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+     * This property is applicable only to Autonomous Databases on the Exadata Cloud@Customer platform.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+    Boolean isAccessControlEnabled;
+
+    /**
+     * The client IP access control list (ACL). This feature is available for autonomous databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) and on Exadata Cloud@Customer.
+     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance.
+     * <p>
+     * For shared Exadata infrastructure, this is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Use a semicolon (;) as a deliminator between the VCN-specific subnets or IPs.
      * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
+     * For Exadata Cloud@Customer, this is an array of IP addresses or CIDR (Classless Inter-Domain Routing) notations.
+     * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"1.1.2.25\"]`
+     * <p>
+     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbVersionSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDbVersionSummary.java
@@ -72,13 +72,47 @@ public class AutonomousDbVersionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isPaidEnabled")
+        private Boolean isPaidEnabled;
+
+        public Builder isPaidEnabled(Boolean isPaidEnabled) {
+            this.isPaidEnabled = isPaidEnabled;
+            this.__explicitlySet__.add("isPaidEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefaultForFree")
+        private Boolean isDefaultForFree;
+
+        public Builder isDefaultForFree(Boolean isDefaultForFree) {
+            this.isDefaultForFree = isDefaultForFree;
+            this.__explicitlySet__.add("isDefaultForFree");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefaultForPaid")
+        private Boolean isDefaultForPaid;
+
+        public Builder isDefaultForPaid(Boolean isDefaultForPaid) {
+            this.isDefaultForPaid = isDefaultForPaid;
+            this.__explicitlySet__.add("isDefaultForPaid");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AutonomousDbVersionSummary build() {
             AutonomousDbVersionSummary __instance__ =
                     new AutonomousDbVersionSummary(
-                            version, dbWorkload, isDedicated, details, isFreeTierEnabled);
+                            version,
+                            dbWorkload,
+                            isDedicated,
+                            details,
+                            isFreeTierEnabled,
+                            isPaidEnabled,
+                            isDefaultForFree,
+                            isDefaultForPaid);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +124,10 @@ public class AutonomousDbVersionSummary {
                             .dbWorkload(o.getDbWorkload())
                             .isDedicated(o.getIsDedicated())
                             .details(o.getDetails())
-                            .isFreeTierEnabled(o.getIsFreeTierEnabled());
+                            .isFreeTierEnabled(o.getIsFreeTierEnabled())
+                            .isPaidEnabled(o.getIsPaidEnabled())
+                            .isDefaultForFree(o.getIsDefaultForFree())
+                            .isDefaultForPaid(o.getIsDefaultForPaid());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -190,6 +227,24 @@ public class AutonomousDbVersionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isFreeTierEnabled")
     Boolean isFreeTierEnabled;
+
+    /**
+     * True if this version of the Oracle Database software has payments enabled.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPaidEnabled")
+    Boolean isPaidEnabled;
+
+    /**
+     * True if this version of the Oracle Database software's default is free.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefaultForFree")
+    Boolean isDefaultForFree;
+
+    /**
+     * True if this version of the Oracle Database software's default is paid.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefaultForPaid")
+    Boolean isDefaultForPaid;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -222,12 +222,29 @@ public class CreateAutonomousDatabaseBase {
     String autonomousContainerDatabaseId;
 
     /**
-     * The client IP access control list (ACL). This feature is available for databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) only.
-     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Indicates if the database-level access control is enabled.
+     * If disabled, database access is defined by the network security rules.
+     * If enabled, database access is restricted to the IP addresses defined by the rules specified with the `whitelistedIps` property. While specifying `whitelistedIps` rules is optional,
+     *  if database-level access control is enabled and no rules are specified, the database will become inaccessible. The rules can be added later using the `UpdateAutonomousDatabase` API operation or edit option in console.
+     * When creating a database clone, the desired access control setting should be specified. By default, database-level access control will be disabled for the clone.
      * <p>
-     * To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+     * This property is applicable only to Autonomous Databases on the Exadata Cloud@Customer platform.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+    Boolean isAccessControlEnabled;
+
+    /**
+     * The client IP access control list (ACL). This feature is available for autonomous databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) and on Exadata Cloud@Customer.
+     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance.
+     * <p>
+     * For shared Exadata infrastructure, this is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Use a semicolon (;) as a deliminator between the VCN-specific subnets or IPs.
      * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
+     * For Exadata Cloud@Customer, this is an array of IP addresses or CIDR (Classless Inter-Domain Routing) notations.
+     * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"1.1.2.25\"]`
+     * <p>
+     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -152,6 +152,15 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -262,6 +271,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             isAutoScalingEnabled,
                             isDedicated,
                             autonomousContainerDatabaseId,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isDataGuardEnabled,
                             subnetId,
@@ -293,6 +303,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isDedicated(o.getIsDedicated())
                             .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .subnetId(o.getSubnetId())
@@ -331,6 +342,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             Boolean isAutoScalingEnabled,
             Boolean isDedicated,
             String autonomousContainerDatabaseId,
+            Boolean isAccessControlEnabled,
             java.util.List<String> whitelistedIps,
             Boolean isDataGuardEnabled,
             String subnetId,
@@ -355,6 +367,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                 isAutoScalingEnabled,
                 isDedicated,
                 autonomousContainerDatabaseId,
+                isAccessControlEnabled,
                 whitelistedIps,
                 isDataGuardEnabled,
                 subnetId,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
@@ -152,6 +152,15 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -244,6 +253,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             isAutoScalingEnabled,
                             isDedicated,
                             autonomousContainerDatabaseId,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isDataGuardEnabled,
                             subnetId,
@@ -273,6 +283,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isDedicated(o.getIsDedicated())
                             .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .subnetId(o.getSubnetId())
@@ -309,6 +320,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             Boolean isAutoScalingEnabled,
             Boolean isDedicated,
             String autonomousContainerDatabaseId,
+            Boolean isAccessControlEnabled,
             java.util.List<String> whitelistedIps,
             Boolean isDataGuardEnabled,
             String subnetId,
@@ -331,6 +343,7 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 isAutoScalingEnabled,
                 isDedicated,
                 autonomousContainerDatabaseId,
+                isAccessControlEnabled,
                 whitelistedIps,
                 isDataGuardEnabled,
                 subnetId,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
@@ -152,6 +152,15 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -262,6 +271,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             isAutoScalingEnabled,
                             isDedicated,
                             autonomousContainerDatabaseId,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isDataGuardEnabled,
                             subnetId,
@@ -293,6 +303,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isDedicated(o.getIsDedicated())
                             .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .subnetId(o.getSubnetId())
@@ -331,6 +342,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             Boolean isAutoScalingEnabled,
             Boolean isDedicated,
             String autonomousContainerDatabaseId,
+            Boolean isAccessControlEnabled,
             java.util.List<String> whitelistedIps,
             Boolean isDataGuardEnabled,
             String subnetId,
@@ -355,6 +367,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                 isAutoScalingEnabled,
                 isDedicated,
                 autonomousContainerDatabaseId,
+                isAccessControlEnabled,
                 whitelistedIps,
                 isDataGuardEnabled,
                 subnetId,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
@@ -153,6 +153,15 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -272,6 +281,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             isAutoScalingEnabled,
                             isDedicated,
                             autonomousContainerDatabaseId,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isDataGuardEnabled,
                             subnetId,
@@ -304,6 +314,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isDedicated(o.getIsDedicated())
                             .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .subnetId(o.getSubnetId())
@@ -343,6 +354,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             Boolean isAutoScalingEnabled,
             Boolean isDedicated,
             String autonomousContainerDatabaseId,
+            Boolean isAccessControlEnabled,
             java.util.List<String> whitelistedIps,
             Boolean isDataGuardEnabled,
             String subnetId,
@@ -368,6 +380,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                 isAutoScalingEnabled,
                 isDedicated,
                 autonomousContainerDatabaseId,
+                isAccessControlEnabled,
                 whitelistedIps,
                 isDataGuardEnabled,
                 subnetId,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
@@ -48,6 +48,12 @@ package com.oracle.bmc.database.model;
 public class CreateDataGuardAssociationDetails {
 
     /**
+     * The database software image [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+    String databaseSoftwareImageId;
+
+    /**
      * A strong password for the `SYS`, `SYSTEM`, and `PDB Admin` users to apply during standby creation.
      * <p>
      * The password must contain no fewer than nine characters and include:

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
@@ -36,6 +36,15 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+        private String databaseSoftwareImageId;
+
+        public Builder databaseSoftwareImageId(String databaseSoftwareImageId) {
+            this.databaseSoftwareImageId = databaseSoftwareImageId;
+            this.__explicitlySet__.add("databaseSoftwareImageId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseAdminPassword")
         private String databaseAdminPassword;
 
@@ -87,6 +96,7 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
         public CreateDataGuardAssociationToExistingDbSystemDetails build() {
             CreateDataGuardAssociationToExistingDbSystemDetails __instance__ =
                     new CreateDataGuardAssociationToExistingDbSystemDetails(
+                            databaseSoftwareImageId,
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
@@ -99,7 +109,8 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDataGuardAssociationToExistingDbSystemDetails o) {
             Builder copiedBuilder =
-                    databaseAdminPassword(o.getDatabaseAdminPassword())
+                    databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
+                            .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
                             .peerDbSystemId(o.getPeerDbSystemId())
@@ -119,12 +130,13 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
 
     @Deprecated
     public CreateDataGuardAssociationToExistingDbSystemDetails(
+            String databaseSoftwareImageId,
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
             String peerDbSystemId,
             String peerDbHomeId) {
-        super(databaseAdminPassword, protectionMode, transportType);
+        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
         this.peerDbSystemId = peerDbSystemId;
         this.peerDbHomeId = peerDbHomeId;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
@@ -34,6 +34,15 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+        private String databaseSoftwareImageId;
+
+        public Builder databaseSoftwareImageId(String databaseSoftwareImageId) {
+            this.databaseSoftwareImageId = databaseSoftwareImageId;
+            this.__explicitlySet__.add("databaseSoftwareImageId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseAdminPassword")
         private String databaseAdminPassword;
 
@@ -85,6 +94,7 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
         public CreateDataGuardAssociationToExistingVmClusterDetails build() {
             CreateDataGuardAssociationToExistingVmClusterDetails __instance__ =
                     new CreateDataGuardAssociationToExistingVmClusterDetails(
+                            databaseSoftwareImageId,
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
@@ -97,7 +107,8 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDataGuardAssociationToExistingVmClusterDetails o) {
             Builder copiedBuilder =
-                    databaseAdminPassword(o.getDatabaseAdminPassword())
+                    databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
+                            .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
                             .peerVmClusterId(o.getPeerVmClusterId())
@@ -117,12 +128,13 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
 
     @Deprecated
     public CreateDataGuardAssociationToExistingVmClusterDetails(
+            String databaseSoftwareImageId,
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
             String peerVmClusterId,
             String peerDbHomeId) {
-        super(databaseAdminPassword, protectionMode, transportType);
+        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
         this.peerVmClusterId = peerVmClusterId;
         this.peerDbHomeId = peerDbHomeId;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
@@ -36,6 +36,15 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+        private String databaseSoftwareImageId;
+
+        public Builder databaseSoftwareImageId(String databaseSoftwareImageId) {
+            this.databaseSoftwareImageId = databaseSoftwareImageId;
+            this.__explicitlySet__.add("databaseSoftwareImageId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseAdminPassword")
         private String databaseAdminPassword;
 
@@ -132,6 +141,7 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
         public CreateDataGuardAssociationWithNewDbSystemDetails build() {
             CreateDataGuardAssociationWithNewDbSystemDetails __instance__ =
                     new CreateDataGuardAssociationWithNewDbSystemDetails(
+                            databaseSoftwareImageId,
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
@@ -149,7 +159,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDataGuardAssociationWithNewDbSystemDetails o) {
             Builder copiedBuilder =
-                    databaseAdminPassword(o.getDatabaseAdminPassword())
+                    databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
+                            .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
                             .displayName(o.getDisplayName())
@@ -174,6 +185,7 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
 
     @Deprecated
     public CreateDataGuardAssociationWithNewDbSystemDetails(
+            String databaseSoftwareImageId,
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
@@ -184,7 +196,7 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             java.util.List<String> nsgIds,
             java.util.List<String> backupNetworkNsgIds,
             String hostname) {
-        super(databaseAdminPassword, protectionMode, transportType);
+        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
         this.displayName = displayName;
         this.availabilityDomain = availabilityDomain;
         this.shape = shape;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
@@ -74,6 +74,15 @@ public class CreateDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("tdeWalletPassword")
+        private String tdeWalletPassword;
+
+        public Builder tdeWalletPassword(String tdeWalletPassword) {
+            this.tdeWalletPassword = tdeWalletPassword;
+            this.__explicitlySet__.add("tdeWalletPassword");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("characterSet")
         private String characterSet;
 
@@ -140,6 +149,7 @@ public class CreateDatabaseDetails {
                             databaseSoftwareImageId,
                             pdbName,
                             adminPassword,
+                            tdeWalletPassword,
                             characterSet,
                             ncharacterSet,
                             dbWorkload,
@@ -158,6 +168,7 @@ public class CreateDatabaseDetails {
                             .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
                             .pdbName(o.getPdbName())
                             .adminPassword(o.getAdminPassword())
+                            .tdeWalletPassword(o.getTdeWalletPassword())
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbWorkload(o.getDbWorkload())
@@ -206,6 +217,12 @@ public class CreateDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
     String adminPassword;
+
+    /**
+     * The optional password to open the TDE wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tdeWalletPassword")
+    String tdeWalletPassword;
 
     /**
      * The character set for the database.  The default is AL32UTF8. Allowed values are:

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
@@ -152,6 +152,15 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -262,6 +271,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             isAutoScalingEnabled,
                             isDedicated,
                             autonomousContainerDatabaseId,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isDataGuardEnabled,
                             subnetId,
@@ -293,6 +303,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isDedicated(o.getIsDedicated())
                             .autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isDataGuardEnabled(o.getIsDataGuardEnabled())
                             .subnetId(o.getSubnetId())
@@ -331,6 +342,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             Boolean isAutoScalingEnabled,
             Boolean isDedicated,
             String autonomousContainerDatabaseId,
+            Boolean isAccessControlEnabled,
             java.util.List<String> whitelistedIps,
             Boolean isDataGuardEnabled,
             String subnetId,
@@ -355,6 +367,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                 isAutoScalingEnabled,
                 isDedicated,
                 autonomousContainerDatabaseId,
+                isAccessControlEnabled,
                 whitelistedIps,
                 isDataGuardEnabled,
                 subnetId,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -120,6 +120,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+        private Boolean isAccessControlEnabled;
+
+        public Builder isAccessControlEnabled(Boolean isAccessControlEnabled) {
+            this.isAccessControlEnabled = isAccessControlEnabled;
+            this.__explicitlySet__.add("isAccessControlEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")
         private java.util.List<String> whitelistedIps;
 
@@ -235,6 +244,7 @@ public class UpdateAutonomousDatabaseDetails {
                             definedTags,
                             dbWorkload,
                             licenseModel,
+                            isAccessControlEnabled,
                             whitelistedIps,
                             isAutoScalingEnabled,
                             isRefreshableClone,
@@ -263,6 +273,7 @@ public class UpdateAutonomousDatabaseDetails {
                             .definedTags(o.getDefinedTags())
                             .dbWorkload(o.getDbWorkload())
                             .licenseModel(o.getLicenseModel())
+                            .isAccessControlEnabled(o.getIsAccessControlEnabled())
                             .whitelistedIps(o.getWhitelistedIps())
                             .isAutoScalingEnabled(o.getIsAutoScalingEnabled())
                             .isRefreshableClone(o.getIsRefreshableClone())
@@ -444,12 +455,29 @@ public class UpdateAutonomousDatabaseDetails {
     LicenseModel licenseModel;
 
     /**
-     * The client IP access control list (ACL). This feature is available for databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) only.
-     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance. This is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Indicates if the database-level access control is enabled.
+     * If disabled, database access is defined by the network security rules.
+     * If enabled, database access is restricted to the IP addresses defined by the rules specified with the `whitelistedIps` property. While specifying `whitelistedIps` rules is optional,
+     *  if database-level access control is enabled and no rules are specified, the database will become inaccessible. The rules can be added later using the `UpdateAutonomousDatabase` API operation or edit option in console.
+     * When creating a database clone, the desired access control setting should be specified. By default, database-level access control will be disabled for the clone.
      * <p>
-     * To add the whitelist VCN specific subnet or IP, use a semicoln ';' as a deliminator to add the VCN specific subnets or IPs.
-     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
+     * This property is applicable only to Autonomous Databases on the Exadata Cloud@Customer platform.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAccessControlEnabled")
+    Boolean isAccessControlEnabled;
+
+    /**
+     * The client IP access control list (ACL). This feature is available for autonomous databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI) and on Exadata Cloud@Customer.
+     * Only clients connecting from an IP address included in the ACL may access the Autonomous Database instance.
+     * <p>
+     * For shared Exadata infrastructure, this is an array of CIDR (Classless Inter-Domain Routing) notations for a subnet or VCN OCID.
+     * Use a semicolon (;) as a deliminator between the VCN-specific subnets or IPs.
      * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"ocid1.vcn.oc1.sea.<unique_id>\",\"ocid1.vcn.oc1.sea.<unique_id1>;1.1.1.1\",\"ocid1.vcn.oc1.sea.<unique_id2>;1.1.0.0/16\"]`
+     * For Exadata Cloud@Customer, this is an array of IP addresses or CIDR (Classless Inter-Domain Routing) notations.
+     * Example: `[\"1.1.1.1\",\"1.1.1.0/24\",\"1.1.2.25\"]`
+     * <p>
+     * For an update operation, if you want to delete all the IPs in the ACL, use an array with a single empty string entry.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("whitelistedIps")

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDatabaseDetails.java
@@ -47,6 +47,33 @@ public class UpdateDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("newAdminPassword")
+        private String newAdminPassword;
+
+        public Builder newAdminPassword(String newAdminPassword) {
+            this.newAdminPassword = newAdminPassword;
+            this.__explicitlySet__.add("newAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("oldTdeWalletPassword")
+        private String oldTdeWalletPassword;
+
+        public Builder oldTdeWalletPassword(String oldTdeWalletPassword) {
+            this.oldTdeWalletPassword = oldTdeWalletPassword;
+            this.__explicitlySet__.add("oldTdeWalletPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("newTdeWalletPassword")
+        private String newTdeWalletPassword;
+
+        public Builder newTdeWalletPassword(String newTdeWalletPassword) {
+            this.newTdeWalletPassword = newTdeWalletPassword;
+            this.__explicitlySet__.add("newTdeWalletPassword");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -71,7 +98,14 @@ public class UpdateDatabaseDetails {
 
         public UpdateDatabaseDetails build() {
             UpdateDatabaseDetails __instance__ =
-                    new UpdateDatabaseDetails(dbBackupConfig, dbHomeId, freeformTags, definedTags);
+                    new UpdateDatabaseDetails(
+                            dbBackupConfig,
+                            dbHomeId,
+                            newAdminPassword,
+                            oldTdeWalletPassword,
+                            newTdeWalletPassword,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -81,6 +115,9 @@ public class UpdateDatabaseDetails {
             Builder copiedBuilder =
                     dbBackupConfig(o.getDbBackupConfig())
                             .dbHomeId(o.getDbHomeId())
+                            .newAdminPassword(o.getNewAdminPassword())
+                            .oldTdeWalletPassword(o.getOldTdeWalletPassword())
+                            .newTdeWalletPassword(o.getNewTdeWalletPassword())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -104,6 +141,24 @@ public class UpdateDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbHomeId")
     String dbHomeId;
+
+    /**
+     * A new strong password for SYS, SYSTEM, and the plugbable database ADMIN user. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("newAdminPassword")
+    String newAdminPassword;
+
+    /**
+     * The existing password to open the TDE wallet. It is required to set a new tde password.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oldTdeWalletPassword")
+    String oldTdeWalletPassword;
+
+    /**
+     * The new password to open the TDE wallet. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("newTdeWalletPassword")
+    String newTdeWalletPassword;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/Dns.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/Dns.java
@@ -48,6 +48,17 @@ public interface Dns extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves a resolver into a different compartment along with its protected default view and any endpoints.
+     * Zones in the default view are not moved.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeResolverCompartmentResponse changeResolverCompartment(
+            ChangeResolverCompartmentRequest request);
+
+    /**
      * Moves a steering policy into a different compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -66,13 +77,33 @@ public interface Dns extends AutoCloseable {
             ChangeTsigKeyCompartmentRequest request);
 
     /**
-     * Moves a zone into a different compartment.
-     * **Note:** All SteeringPolicyAttachment objects associated with this zone will also be moved into the provided compartment.
+     * Moves a view into a different compartment. Protected views cannot have their compartment changed.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeViewCompartmentResponse changeViewCompartment(ChangeViewCompartmentRequest request);
+
+    /**
+     * Moves a zone into a different compartment. Protected zones cannot have their compartment changed.
+     * <p>
+     **Note:** All SteeringPolicyAttachment objects associated with this zone will also be moved into the provided compartment.
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
      */
     ChangeZoneCompartmentResponse changeZoneCompartment(ChangeZoneCompartmentRequest request);
+
+    /**
+     * Creates a new resolver endpoint.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateResolverEndpointResponse createResolverEndpoint(CreateResolverEndpointRequest request);
 
     /**
      * Creates a new steering policy in the specified compartment. For more information on
@@ -110,9 +141,18 @@ public interface Dns extends AutoCloseable {
     CreateTsigKeyResponse createTsigKey(CreateTsigKeyRequest request);
 
     /**
-     * Creates a new zone in the specified compartment. The `compartmentId`
-     * query parameter is required if the `Content-Type` header for the
-     * request is `text/dns`.
+     * Creates a new view in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateViewResponse createView(CreateViewRequest request);
+
+    /**
+     * Creates a new zone in the specified compartment. If the `Content-Type` header for the request is `text/dns`, the
+     * `compartmentId` query parameter is required. Additionally, for `text/dns`, the `scope` and `viewId` query
+     * parameters are required to create a private zone.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -136,6 +176,17 @@ public interface Dns extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     DeleteRRSetResponse deleteRRSet(DeleteRRSetRequest request);
+
+    /**
+     * Deletes the specified resolver endpoint. Note that attempting to delete a resolver endpoint in the
+     * DELETED lifecycle state will result in a 404 to be consistent with other operations of the API.
+     * Resolver endpoints may not be deleted if they are referenced by a resolver rule.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteResolverEndpointResponse deleteResolverEndpoint(DeleteResolverEndpointRequest request);
 
     /**
      * Deletes the specified steering policy.
@@ -170,8 +221,22 @@ public interface Dns extends AutoCloseable {
     DeleteTsigKeyResponse deleteTsigKey(DeleteTsigKeyRequest request);
 
     /**
+     * Deletes the specified view. Note that attempting to delete a
+     * view in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API. Views can not be
+     * deleted if they are referenced by non-deleted zones or resolvers.
+     * Protected views cannot be deleted.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteViewResponse deleteView(DeleteViewRequest request);
+
+    /**
      * Deletes the specified zone and all its steering policy attachments.
-     * A `204` response indicates that zone has been successfully deleted.
+     * A `204` response indicates that the zone has been successfully deleted.
+     * Protected zones cannot be deleted.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -199,6 +264,27 @@ public interface Dns extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetRRSetResponse getRRSet(GetRRSetRequest request);
+
+    /**
+     * Get information about a specific resolver. Note that attempting to get a
+     * resolver in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetResolverResponse getResolver(GetResolverRequest request);
+
+    /**
+     * Get information about a specific resolver endpoint. Note that attempting to get a resolver endpoint
+     * in the DELETED lifecycle state will result in a 404 to be consistent with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetResolverEndpointResponse getResolverEndpoint(GetResolverEndpointRequest request);
 
     /**
      * Gets information about the specified steering policy.
@@ -229,6 +315,17 @@ public interface Dns extends AutoCloseable {
     GetTsigKeyResponse getTsigKey(GetTsigKeyRequest request);
 
     /**
+     * Get information about a specific view. Note that attempting to get a
+     * view in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetViewResponse getView(GetViewRequest request);
+
+    /**
      * Gets information about the specified zone, including its creation date,
      * zone type, and serial.
      *
@@ -248,6 +345,32 @@ public interface Dns extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     GetZoneRecordsResponse getZoneRecords(GetZoneRecordsRequest request);
+
+    /**
+     * Gets a list of all endpoints within a resolver. The collection can be filtered by name or lifecycle state.
+     * It can be sorted on creation time or name both in ASC or DESC order. Note that when no lifecycleState
+     * query parameter is provided that the collection does not include resolver endpoints in the DELETED
+     * lifecycle state to be consistent with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListResolverEndpointsResponse listResolverEndpoints(ListResolverEndpointsRequest request);
+
+    /**
+     * Gets a list of all resolvers within a compartment. The collection can
+     * be filtered by display name, id, or lifecycle state. It can be sorted
+     * on creation time or displayName both in ASC or DESC order. Note that
+     * when no lifecycleState query parameter is provided that the collection
+     * does not include resolvers in the DELETED lifecycleState to be consistent
+     * with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListResolversResponse listResolvers(ListResolversRequest request);
 
     /**
      * Gets a list of all steering policies in the specified compartment.
@@ -278,8 +401,22 @@ public interface Dns extends AutoCloseable {
     ListTsigKeysResponse listTsigKeys(ListTsigKeysRequest request);
 
     /**
+     * Gets a list of all views within a compartment. The collection can
+     * be filtered by display name, id, or lifecycle state. It can be sorted
+     * on creation time or displayName both in ASC or DESC order. Note that
+     * when no lifecycleState query parameter is provided that the collection
+     * does not include views in the DELETED lifecycleState to be consistent
+     * with other operations of the API.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListViewsResponse listViews(ListViewsRequest request);
+
+    /**
      * Gets a list of all zones in the specified compartment. The collection
-     * can be filtered by name, time created, and zone type.
+     * can be filtered by name, time created, scope, associated view, and zone type.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -342,6 +479,24 @@ public interface Dns extends AutoCloseable {
     UpdateRRSetResponse updateRRSet(UpdateRRSetRequest request);
 
     /**
+     * Updates the specified resolver with your new information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateResolverResponse updateResolver(UpdateResolverRequest request);
+
+    /**
+     * Updates the specified resolver endpoint with your new information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateResolverEndpointResponse updateResolverEndpoint(UpdateResolverEndpointRequest request);
+
+    /**
      * Updates the configuration of the specified steering policy.
      *
      * @param request The request object containing the details to send
@@ -368,6 +523,15 @@ public interface Dns extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     UpdateTsigKeyResponse updateTsigKey(UpdateTsigKeyRequest request);
+
+    /**
+     * Updates the specified view with your new information.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateViewResponse updateView(UpdateViewRequest request);
 
     /**
      * Updates the specified secondary zone with your new external master

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsAsync.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsAsync.java
@@ -48,6 +48,24 @@ public interface DnsAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves a resolver into a different compartment along with its protected default view and any endpoints.
+     * Zones in the default view are not moved.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeResolverCompartmentResponse> changeResolverCompartment(
+            ChangeResolverCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeResolverCompartmentRequest, ChangeResolverCompartmentResponse>
+                    handler);
+
+    /**
      * Moves a steering policy into a different compartment.
      *
      * @param request The request object containing the details to send
@@ -82,8 +100,27 @@ public interface DnsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Moves a zone into a different compartment.
-     * **Note:** All SteeringPolicyAttachment objects associated with this zone will also be moved into the provided compartment.
+     * Moves a view into a different compartment. Protected views cannot have their compartment changed.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeViewCompartmentResponse> changeViewCompartment(
+            ChangeViewCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeViewCompartmentRequest, ChangeViewCompartmentResponse>
+                    handler);
+
+    /**
+     * Moves a zone into a different compartment. Protected zones cannot have their compartment changed.
+     * <p>
+     **Note:** All SteeringPolicyAttachment objects associated with this zone will also be moved into the provided compartment.
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -96,6 +133,23 @@ public interface DnsAsync extends AutoCloseable {
             ChangeZoneCompartmentRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ChangeZoneCompartmentRequest, ChangeZoneCompartmentResponse>
+                    handler);
+
+    /**
+     * Creates a new resolver endpoint.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateResolverEndpointResponse> createResolverEndpoint(
+            CreateResolverEndpointRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateResolverEndpointRequest, CreateResolverEndpointResponse>
                     handler);
 
     /**
@@ -158,9 +212,24 @@ public interface DnsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a new zone in the specified compartment. The `compartmentId`
-     * query parameter is required if the `Content-Type` header for the
-     * request is `text/dns`.
+     * Creates a new view in the specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateViewResponse> createView(
+            CreateViewRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateViewRequest, CreateViewResponse> handler);
+
+    /**
+     * Creates a new zone in the specified compartment. If the `Content-Type` header for the request is `text/dns`, the
+     * `compartmentId` query parameter is required. Additionally, for `text/dns`, the `scope` and `viewId` query
+     * parameters are required to create a private zone.
      *
      *
      * @param request The request object containing the details to send
@@ -204,6 +273,25 @@ public interface DnsAsync extends AutoCloseable {
     java.util.concurrent.Future<DeleteRRSetResponse> deleteRRSet(
             DeleteRRSetRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeleteRRSetRequest, DeleteRRSetResponse> handler);
+
+    /**
+     * Deletes the specified resolver endpoint. Note that attempting to delete a resolver endpoint in the
+     * DELETED lifecycle state will result in a 404 to be consistent with other operations of the API.
+     * Resolver endpoints may not be deleted if they are referenced by a resolver rule.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteResolverEndpointResponse> deleteResolverEndpoint(
+            DeleteResolverEndpointRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteResolverEndpointRequest, DeleteResolverEndpointResponse>
+                    handler);
 
     /**
      * Deletes the specified steering policy.
@@ -262,8 +350,28 @@ public interface DnsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deletes the specified view. Note that attempting to delete a
+     * view in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API. Views can not be
+     * deleted if they are referenced by non-deleted zones or resolvers.
+     * Protected views cannot be deleted.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteViewResponse> deleteView(
+            DeleteViewRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteViewRequest, DeleteViewResponse> handler);
+
+    /**
      * Deletes the specified zone and all its steering policy attachments.
-     * A `204` response indicates that zone has been successfully deleted.
+     * A `204` response indicates that the zone has been successfully deleted.
+     * Protected zones cannot be deleted.
      *
      *
      * @param request The request object containing the details to send
@@ -310,6 +418,41 @@ public interface DnsAsync extends AutoCloseable {
     java.util.concurrent.Future<GetRRSetResponse> getRRSet(
             GetRRSetRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetRRSetRequest, GetRRSetResponse> handler);
+
+    /**
+     * Get information about a specific resolver. Note that attempting to get a
+     * resolver in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetResolverResponse> getResolver(
+            GetResolverRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetResolverRequest, GetResolverResponse> handler);
+
+    /**
+     * Get information about a specific resolver endpoint. Note that attempting to get a resolver endpoint
+     * in the DELETED lifecycle state will result in a 404 to be consistent with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetResolverEndpointResponse> getResolverEndpoint(
+            GetResolverEndpointRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetResolverEndpointRequest, GetResolverEndpointResponse>
+                    handler);
 
     /**
      * Gets information about the specified steering policy.
@@ -361,6 +504,23 @@ public interface DnsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetTsigKeyRequest, GetTsigKeyResponse> handler);
 
     /**
+     * Get information about a specific view. Note that attempting to get a
+     * view in the DELETED lifecycleState will result in a 404 to be
+     * consistent with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetViewResponse> getView(
+            GetViewRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetViewRequest, GetViewResponse> handler);
+
+    /**
      * Gets information about the specified zone, including its creation date,
      * zone type, and serial.
      *
@@ -392,6 +552,47 @@ public interface DnsAsync extends AutoCloseable {
     java.util.concurrent.Future<GetZoneRecordsResponse> getZoneRecords(
             GetZoneRecordsRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetZoneRecordsRequest, GetZoneRecordsResponse>
+                    handler);
+
+    /**
+     * Gets a list of all endpoints within a resolver. The collection can be filtered by name or lifecycle state.
+     * It can be sorted on creation time or name both in ASC or DESC order. Note that when no lifecycleState
+     * query parameter is provided that the collection does not include resolver endpoints in the DELETED
+     * lifecycle state to be consistent with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListResolverEndpointsResponse> listResolverEndpoints(
+            ListResolverEndpointsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListResolverEndpointsRequest, ListResolverEndpointsResponse>
+                    handler);
+
+    /**
+     * Gets a list of all resolvers within a compartment. The collection can
+     * be filtered by display name, id, or lifecycle state. It can be sorted
+     * on creation time or displayName both in ASC or DESC order. Note that
+     * when no lifecycleState query parameter is provided that the collection
+     * does not include resolvers in the DELETED lifecycleState to be consistent
+     * with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListResolversResponse> listResolvers(
+            ListResolversRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListResolversRequest, ListResolversResponse>
                     handler);
 
     /**
@@ -447,8 +648,28 @@ public interface DnsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets a list of all views within a compartment. The collection can
+     * be filtered by display name, id, or lifecycle state. It can be sorted
+     * on creation time or displayName both in ASC or DESC order. Note that
+     * when no lifecycleState query parameter is provided that the collection
+     * does not include views in the DELETED lifecycleState to be consistent
+     * with other operations of the API.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListViewsResponse> listViews(
+            ListViewsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListViewsRequest, ListViewsResponse> handler);
+
+    /**
      * Gets a list of all zones in the specified compartment. The collection
-     * can be filtered by name, time created, and zone type.
+     * can be filtered by name, time created, scope, associated view, and zone type.
      *
      *
      * @param request The request object containing the details to send
@@ -552,6 +773,39 @@ public interface DnsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateRRSetRequest, UpdateRRSetResponse> handler);
 
     /**
+     * Updates the specified resolver with your new information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateResolverResponse> updateResolver(
+            UpdateResolverRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateResolverRequest, UpdateResolverResponse>
+                    handler);
+
+    /**
+     * Updates the specified resolver endpoint with your new information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateResolverEndpointResponse> updateResolverEndpoint(
+            UpdateResolverEndpointRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateResolverEndpointRequest, UpdateResolverEndpointResponse>
+                    handler);
+
+    /**
      * Updates the configuration of the specified steering policy.
      *
      *
@@ -602,6 +856,21 @@ public interface DnsAsync extends AutoCloseable {
             UpdateTsigKeyRequest request,
             com.oracle.bmc.responses.AsyncHandler<UpdateTsigKeyRequest, UpdateTsigKeyResponse>
                     handler);
+
+    /**
+     * Updates the specified view with your new information.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateViewResponse> updateView(
+            UpdateViewRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateViewRequest, UpdateViewResponse> handler);
 
     /**
      * Updates the specified secondary zone with your new external master

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsAsyncClient.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsAsyncClient.java
@@ -325,6 +325,49 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeResolverCompartmentResponse> changeResolverCompartment(
+            ChangeResolverCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeResolverCompartmentRequest, ChangeResolverCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeResolverCompartment");
+        final ChangeResolverCompartmentRequest interceptedRequest =
+                ChangeResolverCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeResolverCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeResolverCompartmentResponse>
+                transformer = ChangeResolverCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeResolverCompartmentRequest, ChangeResolverCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeResolverCompartmentRequest,
+                                ChangeResolverCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeResolverCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeResolverCompartmentRequest, ChangeResolverCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeSteeringPolicyCompartmentResponse>
             changeSteeringPolicyCompartment(
                     ChangeSteeringPolicyCompartmentRequest request,
@@ -414,6 +457,48 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeViewCompartmentResponse> changeViewCompartment(
+            ChangeViewCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeViewCompartmentRequest, ChangeViewCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeViewCompartment");
+        final ChangeViewCompartmentRequest interceptedRequest =
+                ChangeViewCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeViewCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeViewCompartmentResponse>
+                transformer = ChangeViewCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeViewCompartmentRequest, ChangeViewCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeViewCompartmentRequest, ChangeViewCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeViewCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeViewCompartmentRequest, ChangeViewCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeZoneCompartmentResponse> changeZoneCompartment(
             ChangeZoneCompartmentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -443,6 +528,48 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ChangeZoneCompartmentRequest, ChangeZoneCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateResolverEndpointResponse> createResolverEndpoint(
+            CreateResolverEndpointRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateResolverEndpointRequest, CreateResolverEndpointResponse>
+                    handler) {
+        LOG.trace("Called async createResolverEndpoint");
+        final CreateResolverEndpointRequest interceptedRequest =
+                CreateResolverEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateResolverEndpointResponse>
+                transformer = CreateResolverEndpointConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateResolverEndpointRequest, CreateResolverEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateResolverEndpointRequest, CreateResolverEndpointResponse>,
+                        java.util.concurrent.Future<CreateResolverEndpointResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateResolverEndpointRequest, CreateResolverEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -582,6 +709,44 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateViewResponse> createView(
+            CreateViewRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateViewRequest, CreateViewResponse>
+                    handler) {
+        LOG.trace("Called async createView");
+        final CreateViewRequest interceptedRequest = CreateViewConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateViewConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateViewResponse>
+                transformer = CreateViewConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateViewRequest, CreateViewResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateViewRequest, CreateViewResponse>,
+                        java.util.concurrent.Future<CreateViewResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateViewRequest, CreateViewResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateZoneResponse> createZone(
             CreateZoneRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateZoneRequest, CreateZoneResponse>
@@ -685,6 +850,47 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteRRSetRequest, DeleteRRSetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteResolverEndpointResponse> deleteResolverEndpoint(
+            DeleteResolverEndpointRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteResolverEndpointRequest, DeleteResolverEndpointResponse>
+                    handler) {
+        LOG.trace("Called async deleteResolverEndpoint");
+        final DeleteResolverEndpointRequest interceptedRequest =
+                DeleteResolverEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteResolverEndpointResponse>
+                transformer = DeleteResolverEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteResolverEndpointRequest, DeleteResolverEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteResolverEndpointRequest, DeleteResolverEndpointResponse>,
+                        java.util.concurrent.Future<DeleteResolverEndpointResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteResolverEndpointRequest, DeleteResolverEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -822,6 +1028,43 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteViewResponse> deleteView(
+            DeleteViewRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteViewRequest, DeleteViewResponse>
+                    handler) {
+        LOG.trace("Called async deleteView");
+        final DeleteViewRequest interceptedRequest = DeleteViewConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteViewConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteViewResponse>
+                transformer = DeleteViewConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteViewRequest, DeleteViewResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteViewRequest, DeleteViewResponse>,
+                        java.util.concurrent.Future<DeleteViewResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteViewRequest, DeleteViewResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteZoneResponse> deleteZone(
             DeleteZoneRequest request,
             final com.oracle.bmc.responses.AsyncHandler<DeleteZoneRequest, DeleteZoneResponse>
@@ -921,6 +1164,85 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetRRSetRequest, GetRRSetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetResolverResponse> getResolver(
+            GetResolverRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetResolverRequest, GetResolverResponse>
+                    handler) {
+        LOG.trace("Called async getResolver");
+        final GetResolverRequest interceptedRequest =
+                GetResolverConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetResolverConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetResolverResponse>
+                transformer = GetResolverConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetResolverRequest, GetResolverResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetResolverRequest, GetResolverResponse>,
+                        java.util.concurrent.Future<GetResolverResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetResolverRequest, GetResolverResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetResolverEndpointResponse> getResolverEndpoint(
+            GetResolverEndpointRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetResolverEndpointRequest, GetResolverEndpointResponse>
+                    handler) {
+        LOG.trace("Called async getResolverEndpoint");
+        final GetResolverEndpointRequest interceptedRequest =
+                GetResolverEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetResolverEndpointResponse>
+                transformer = GetResolverEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetResolverEndpointRequest, GetResolverEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetResolverEndpointRequest, GetResolverEndpointResponse>,
+                        java.util.concurrent.Future<GetResolverEndpointResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetResolverEndpointRequest, GetResolverEndpointResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1054,6 +1376,41 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetViewResponse> getView(
+            GetViewRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetViewRequest, GetViewResponse> handler) {
+        LOG.trace("Called async getView");
+        final GetViewRequest interceptedRequest = GetViewConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetViewConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetViewResponse>
+                transformer = GetViewConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetViewRequest, GetViewResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<GetViewRequest, GetViewResponse>,
+                        java.util.concurrent.Future<GetViewResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetViewRequest, GetViewResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetZoneResponse> getZone(
             GetZoneRequest request,
             final com.oracle.bmc.responses.AsyncHandler<GetZoneRequest, GetZoneResponse> handler) {
@@ -1115,6 +1472,85 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetZoneRecordsRequest, GetZoneRecordsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListResolverEndpointsResponse> listResolverEndpoints(
+            ListResolverEndpointsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListResolverEndpointsRequest, ListResolverEndpointsResponse>
+                    handler) {
+        LOG.trace("Called async listResolverEndpoints");
+        final ListResolverEndpointsRequest interceptedRequest =
+                ListResolverEndpointsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListResolverEndpointsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListResolverEndpointsResponse>
+                transformer = ListResolverEndpointsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListResolverEndpointsRequest, ListResolverEndpointsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListResolverEndpointsRequest, ListResolverEndpointsResponse>,
+                        java.util.concurrent.Future<ListResolverEndpointsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListResolverEndpointsRequest, ListResolverEndpointsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListResolversResponse> listResolvers(
+            ListResolversRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListResolversRequest, ListResolversResponse>
+                    handler) {
+        LOG.trace("Called async listResolvers");
+        final ListResolversRequest interceptedRequest =
+                ListResolversConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListResolversConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListResolversResponse>
+                transformer = ListResolversConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListResolversRequest, ListResolversResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListResolversRequest, ListResolversResponse>,
+                        java.util.concurrent.Future<ListResolversResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListResolversRequest, ListResolversResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1238,6 +1674,42 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListTsigKeysRequest, ListTsigKeysResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListViewsResponse> listViews(
+            ListViewsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListViewsRequest, ListViewsResponse>
+                    handler) {
+        LOG.trace("Called async listViews");
+        final ListViewsRequest interceptedRequest = ListViewsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListViewsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListViewsResponse>
+                transformer = ListViewsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListViewsRequest, ListViewsResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<ListViewsRequest, ListViewsResponse>,
+                        java.util.concurrent.Future<ListViewsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListViewsRequest, ListViewsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1481,6 +1953,86 @@ public class DnsAsyncClient implements DnsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<UpdateResolverResponse> updateResolver(
+            UpdateResolverRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateResolverRequest, UpdateResolverResponse>
+                    handler) {
+        LOG.trace("Called async updateResolver");
+        final UpdateResolverRequest interceptedRequest =
+                UpdateResolverConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateResolverConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateResolverResponse>
+                transformer = UpdateResolverConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateResolverRequest, UpdateResolverResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateResolverRequest, UpdateResolverResponse>,
+                        java.util.concurrent.Future<UpdateResolverResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateResolverRequest, UpdateResolverResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateResolverEndpointResponse> updateResolverEndpoint(
+            UpdateResolverEndpointRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateResolverEndpointRequest, UpdateResolverEndpointResponse>
+                    handler) {
+        LOG.trace("Called async updateResolverEndpoint");
+        final UpdateResolverEndpointRequest interceptedRequest =
+                UpdateResolverEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateResolverEndpointResponse>
+                transformer = UpdateResolverEndpointConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateResolverEndpointRequest, UpdateResolverEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateResolverEndpointRequest, UpdateResolverEndpointResponse>,
+                        java.util.concurrent.Future<UpdateResolverEndpointResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateResolverEndpointRequest, UpdateResolverEndpointResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateSteeringPolicyResponse> updateSteeringPolicy(
             UpdateSteeringPolicyRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1592,6 +2144,43 @@ public class DnsAsyncClient implements DnsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateTsigKeyRequest, UpdateTsigKeyResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateViewResponse> updateView(
+            UpdateViewRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateViewRequest, UpdateViewResponse>
+                    handler) {
+        LOG.trace("Called async updateView");
+        final UpdateViewRequest interceptedRequest = UpdateViewConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateViewConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateViewResponse>
+                transformer = UpdateViewConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateViewRequest, UpdateViewResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateViewRequest, UpdateViewResponse>,
+                        java.util.concurrent.Future<UpdateViewResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateViewRequest, UpdateViewResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsClient.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsClient.java
@@ -441,6 +441,42 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public ChangeResolverCompartmentResponse changeResolverCompartment(
+            ChangeResolverCompartmentRequest request) {
+        LOG.trace("Called changeResolverCompartment");
+        final ChangeResolverCompartmentRequest interceptedRequest =
+                ChangeResolverCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeResolverCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeResolverCompartmentResponse>
+                transformer = ChangeResolverCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeResolverCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeSteeringPolicyCompartmentResponse changeSteeringPolicyCompartment(
             ChangeSteeringPolicyCompartmentRequest request) {
         LOG.trace("Called changeSteeringPolicyCompartment");
@@ -511,6 +547,40 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public ChangeViewCompartmentResponse changeViewCompartment(
+            ChangeViewCompartmentRequest request) {
+        LOG.trace("Called changeViewCompartment");
+        final ChangeViewCompartmentRequest interceptedRequest =
+                ChangeViewCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeViewCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ChangeViewCompartmentResponse>
+                transformer = ChangeViewCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeViewCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeZoneCompartmentResponse changeZoneCompartment(
             ChangeZoneCompartmentRequest request) {
         LOG.trace("Called changeZoneCompartment");
@@ -538,6 +608,40 @@ public class DnsClient implements Dns {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getChangeZoneCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateResolverEndpointResponse createResolverEndpoint(
+            CreateResolverEndpointRequest request) {
+        LOG.trace("Called createResolverEndpoint");
+        final CreateResolverEndpointRequest interceptedRequest =
+                CreateResolverEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateResolverEndpointResponse>
+                transformer = CreateResolverEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateResolverEndpointDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -646,6 +750,38 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public CreateViewResponse createView(CreateViewRequest request) {
+        LOG.trace("Called createView");
+        final CreateViewRequest interceptedRequest = CreateViewConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateViewConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateViewResponse> transformer =
+                CreateViewConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateViewDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateZoneResponse createZone(CreateZoneRequest request) {
         LOG.trace("Called createZone");
         final CreateZoneRequest interceptedRequest = CreateZoneConverter.interceptRequest(request);
@@ -714,6 +850,36 @@ public class DnsClient implements Dns {
                 DeleteRRSetConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteRRSetResponse>
                 transformer = DeleteRRSetConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteResolverEndpointResponse deleteResolverEndpoint(
+            DeleteResolverEndpointRequest request) {
+        LOG.trace("Called deleteResolverEndpoint");
+        final DeleteResolverEndpointRequest interceptedRequest =
+                DeleteResolverEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteResolverEndpointResponse>
+                transformer = DeleteResolverEndpointConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -824,6 +990,34 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public DeleteViewResponse deleteView(DeleteViewRequest request) {
+        LOG.trace("Called deleteView");
+        final DeleteViewRequest interceptedRequest = DeleteViewConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteViewConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteViewResponse> transformer =
+                DeleteViewConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteZoneResponse deleteZone(DeleteZoneRequest request) {
         LOG.trace("Called deleteZone");
         final DeleteZoneRequest interceptedRequest = DeleteZoneConverter.interceptRequest(request);
@@ -887,6 +1081,62 @@ public class DnsClient implements Dns {
                 GetRRSetConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetRRSetResponse> transformer =
                 GetRRSetConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetResolverResponse getResolver(GetResolverRequest request) {
+        LOG.trace("Called getResolver");
+        final GetResolverRequest interceptedRequest =
+                GetResolverConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetResolverConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetResolverResponse>
+                transformer = GetResolverConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetResolverEndpointResponse getResolverEndpoint(GetResolverEndpointRequest request) {
+        LOG.trace("Called getResolverEndpoint");
+        final GetResolverEndpointRequest interceptedRequest =
+                GetResolverEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetResolverEndpointResponse>
+                transformer = GetResolverEndpointConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -992,6 +1242,33 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public GetViewResponse getView(GetViewRequest request) {
+        LOG.trace("Called getView");
+        final GetViewRequest interceptedRequest = GetViewConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetViewConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetViewResponse> transformer =
+                GetViewConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetZoneResponse getZone(GetZoneRequest request) {
         LOG.trace("Called getZone");
         final GetZoneRequest interceptedRequest = GetZoneConverter.interceptRequest(request);
@@ -1027,6 +1304,63 @@ public class DnsClient implements Dns {
                 GetZoneRecordsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetZoneRecordsResponse>
                 transformer = GetZoneRecordsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListResolverEndpointsResponse listResolverEndpoints(
+            ListResolverEndpointsRequest request) {
+        LOG.trace("Called listResolverEndpoints");
+        final ListResolverEndpointsRequest interceptedRequest =
+                ListResolverEndpointsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListResolverEndpointsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListResolverEndpointsResponse>
+                transformer = ListResolverEndpointsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListResolversResponse listResolvers(ListResolversRequest request) {
+        LOG.trace("Called listResolvers");
+        final ListResolversRequest interceptedRequest =
+                ListResolversConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListResolversConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListResolversResponse>
+                transformer = ListResolversConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1113,6 +1447,33 @@ public class DnsClient implements Dns {
                 ListTsigKeysConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListTsigKeysResponse>
                 transformer = ListTsigKeysConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListViewsResponse listViews(ListViewsRequest request) {
+        LOG.trace("Called listViews");
+        final ListViewsRequest interceptedRequest = ListViewsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListViewsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListViewsResponse> transformer =
+                ListViewsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1319,6 +1680,71 @@ public class DnsClient implements Dns {
     }
 
     @Override
+    public UpdateResolverResponse updateResolver(UpdateResolverRequest request) {
+        LOG.trace("Called updateResolver");
+        final UpdateResolverRequest interceptedRequest =
+                UpdateResolverConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateResolverConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateResolverResponse>
+                transformer = UpdateResolverConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateResolverDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateResolverEndpointResponse updateResolverEndpoint(
+            UpdateResolverEndpointRequest request) {
+        LOG.trace("Called updateResolverEndpoint");
+        final UpdateResolverEndpointRequest interceptedRequest =
+                UpdateResolverEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateResolverEndpointConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateResolverEndpointResponse>
+                transformer = UpdateResolverEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateResolverEndpointDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateSteeringPolicyResponse updateSteeringPolicy(UpdateSteeringPolicyRequest request) {
         LOG.trace("Called updateSteeringPolicy");
         final UpdateSteeringPolicyRequest interceptedRequest =
@@ -1411,6 +1837,37 @@ public class DnsClient implements Dns {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateTsigKeyDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateViewResponse updateView(UpdateViewRequest request) {
+        LOG.trace("Called updateView");
+        final UpdateViewRequest interceptedRequest = UpdateViewConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateViewConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateViewResponse> transformer =
+                UpdateViewConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateViewDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsPaginators.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsPaginators.java
@@ -362,6 +362,231 @@ public class DnsPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listResolverEndpoints operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListResolverEndpointsResponse> listResolverEndpointsResponseIterator(
+            final ListResolverEndpointsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListResolverEndpointsRequest.Builder, ListResolverEndpointsRequest,
+                ListResolverEndpointsResponse>(
+                new com.google.common.base.Supplier<ListResolverEndpointsRequest.Builder>() {
+                    @Override
+                    public ListResolverEndpointsRequest.Builder get() {
+                        return ListResolverEndpointsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListResolverEndpointsResponse, String>() {
+                    @Override
+                    public String apply(ListResolverEndpointsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListResolverEndpointsRequest.Builder>,
+                        ListResolverEndpointsRequest>() {
+                    @Override
+                    public ListResolverEndpointsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListResolverEndpointsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListResolverEndpointsRequest, ListResolverEndpointsResponse>() {
+                    @Override
+                    public ListResolverEndpointsResponse apply(
+                            ListResolverEndpointsRequest request) {
+                        return client.listResolverEndpoints(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.dns.model.ResolverEndpointSummary} objects
+     * contained in responses from the listResolverEndpoints operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.dns.model.ResolverEndpointSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.dns.model.ResolverEndpointSummary>
+            listResolverEndpointsRecordIterator(final ListResolverEndpointsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListResolverEndpointsRequest.Builder, ListResolverEndpointsRequest,
+                ListResolverEndpointsResponse, com.oracle.bmc.dns.model.ResolverEndpointSummary>(
+                new com.google.common.base.Supplier<ListResolverEndpointsRequest.Builder>() {
+                    @Override
+                    public ListResolverEndpointsRequest.Builder get() {
+                        return ListResolverEndpointsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListResolverEndpointsResponse, String>() {
+                    @Override
+                    public String apply(ListResolverEndpointsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListResolverEndpointsRequest.Builder>,
+                        ListResolverEndpointsRequest>() {
+                    @Override
+                    public ListResolverEndpointsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListResolverEndpointsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListResolverEndpointsRequest, ListResolverEndpointsResponse>() {
+                    @Override
+                    public ListResolverEndpointsResponse apply(
+                            ListResolverEndpointsRequest request) {
+                        return client.listResolverEndpoints(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListResolverEndpointsResponse,
+                        java.util.List<com.oracle.bmc.dns.model.ResolverEndpointSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.dns.model.ResolverEndpointSummary> apply(
+                            ListResolverEndpointsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listResolvers operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListResolversResponse> listResolversResponseIterator(
+            final ListResolversRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListResolversRequest.Builder, ListResolversRequest, ListResolversResponse>(
+                new com.google.common.base.Supplier<ListResolversRequest.Builder>() {
+                    @Override
+                    public ListResolversRequest.Builder get() {
+                        return ListResolversRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListResolversResponse, String>() {
+                    @Override
+                    public String apply(ListResolversResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListResolversRequest.Builder>,
+                        ListResolversRequest>() {
+                    @Override
+                    public ListResolversRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListResolversRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListResolversRequest, ListResolversResponse>() {
+                    @Override
+                    public ListResolversResponse apply(ListResolversRequest request) {
+                        return client.listResolvers(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.dns.model.ResolverSummary} objects
+     * contained in responses from the listResolvers operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.dns.model.ResolverSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.dns.model.ResolverSummary> listResolversRecordIterator(
+            final ListResolversRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListResolversRequest.Builder, ListResolversRequest, ListResolversResponse,
+                com.oracle.bmc.dns.model.ResolverSummary>(
+                new com.google.common.base.Supplier<ListResolversRequest.Builder>() {
+                    @Override
+                    public ListResolversRequest.Builder get() {
+                        return ListResolversRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListResolversResponse, String>() {
+                    @Override
+                    public String apply(ListResolversResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListResolversRequest.Builder>,
+                        ListResolversRequest>() {
+                    @Override
+                    public ListResolversRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListResolversRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListResolversRequest, ListResolversResponse>() {
+                    @Override
+                    public ListResolversResponse apply(ListResolversRequest request) {
+                        return client.listResolvers(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListResolversResponse,
+                        java.util.List<com.oracle.bmc.dns.model.ResolverSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.dns.model.ResolverSummary> apply(
+                            ListResolversResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listSteeringPolicies operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -704,6 +929,114 @@ public class DnsPaginators {
                     @Override
                     public java.util.List<com.oracle.bmc.dns.model.TsigKeySummary> apply(
                             ListTsigKeysResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listViews operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListViewsResponse> listViewsResponseIterator(final ListViewsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListViewsRequest.Builder, ListViewsRequest, ListViewsResponse>(
+                new com.google.common.base.Supplier<ListViewsRequest.Builder>() {
+                    @Override
+                    public ListViewsRequest.Builder get() {
+                        return ListViewsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListViewsResponse, String>() {
+                    @Override
+                    public String apply(ListViewsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListViewsRequest.Builder>,
+                        ListViewsRequest>() {
+                    @Override
+                    public ListViewsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListViewsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListViewsRequest, ListViewsResponse>() {
+                    @Override
+                    public ListViewsResponse apply(ListViewsRequest request) {
+                        return client.listViews(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.dns.model.ViewSummary} objects
+     * contained in responses from the listViews operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.dns.model.ViewSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.dns.model.ViewSummary> listViewsRecordIterator(
+            final ListViewsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListViewsRequest.Builder, ListViewsRequest, ListViewsResponse,
+                com.oracle.bmc.dns.model.ViewSummary>(
+                new com.google.common.base.Supplier<ListViewsRequest.Builder>() {
+                    @Override
+                    public ListViewsRequest.Builder get() {
+                        return ListViewsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListViewsResponse, String>() {
+                    @Override
+                    public String apply(ListViewsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListViewsRequest.Builder>,
+                        ListViewsRequest>() {
+                    @Override
+                    public ListViewsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListViewsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListViewsRequest, ListViewsResponse>() {
+                    @Override
+                    public ListViewsResponse apply(ListViewsRequest request) {
+                        return client.listViews(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListViewsResponse, java.util.List<com.oracle.bmc.dns.model.ViewSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.dns.model.ViewSummary> apply(
+                            ListViewsResponse response) {
                         return response.getItems();
                     }
                 });

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsWaiters.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/DnsWaiters.java
@@ -26,6 +26,206 @@ public class DnsWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetResolverRequest, GetResolverResponse> forResolver(
+            GetResolverRequest request,
+            com.oracle.bmc.dns.model.Resolver.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forResolver(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetResolverRequest, GetResolverResponse> forResolver(
+            GetResolverRequest request,
+            com.oracle.bmc.dns.model.Resolver.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forResolver(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetResolverRequest, GetResolverResponse> forResolver(
+            GetResolverRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.dns.model.Resolver.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forResolver(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Resolver.
+    private com.oracle.bmc.waiter.Waiter<GetResolverRequest, GetResolverResponse> forResolver(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetResolverRequest request,
+            final com.oracle.bmc.dns.model.Resolver.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.dns.model.Resolver.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetResolverRequest, GetResolverResponse>() {
+                            @Override
+                            public GetResolverResponse apply(GetResolverRequest request) {
+                                return client.getResolver(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetResolverResponse>() {
+                            @Override
+                            public boolean apply(GetResolverResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getResolver().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dns.model.Resolver.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetResolverEndpointRequest, GetResolverEndpointResponse>
+            forResolverEndpoint(
+                    GetResolverEndpointRequest request,
+                    com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forResolverEndpoint(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetResolverEndpointRequest, GetResolverEndpointResponse>
+            forResolverEndpoint(
+                    GetResolverEndpointRequest request,
+                    com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forResolverEndpoint(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetResolverEndpointRequest, GetResolverEndpointResponse>
+            forResolverEndpoint(
+                    GetResolverEndpointRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forResolverEndpoint(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for ResolverEndpoint.
+    private com.oracle.bmc.waiter.Waiter<GetResolverEndpointRequest, GetResolverEndpointResponse>
+            forResolverEndpoint(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetResolverEndpointRequest request,
+                    final com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetResolverEndpointRequest, GetResolverEndpointResponse>() {
+                            @Override
+                            public GetResolverEndpointResponse apply(
+                                    GetResolverEndpointRequest request) {
+                                return client.getResolverEndpoint(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetResolverEndpointResponse>() {
+                            @Override
+                            public boolean apply(GetResolverEndpointResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getResolverEndpoint().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dns.model.ResolverEndpoint.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetSteeringPolicyRequest, GetSteeringPolicyResponse>
             forSteeringPolicy(
                     GetSteeringPolicyRequest request,
@@ -324,6 +524,100 @@ public class DnsWaiters {
                             }
                         },
                         false),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetViewRequest, GetViewResponse> forView(
+            GetViewRequest request, com.oracle.bmc.dns.model.View.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forView(com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetViewRequest, GetViewResponse> forView(
+            GetViewRequest request,
+            com.oracle.bmc.dns.model.View.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forView(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetViewRequest, GetViewResponse> forView(
+            GetViewRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.dns.model.View.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forView(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for View.
+    private com.oracle.bmc.waiter.Waiter<GetViewRequest, GetViewResponse> forView(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetViewRequest request,
+            final com.oracle.bmc.dns.model.View.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.dns.model.View.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<GetViewRequest, GetViewResponse>() {
+                            @Override
+                            public GetViewResponse apply(GetViewRequest request) {
+                                return client.getView(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetViewResponse>() {
+                            @Override
+                            public boolean apply(GetViewResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getView().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.dns.model.View.LifecycleState.Deleted)),
                 request);
     }
 

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeResolverCompartmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeResolverCompartmentConverter.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class ChangeResolverCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.ChangeResolverCompartmentRequest interceptRequest(
+            com.oracle.bmc.dns.requests.ChangeResolverCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.ChangeResolverCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notNull(
+                request.getChangeResolverCompartmentDetails(),
+                "changeResolverCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .ChangeResolverCompartmentResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.ChangeResolverCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeSteeringPolicyCompartmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeSteeringPolicyCompartmentConverter.java
@@ -43,6 +43,14 @@ public class ChangeSteeringPolicyCompartmentConverter {
                         .path("actions")
                         .path("changeCompartment");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeTsigKeyCompartmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeTsigKeyCompartmentConverter.java
@@ -42,6 +42,14 @@ public class ChangeTsigKeyCompartmentConverter {
                         .path("actions")
                         .path("changeCompartment");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeViewCompartmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeViewCompartmentConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class ChangeViewCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.ChangeViewCompartmentRequest interceptRequest(
+            com.oracle.bmc.dns.requests.ChangeViewCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.ChangeViewCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getViewId(), "viewId must not be blank");
+        Validate.notNull(
+                request.getChangeViewCompartmentDetails(),
+                "changeViewCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("views")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getViewId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .ChangeViewCompartmentResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.ChangeViewCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeZoneCompartmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ChangeZoneCompartmentConverter.java
@@ -42,6 +42,14 @@ public class ChangeZoneCompartmentConverter {
                         .path("actions")
                         .path("changeCompartment");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -101,6 +109,18 @@ public class ChangeZoneCompartmentConverter {
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
                                                     String.class));
                                 }
 

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateResolverEndpointConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateResolverEndpointConverter.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class CreateResolverEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.CreateResolverEndpointRequest interceptRequest(
+            com.oracle.bmc.dns.requests.CreateResolverEndpointRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.CreateResolverEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notNull(
+                request.getCreateResolverEndpointDetails(),
+                "createResolverEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("endpoints");
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.CreateResolverEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.CreateResolverEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.CreateResolverEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.CreateResolverEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.CreateResolverEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ResolverEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ResolverEndpoint.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ResolverEndpoint>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.CreateResolverEndpointResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .CreateResolverEndpointResponse.builder();
+
+                                builder.resolverEndpoint(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.CreateResolverEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateSteeringPolicyAttachmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateSteeringPolicyAttachmentConverter.java
@@ -35,6 +35,14 @@ public class CreateSteeringPolicyAttachmentConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20180115").path("steeringPolicyAttachments");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -90,6 +98,27 @@ public class CreateSteeringPolicyAttachmentConverter {
 
                                 builder.steeringPolicyAttachment(response.getItem());
 
+                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "ETag");
+                                if (eTagHeader.isPresent()) {
+                                    builder.eTag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(
@@ -100,15 +129,6 @@ public class CreateSteeringPolicyAttachmentConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "ETag");
-                                if (eTagHeader.isPresent()) {
-                                    builder.eTag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "ETag", eTagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.dns.responses.CreateSteeringPolicyAttachmentResponse

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateSteeringPolicyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateSteeringPolicyConverter.java
@@ -34,6 +34,14 @@ public class CreateSteeringPolicyConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20180115").path("steeringPolicies");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -85,6 +93,27 @@ public class CreateSteeringPolicyConverter {
 
                                 builder.steeringPolicy(response.getItem());
 
+                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "ETag");
+                                if (eTagHeader.isPresent()) {
+                                    builder.eTag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(
@@ -95,15 +124,6 @@ public class CreateSteeringPolicyConverter {
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
                                                     String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "ETag");
-                                if (eTagHeader.isPresent()) {
-                                    builder.eTag(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "ETag", eTagHeader.get().get(0), String.class));
                                 }
 
                                 com.oracle.bmc.dns.responses.CreateSteeringPolicyResponse

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateTsigKeyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateTsigKeyConverter.java
@@ -32,6 +32,14 @@ public class CreateTsigKeyConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20180115").path("tsigKeys");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -85,6 +93,18 @@ public class CreateTsigKeyConverter {
                                 }
 
                                 com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
                                         opcRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(
                                                         headers, "opc-request-id");
@@ -93,6 +113,18 @@ public class CreateTsigKeyConverter {
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
                                                     String.class));
                                 }
 

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateViewConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateViewConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class CreateViewConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.CreateViewRequest interceptRequest(
+            com.oracle.bmc.dns.requests.CreateViewRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.CreateViewRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateViewDetails(), "createViewDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20180115").path("views");
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.CreateViewResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.CreateViewResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.CreateViewResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.CreateViewResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.CreateViewResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<View>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(View.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<View> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.CreateViewResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.CreateViewResponse.builder();
+
+                                builder.view(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.CreateViewResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateZoneConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/CreateZoneConverter.java
@@ -40,6 +40,22 @@ public class CreateZoneConverter {
                                     request.getCompartmentId()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
@@ -80,6 +96,27 @@ public class CreateZoneConverter {
 
                                 builder.zone(response.getItem());
 
+                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "ETag");
+                                if (eTagHeader.isPresent()) {
+                                    builder.eTag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "Location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "Location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(
@@ -92,13 +129,16 @@ public class CreateZoneConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "ETag");
-                                if (eTagHeader.isPresent()) {
-                                    builder.eTag(
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
                                 }
 
                                 com.oracle.bmc.dns.responses.CreateZoneResponse responseWrapper =

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteDomainRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteDomainRecordsConverter.java
@@ -42,6 +42,22 @@ public class DeleteDomainRecordsConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getDomain()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteRRSetConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteRRSetConverter.java
@@ -54,6 +54,22 @@ public class DeleteRRSetConverter {
                                     request.getCompartmentId()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteResolverEndpointConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteResolverEndpointConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class DeleteResolverEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.DeleteResolverEndpointRequest interceptRequest(
+            com.oracle.bmc.dns.requests.DeleteResolverEndpointRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.DeleteResolverEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notBlank(
+                request.getResolverEndpointName(), "resolverEndpointName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("endpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverEndpointName()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getIfUnmodifiedSince() != null) {
+            ib.header("If-Unmodified-Since", request.getIfUnmodifiedSince());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .DeleteResolverEndpointResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.DeleteResolverEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteSteeringPolicyAttachmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteSteeringPolicyAttachmentConverter.java
@@ -40,6 +40,14 @@ public class DeleteSteeringPolicyAttachmentConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyAttachmentId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteSteeringPolicyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteSteeringPolicyConverter.java
@@ -37,6 +37,14 @@ public class DeleteSteeringPolicyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteTsigKeyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteTsigKeyConverter.java
@@ -37,6 +37,14 @@ public class DeleteTsigKeyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getTsigKeyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteViewConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteViewConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class DeleteViewConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.DeleteViewRequest interceptRequest(
+            com.oracle.bmc.dns.requests.DeleteViewRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.DeleteViewRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getViewId(), "viewId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("views")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getViewId()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getIfUnmodifiedSince() != null) {
+            ib.header("If-Unmodified-Since", request.getIfUnmodifiedSince());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.DeleteViewResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.DeleteViewResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.DeleteViewResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.DeleteViewResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.DeleteViewResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.DeleteViewResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.DeleteViewResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.DeleteViewResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteZoneConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/DeleteZoneConverter.java
@@ -37,6 +37,22 @@ public class DeleteZoneConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getZoneNameOrId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(
@@ -100,6 +116,18 @@ public class DeleteZoneConverter {
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
                                                     String.class));
                                 }
 

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetDomainRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetDomainRecordsConverter.java
@@ -74,6 +74,22 @@ public class GetDomainRecordsConverter {
                                     request.getRtype()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getSortBy() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetRRSetConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetRRSetConverter.java
@@ -78,6 +78,22 @@ public class GetRRSetConverter {
                                     request.getCompartmentId()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetResolverConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetResolverConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class GetResolverConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.GetResolverRequest interceptRequest(
+            com.oracle.bmc.dns.requests.GetResolverRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.GetResolverRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfModifiedSince() != null) {
+            ib.header("If-Modified-Since", request.getIfModifiedSince());
+        }
+
+        if (request.getIfNoneMatch() != null) {
+            ib.header("If-None-Match", request.getIfNoneMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.GetResolverResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.GetResolverResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.GetResolverResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.GetResolverResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.GetResolverResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Resolver>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Resolver.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Resolver> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.GetResolverResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.GetResolverResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.resolver(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.GetResolverResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetResolverEndpointConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetResolverEndpointConverter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class GetResolverEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.GetResolverEndpointRequest interceptRequest(
+            com.oracle.bmc.dns.requests.GetResolverEndpointRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.GetResolverEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notBlank(
+                request.getResolverEndpointName(), "resolverEndpointName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("endpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverEndpointName()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfModifiedSince() != null) {
+            ib.header("If-Modified-Since", request.getIfModifiedSince());
+        }
+
+        if (request.getIfNoneMatch() != null) {
+            ib.header("If-None-Match", request.getIfNoneMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.GetResolverEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.GetResolverEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.GetResolverEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.GetResolverEndpointResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.GetResolverEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ResolverEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ResolverEndpoint.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ResolverEndpoint>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.GetResolverEndpointResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .GetResolverEndpointResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.resolverEndpoint(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.GetResolverEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetSteeringPolicyAttachmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetSteeringPolicyAttachmentConverter.java
@@ -39,6 +39,14 @@ public class GetSteeringPolicyAttachmentConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyAttachmentId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetSteeringPolicyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetSteeringPolicyConverter.java
@@ -37,6 +37,14 @@ public class GetSteeringPolicyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetTsigKeyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetTsigKeyConverter.java
@@ -37,6 +37,14 @@ public class GetTsigKeyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getTsigKeyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetViewConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetViewConverter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class GetViewConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.GetViewRequest interceptRequest(
+            com.oracle.bmc.dns.requests.GetViewRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.GetViewRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getViewId(), "viewId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("views")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getViewId()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfModifiedSince() != null) {
+            ib.header("If-Modified-Since", request.getIfModifiedSince());
+        }
+
+        if (request.getIfNoneMatch() != null) {
+            ib.header("If-None-Match", request.getIfNoneMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.GetViewResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.GetViewResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.GetViewResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.GetViewResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.GetViewResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<View>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(View.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<View> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.GetViewResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.GetViewResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.view(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.GetViewResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetZoneConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetZoneConverter.java
@@ -37,6 +37,22 @@ public class GetZoneConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getZoneNameOrId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetZoneRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/GetZoneRecordsConverter.java
@@ -110,6 +110,22 @@ public class GetZoneRecordsConverter {
                                     request.getCompartmentId()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListResolverEndpointsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListResolverEndpointsConverter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class ListResolverEndpointsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.ListResolverEndpointsRequest interceptRequest(
+            com.oracle.bmc.dns.requests.ListResolverEndpointsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.ListResolverEndpointsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("endpoints");
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.ListResolverEndpointsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.ListResolverEndpointsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.ListResolverEndpointsResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.ListResolverEndpointsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.ListResolverEndpointsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<ResolverEndpointSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ResolverEndpointSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ResolverEndpointSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.ListResolverEndpointsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .ListResolverEndpointsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.ListResolverEndpointsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListResolversConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListResolversConverter.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class ListResolversConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.ListResolversRequest interceptRequest(
+            com.oracle.bmc.dns.requests.ListResolversRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.ListResolversRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20180115").path("resolvers");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.ListResolversResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.ListResolversResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.ListResolversResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.ListResolversResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.ListResolversResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<ResolverSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ResolverSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ResolverSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.ListResolversResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.ListResolversResponse
+                                                .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.ListResolversResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListSteeringPoliciesConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListSteeringPoliciesConverter.java
@@ -134,6 +134,14 @@ public class ListSteeringPoliciesConverter {
                                     request.getSortOrder().getValue()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListSteeringPolicyAttachmentsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListSteeringPolicyAttachmentsConverter.java
@@ -142,6 +142,14 @@ public class ListSteeringPolicyAttachmentsConverter {
                                     request.getSortOrder().getValue()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListTsigKeysConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListTsigKeysConverter.java
@@ -94,6 +94,14 @@ public class ListTsigKeysConverter {
                                     request.getSortOrder().getValue()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListViewsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListViewsConverter.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class ListViewsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.ListViewsRequest interceptRequest(
+            com.oracle.bmc.dns.requests.ListViewsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.ListViewsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20180115").path("views");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.ListViewsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.ListViewsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.ListViewsResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.ListViewsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.ListViewsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<ViewSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<ViewSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ViewSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.ListViewsResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.ListViewsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.ListViewsResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListZonesConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/ListZonesConverter.java
@@ -118,6 +118,22 @@ public class ListZonesConverter {
                                     request.getSortOrder().getValue()));
         }
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchDomainRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchDomainRecordsConverter.java
@@ -44,6 +44,22 @@ public class PatchDomainRecordsConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getDomain()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchRRSetConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchRRSetConverter.java
@@ -47,6 +47,22 @@ public class PatchRRSetConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getRtype()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchZoneRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/PatchZoneRecordsConverter.java
@@ -40,6 +40,22 @@ public class PatchZoneRecordsConverter {
                                         request.getZoneNameOrId()))
                         .path("records");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateDomainRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateDomainRecordsConverter.java
@@ -44,6 +44,22 @@ public class UpdateDomainRecordsConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getDomain()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateRRSetConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateRRSetConverter.java
@@ -47,6 +47,22 @@ public class UpdateRRSetConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getRtype()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateResolverConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateResolverConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class UpdateResolverConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.UpdateResolverRequest interceptRequest(
+            com.oracle.bmc.dns.requests.UpdateResolverRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.UpdateResolverRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notNull(request.getUpdateResolverDetails(), "updateResolverDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getIfUnmodifiedSince() != null) {
+            ib.header("If-Unmodified-Since", request.getIfUnmodifiedSince());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.UpdateResolverResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.UpdateResolverResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.UpdateResolverResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.UpdateResolverResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.UpdateResolverResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Resolver>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Resolver.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Resolver> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.UpdateResolverResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses.UpdateResolverResponse
+                                                        .builder();
+
+                                builder.resolver(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.UpdateResolverResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateResolverEndpointConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateResolverEndpointConverter.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class UpdateResolverEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.UpdateResolverEndpointRequest interceptRequest(
+            com.oracle.bmc.dns.requests.UpdateResolverEndpointRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.UpdateResolverEndpointRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getResolverId(), "resolverId must not be blank");
+        Validate.notBlank(
+                request.getResolverEndpointName(), "resolverEndpointName must not be blank");
+        Validate.notNull(
+                request.getUpdateResolverEndpointDetails(),
+                "updateResolverEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("resolvers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverId()))
+                        .path("endpoints")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getResolverEndpointName()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getIfUnmodifiedSince() != null) {
+            ib.header("If-Unmodified-Since", request.getIfUnmodifiedSince());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ResolverEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ResolverEndpoint.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ResolverEndpoint>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dns.responses
+                                                        .UpdateResolverEndpointResponse.builder();
+
+                                builder.resolverEndpoint(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.UpdateResolverEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateSteeringPolicyAttachmentConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateSteeringPolicyAttachmentConverter.java
@@ -43,6 +43,14 @@ public class UpdateSteeringPolicyAttachmentConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyAttachmentId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateSteeringPolicyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateSteeringPolicyConverter.java
@@ -40,6 +40,14 @@ public class UpdateSteeringPolicyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getSteeringPolicyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateTsigKeyConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateTsigKeyConverter.java
@@ -38,6 +38,14 @@ public class UpdateTsigKeyConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getTsigKeyId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateViewConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateViewConverter.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dns.model.*;
+import com.oracle.bmc.dns.requests.*;
+import com.oracle.bmc.dns.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public class UpdateViewConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dns.requests.UpdateViewRequest interceptRequest(
+            com.oracle.bmc.dns.requests.UpdateViewRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dns.requests.UpdateViewRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getViewId(), "viewId must not be blank");
+        Validate.notNull(request.getUpdateViewDetails(), "updateViewDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180115")
+                        .path("views")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getViewId()));
+
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("If-Match", request.getIfMatch());
+        }
+
+        if (request.getIfUnmodifiedSince() != null) {
+            ib.header("If-Unmodified-Since", request.getIfUnmodifiedSince());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.UpdateViewResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.dns.responses.UpdateViewResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dns.responses.UpdateViewResponse>() {
+                            @Override
+                            public com.oracle.bmc.dns.responses.UpdateViewResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dns.responses.UpdateViewResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<View>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create(View.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<View> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dns.responses.UpdateViewResponse.Builder builder =
+                                        com.oracle.bmc.dns.responses.UpdateViewResponse.builder();
+
+                                builder.view(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dns.responses.UpdateViewResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateZoneConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateZoneConverter.java
@@ -38,6 +38,22 @@ public class UpdateZoneConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getZoneNameOrId()));
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(
@@ -94,6 +110,15 @@ public class UpdateZoneConverter {
 
                                 builder.zone(response.getItem());
 
+                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "ETag");
+                                if (eTagHeader.isPresent()) {
+                                    builder.eTag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                }
+
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcRequestIdHeader =
                                                 com.oracle.bmc.http.internal.HeaderUtils.get(
@@ -106,13 +131,16 @@ public class UpdateZoneConverter {
                                                     String.class));
                                 }
 
-                                com.google.common.base.Optional<java.util.List<String>> eTagHeader =
-                                        com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                headers, "ETag");
-                                if (eTagHeader.isPresent()) {
-                                    builder.eTag(
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "ETag", eTagHeader.get().get(0), String.class));
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
                                 }
 
                                 com.oracle.bmc.dns.responses.UpdateZoneResponse responseWrapper =

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateZoneRecordsConverter.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/internal/http/UpdateZoneRecordsConverter.java
@@ -40,6 +40,22 @@ public class UpdateZoneRecordsConverter {
                                         request.getZoneNameOrId()))
                         .path("records");
 
+        if (request.getScope() != null) {
+            target =
+                    target.queryParam(
+                            "scope",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getScope().getValue()));
+        }
+
+        if (request.getViewId() != null) {
+            target =
+                    target.queryParam(
+                            "viewId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getViewId()));
+        }
+
         if (request.getCompartmentId() != null) {
             target =
                     target.queryParam(

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/AttachedView.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/AttachedView.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * Properties of an attached view.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AttachedView.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AttachedView {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+        private String viewId;
+
+        public Builder viewId(String viewId) {
+            this.viewId = viewId;
+            this.__explicitlySet__.add("viewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AttachedView build() {
+            AttachedView __instance__ = new AttachedView(viewId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AttachedView o) {
+            Builder copiedBuilder = viewId(o.getViewId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the view.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+    String viewId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/AttachedViewDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/AttachedViewDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * Properties for defining an attached view.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AttachedViewDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AttachedViewDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+        private String viewId;
+
+        public Builder viewId(String viewId) {
+            this.viewId = viewId;
+            this.__explicitlySet__.add("viewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AttachedViewDetails build() {
+            AttachedViewDetails __instance__ = new AttachedViewDetails(viewId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AttachedViewDetails o) {
+            Builder copiedBuilder = viewId(o.getViewId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the view.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+    String viewId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ChangeResolverCompartmentDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ChangeResolverCompartmentDetails.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeResolverCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeResolverCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeResolverCompartmentDetails build() {
+            ChangeResolverCompartmentDetails __instance__ =
+                    new ChangeResolverCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeResolverCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment into which the resolver, along with
+     * its protected default view and resolver endpoints, should be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ChangeViewCompartmentDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ChangeViewCompartmentDetails.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeViewCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeViewCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeViewCompartmentDetails build() {
+            ChangeViewCompartmentDetails __instance__ =
+                    new ChangeViewCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeViewCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment
+     * into which the view should be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateResolverEndpointDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateResolverEndpointDetails.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for defining a new resolver endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType",
+    defaultImpl = CreateResolverEndpointDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateResolverVnicEndpointDetails.class,
+        name = "VNIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateResolverEndpointDetails {
+
+    /**
+     * The name of the resolver endpoint. Must be unique within the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * An IP address from which forwarded queries may be sent. For VNIC endpoints, this IP address must be part
+     * of the subnet and will be assigned by the system if unspecified when isForwarding is true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+    String forwardingAddress;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for forwarding.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+    Boolean isForwarding;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for listening.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+    Boolean isListening;
+
+    /**
+     * An IP address to listen to queries on. For VNIC endpoints this IP address must be part of the
+     * subnet and will be assigned by the system if unspecified.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+    String listeningAddress;
+
+    /**
+     * The type of resolver endpoint. VNIC is currently the only supported type.
+     *
+     **/
+    public enum EndpointType {
+        Vnic("VNIC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, EndpointType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (EndpointType v : EndpointType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        EndpointType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static EndpointType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid EndpointType: " + key);
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateResolverVnicEndpointDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateResolverVnicEndpointDetails.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for defining a new resolver VNIC endpoint. Either isForwarding or isListening must be true but not both.
+ * If a listeningAddress is not provided then one will be chosen automatically. If isForwarding is true then a
+ * forwardingAddress may be provided. If one is not then one will be chosen automatically. A listeningAddress will
+ * be consumed regardless of if the resolver is configured for listening or not.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateResolverVnicEndpointDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateResolverVnicEndpointDetails extends CreateResolverEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+        private String forwardingAddress;
+
+        public Builder forwardingAddress(String forwardingAddress) {
+            this.forwardingAddress = forwardingAddress;
+            this.__explicitlySet__.add("forwardingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+        private Boolean isForwarding;
+
+        public Builder isForwarding(Boolean isForwarding) {
+            this.isForwarding = isForwarding;
+            this.__explicitlySet__.add("isForwarding");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+        private Boolean isListening;
+
+        public Builder isListening(Boolean isListening) {
+            this.isListening = isListening;
+            this.__explicitlySet__.add("isListening");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+        private String listeningAddress;
+
+        public Builder listeningAddress(String listeningAddress) {
+            this.listeningAddress = listeningAddress;
+            this.__explicitlySet__.add("listeningAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateResolverVnicEndpointDetails build() {
+            CreateResolverVnicEndpointDetails __instance__ =
+                    new CreateResolverVnicEndpointDetails(
+                            name,
+                            forwardingAddress,
+                            isForwarding,
+                            isListening,
+                            listeningAddress,
+                            subnetId,
+                            nsgIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateResolverVnicEndpointDetails o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .forwardingAddress(o.getForwardingAddress())
+                            .isForwarding(o.getIsForwarding())
+                            .isListening(o.getIsListening())
+                            .listeningAddress(o.getListeningAddress())
+                            .subnetId(o.getSubnetId())
+                            .nsgIds(o.getNsgIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateResolverVnicEndpointDetails(
+            String name,
+            String forwardingAddress,
+            Boolean isForwarding,
+            Boolean isListening,
+            String listeningAddress,
+            String subnetId,
+            java.util.List<String> nsgIds) {
+        super(name, forwardingAddress, isForwarding, isListening, listeningAddress);
+        this.subnetId = subnetId;
+        this.nsgIds = nsgIds;
+    }
+
+    /**
+     * The OCID of a subnet. Must be part of the VCN that the resolver is attached to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * An array of NSG OCIDs for the resolver endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateViewDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateViewDetails.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for defining a new view.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateViewDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateViewDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateViewDetails build() {
+            CreateViewDetails __instance__ =
+                    new CreateViewDetails(compartmentId, displayName, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateViewDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the owning compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The display name of the view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateZoneDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/CreateZoneDetails.java
@@ -81,6 +81,24 @@ public class CreateZoneDetails extends CreateZoneBaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+        private String viewId;
+
+        public Builder viewId(String viewId) {
+            this.viewId = viewId;
+            this.__explicitlySet__.add("viewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scope")
+        private Scope scope;
+
+        public Builder scope(Scope scope) {
+            this.scope = scope;
+            this.__explicitlySet__.add("scope");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("externalMasters")
         private java.util.List<ExternalMaster> externalMasters;
 
@@ -101,6 +119,8 @@ public class CreateZoneDetails extends CreateZoneBaseDetails {
                             freeformTags,
                             definedTags,
                             zoneType,
+                            viewId,
+                            scope,
                             externalMasters);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -114,6 +134,8 @@ public class CreateZoneDetails extends CreateZoneBaseDetails {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .zoneType(o.getZoneType())
+                            .viewId(o.getViewId())
+                            .scope(o.getScope())
                             .externalMasters(o.getExternalMasters());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -135,14 +157,19 @@ public class CreateZoneDetails extends CreateZoneBaseDetails {
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             ZoneType zoneType,
+            String viewId,
+            Scope scope,
             java.util.List<ExternalMaster> externalMasters) {
         super(name, compartmentId, freeformTags, definedTags);
         this.zoneType = zoneType;
+        this.viewId = viewId;
+        this.scope = scope;
         this.externalMasters = externalMasters;
     }
 
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL
+     * zones.
      *
      **/
     public enum ZoneType {
@@ -178,11 +205,25 @@ public class CreateZoneDetails extends CreateZoneBaseDetails {
         }
     };
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL
+     * zones.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("zoneType")
     ZoneType zoneType;
+
+    /**
+     * This value will be null for zones in the global DNS.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+    String viewId;
+
+    /**
+     * The scope of the zone.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scope")
+    Scope scope;
 
     /**
      * External master servers for the zone. `externalMasters` becomes a

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/MigrationReplacement.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/MigrationReplacement.java
@@ -94,7 +94,7 @@ public class MigrationReplacement {
     }
 
     /**
-     * The canonical name for the type of the replacement record, such as A or CNAME.
+     * The type of DNS record, such as A or CNAME. For more information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("rtype")

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Record.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Record.java
@@ -163,8 +163,7 @@ public class Record {
     String rrsetVersion;
 
     /**
-     * The canonical name for the record's type, such as A or CNAME. For more
-     * information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+     * The type of DNS record, such as A or CNAME. For more information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("rtype")

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/RecordDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/RecordDetails.java
@@ -162,8 +162,7 @@ public class RecordDetails {
     String rrsetVersion;
 
     /**
-     * The canonical name for the record's type, such as A or CNAME. For more
-     * information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+     * The type of DNS record, such as A or CNAME. For more information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("rtype")

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/RecordOperation.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/RecordOperation.java
@@ -182,8 +182,7 @@ public class RecordOperation {
     String rrsetVersion;
 
     /**
-     * The canonical name for the record's type, such as A or CNAME. For more
-     * information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+     * The type of DNS record, such as A or CNAME. For more information, see [Resource Record (RR) TYPEs](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("rtype")

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Resolver.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Resolver.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver. If the resolver has an attached VCN then the VCN will attempt to answer queries based on the
+ * attached views in priority order. If the query does not match any of the attached views then the query will be
+ * evaluated against the default view. If the default view does not match then the rules will be evaluated in
+ * priority order. If no rules match the query then answers come from Internet DNS. A resolver may have at most 10
+ * resolver endpoints.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Resolver.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Resolver {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedVcnId")
+        private String attachedVcnId;
+
+        public Builder attachedVcnId(String attachedVcnId) {
+            this.attachedVcnId = attachedVcnId;
+            this.__explicitlySet__.add("attachedVcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultViewId")
+        private String defaultViewId;
+
+        public Builder defaultViewId(String defaultViewId) {
+            this.defaultViewId = defaultViewId;
+            this.__explicitlySet__.add("defaultViewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("endpoints")
+        private java.util.List<ResolverEndpointSummary> endpoints;
+
+        public Builder endpoints(java.util.List<ResolverEndpointSummary> endpoints) {
+            this.endpoints = endpoints;
+            this.__explicitlySet__.add("endpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedViews")
+        private java.util.List<AttachedView> attachedViews;
+
+        public Builder attachedViews(java.util.List<AttachedView> attachedViews) {
+            this.attachedViews = attachedViews;
+            this.__explicitlySet__.add("attachedViews");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<ResolverRule> rules;
+
+        public Builder rules(java.util.List<ResolverRule> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Resolver build() {
+            Resolver __instance__ =
+                    new Resolver(
+                            compartmentId,
+                            attachedVcnId,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            id,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            self,
+                            defaultViewId,
+                            isProtected,
+                            endpoints,
+                            attachedViews,
+                            rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Resolver o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .attachedVcnId(o.getAttachedVcnId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .self(o.getSelf())
+                            .defaultViewId(o.getDefaultViewId())
+                            .isProtected(o.getIsProtected())
+                            .endpoints(o.getEndpoints())
+                            .attachedViews(o.getAttachedViews())
+                            .rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the owning compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The OCID of the attached VCN.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedVcnId")
+    String attachedVcnId;
+
+    /**
+     * The display name of the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The OCID of the resolver.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Creating("CREATING"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The OCID of the default view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultViewId")
+    String defaultViewId;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
+
+    /**
+     * Read-only array of endpoints for the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpoints")
+    java.util.List<ResolverEndpointSummary> endpoints;
+
+    /**
+     * The attached views. Views are evaluated in order.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedViews")
+    java.util.List<AttachedView> attachedViews;
+
+    /**
+     * Rules for the resolver. Rules are evaluated in order.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<ResolverRule> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverEndpoint.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverEndpoint.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType",
+    defaultImpl = ResolverEndpoint.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ResolverVnicEndpoint.class,
+        name = "VNIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ResolverEndpoint {
+
+    /**
+     * The name of the resolver endpoint. Must be unique within the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * An IP address from which forwarded queries may be sent. For VNIC endpoints, this IP address must be part
+     * of the subnet and will be assigned by the system if unspecified when isForwarding is true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+    String forwardingAddress;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for forwarding.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+    Boolean isForwarding;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for listening.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+    Boolean isListening;
+
+    /**
+     * An IP address to listen to queries on. For VNIC endpoints this IP address must be part of the
+     * subnet and will be assigned by the system if unspecified.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+    String listeningAddress;
+
+    /**
+     * The OCID of the owning compartment. This will match the resolver that the resolver endpoint is under
+     * and will be updated if the resolver's compartment is changed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Creating("CREATING"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The type of resolver endpoint. VNIC is currently the only supported type.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum EndpointType {
+        Vnic("VNIC"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, EndpointType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (EndpointType v : EndpointType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        EndpointType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static EndpointType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'EndpointType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverEndpointSummary.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverEndpointSummary.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType",
+    defaultImpl = ResolverEndpointSummary.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ResolverVnicEndpointSummary.class,
+        name = "VNIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ResolverEndpointSummary {
+
+    /**
+     * The name of the resolver endpoint. Must be unique within the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * An IP address from which forwarded queries may be sent. For VNIC endpoints, this IP address must be part
+     * of the subnet and will be assigned by the system if unspecified when isForwarding is true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+    String forwardingAddress;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for forwarding.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+    Boolean isForwarding;
+
+    /**
+     * A Boolean flag indicating whether or not the resolver endpoint is for listening.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+    Boolean isListening;
+
+    /**
+     * An IP address to listen to queries on. For VNIC endpoints this IP address must be part of the
+     * subnet and will be assigned by the system if unspecified.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+    String listeningAddress;
+
+    /**
+     * The OCID of the owning compartment. This will match the resolver that the resolver endpoint is under
+     * and will be updated if the resolver's compartment is changed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Creating("CREATING"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The type of resolver endpoint. VNIC is currently the only supported type.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum EndpointType {
+        Vnic("VNIC"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, EndpointType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (EndpointType v : EndpointType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        EndpointType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static EndpointType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'EndpointType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverForwardRule.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverForwardRule.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ResolverForwardRule.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "action"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResolverForwardRule extends ResolverRule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("clientAddressConditions")
+        private java.util.List<String> clientAddressConditions;
+
+        public Builder clientAddressConditions(java.util.List<String> clientAddressConditions) {
+            this.clientAddressConditions = clientAddressConditions;
+            this.__explicitlySet__.add("clientAddressConditions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("qnameCoverConditions")
+        private java.util.List<String> qnameCoverConditions;
+
+        public Builder qnameCoverConditions(java.util.List<String> qnameCoverConditions) {
+            this.qnameCoverConditions = qnameCoverConditions;
+            this.__explicitlySet__.add("qnameCoverConditions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("destinationAddresses")
+        private java.util.List<String> destinationAddresses;
+
+        public Builder destinationAddresses(java.util.List<String> destinationAddresses) {
+            this.destinationAddresses = destinationAddresses;
+            this.__explicitlySet__.add("destinationAddresses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceEndpointName")
+        private String sourceEndpointName;
+
+        public Builder sourceEndpointName(String sourceEndpointName) {
+            this.sourceEndpointName = sourceEndpointName;
+            this.__explicitlySet__.add("sourceEndpointName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResolverForwardRule build() {
+            ResolverForwardRule __instance__ =
+                    new ResolverForwardRule(
+                            clientAddressConditions,
+                            qnameCoverConditions,
+                            destinationAddresses,
+                            sourceEndpointName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResolverForwardRule o) {
+            Builder copiedBuilder =
+                    clientAddressConditions(o.getClientAddressConditions())
+                            .qnameCoverConditions(o.getQnameCoverConditions())
+                            .destinationAddresses(o.getDestinationAddresses())
+                            .sourceEndpointName(o.getSourceEndpointName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ResolverForwardRule(
+            java.util.List<String> clientAddressConditions,
+            java.util.List<String> qnameCoverConditions,
+            java.util.List<String> destinationAddresses,
+            String sourceEndpointName) {
+        super(clientAddressConditions, qnameCoverConditions);
+        this.destinationAddresses = destinationAddresses;
+        this.sourceEndpointName = sourceEndpointName;
+    }
+
+    /**
+     * IP addresses to which queries should be forwarded. Currently limited to a single address.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("destinationAddresses")
+    java.util.List<String> destinationAddresses;
+
+    /**
+     * Name of an endpoint, that is a sub-resource of the resolver, to use as the forwarding interface. The
+     * endpoint must have isForwarding set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceEndpointName")
+    String sourceEndpointName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverForwardRuleDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverForwardRuleDetails.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ResolverForwardRuleDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "action"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResolverForwardRuleDetails extends ResolverRuleDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("clientAddressConditions")
+        private java.util.List<String> clientAddressConditions;
+
+        public Builder clientAddressConditions(java.util.List<String> clientAddressConditions) {
+            this.clientAddressConditions = clientAddressConditions;
+            this.__explicitlySet__.add("clientAddressConditions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("qnameCoverConditions")
+        private java.util.List<String> qnameCoverConditions;
+
+        public Builder qnameCoverConditions(java.util.List<String> qnameCoverConditions) {
+            this.qnameCoverConditions = qnameCoverConditions;
+            this.__explicitlySet__.add("qnameCoverConditions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("destinationAddresses")
+        private java.util.List<String> destinationAddresses;
+
+        public Builder destinationAddresses(java.util.List<String> destinationAddresses) {
+            this.destinationAddresses = destinationAddresses;
+            this.__explicitlySet__.add("destinationAddresses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceEndpointName")
+        private String sourceEndpointName;
+
+        public Builder sourceEndpointName(String sourceEndpointName) {
+            this.sourceEndpointName = sourceEndpointName;
+            this.__explicitlySet__.add("sourceEndpointName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResolverForwardRuleDetails build() {
+            ResolverForwardRuleDetails __instance__ =
+                    new ResolverForwardRuleDetails(
+                            clientAddressConditions,
+                            qnameCoverConditions,
+                            destinationAddresses,
+                            sourceEndpointName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResolverForwardRuleDetails o) {
+            Builder copiedBuilder =
+                    clientAddressConditions(o.getClientAddressConditions())
+                            .qnameCoverConditions(o.getQnameCoverConditions())
+                            .destinationAddresses(o.getDestinationAddresses())
+                            .sourceEndpointName(o.getSourceEndpointName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ResolverForwardRuleDetails(
+            java.util.List<String> clientAddressConditions,
+            java.util.List<String> qnameCoverConditions,
+            java.util.List<String> destinationAddresses,
+            String sourceEndpointName) {
+        super(clientAddressConditions, qnameCoverConditions);
+        this.destinationAddresses = destinationAddresses;
+        this.sourceEndpointName = sourceEndpointName;
+    }
+
+    /**
+     * IP addresses to which queries should be forwarded. Currently limited to a single address.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("destinationAddresses")
+    java.util.List<String> destinationAddresses;
+
+    /**
+     * Name of an endpoint, that is a sub-resource of the resolver, to use as the forwarding interface. The
+     * endpoint must have isForwarding set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceEndpointName")
+    String sourceEndpointName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverRule.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverRule.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * A rule for a resolver. Specifying both qnameCoverConditions and clientAddressConditions is not allowed.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "action",
+    defaultImpl = ResolverRule.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ResolverForwardRule.class,
+        name = "FORWARD"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ResolverRule {
+
+    /**
+     * A list of CIDR blocks. The query must come from a client within one of the blocks in order for the rule action
+     * to apply.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientAddressConditions")
+    java.util.List<String> clientAddressConditions;
+
+    /**
+     * A list of domain names. The query must be covered by one of the domains in order for the rule action to apply.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("qnameCoverConditions")
+    java.util.List<String> qnameCoverConditions;
+
+    /**
+     * The action determines the behavior of the rule. If a query matches a supplied condition then the action will
+     * apply. If there are no conditions on the rule then all queries are subject to the specified action.
+     * * `FORWARD` - Matching requests will be forwarded from the source interface to the destination address.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Action {
+        Forward("FORWARD"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Action> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Action v : Action.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Action(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Action create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Action', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverRuleDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverRuleDetails.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * A rule for a resolver. Specifying both qnameCoverConditions and clientAddressConditions is not allowed.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "action",
+    defaultImpl = ResolverRuleDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ResolverForwardRuleDetails.class,
+        name = "FORWARD"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ResolverRuleDetails {
+
+    /**
+     * A list of CIDR blocks. The query must come from a client within one of the blocks in order for the rule action
+     * to apply.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientAddressConditions")
+    java.util.List<String> clientAddressConditions;
+
+    /**
+     * A list of domain names. The query must be covered by one of the domains in order for the rule action to apply.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("qnameCoverConditions")
+    java.util.List<String> qnameCoverConditions;
+
+    /**
+     * The action determines the behavior of the rule. If a query matches a supplied condition then the action will
+     * apply. If there are no conditions on the rule then all queries are subject to the specified action.
+     * * `FORWARD` - Matching requests will be forwarded from the source interface to the destination address.
+     *
+     **/
+    public enum Action {
+        Forward("FORWARD"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Action> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Action v : Action.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Action(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Action create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Action: " + key);
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverSummary.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverSummary.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver. If the resolver has an attached VCN then the VCN will attempt to answer queries based on the
+ * attached views in priority order. If the query does not match any of the attached views then the query will be
+ * evaluated against the default view. If the default view does not match then the rules will be evaluated in
+ * priority order. If no rules match the query then answers come from Internet DNS. A resolver may have at most 10
+ * resolver endpoints.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ResolverSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResolverSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedVcnId")
+        private String attachedVcnId;
+
+        public Builder attachedVcnId(String attachedVcnId) {
+            this.attachedVcnId = attachedVcnId;
+            this.__explicitlySet__.add("attachedVcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultViewId")
+        private String defaultViewId;
+
+        public Builder defaultViewId(String defaultViewId) {
+            this.defaultViewId = defaultViewId;
+            this.__explicitlySet__.add("defaultViewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResolverSummary build() {
+            ResolverSummary __instance__ =
+                    new ResolverSummary(
+                            compartmentId,
+                            attachedVcnId,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            id,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            self,
+                            defaultViewId,
+                            isProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResolverSummary o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .attachedVcnId(o.getAttachedVcnId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .self(o.getSelf())
+                            .defaultViewId(o.getDefaultViewId())
+                            .isProtected(o.getIsProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the owning compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The OCID of the attached VCN.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedVcnId")
+    String attachedVcnId;
+
+    /**
+     * The display name of the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The OCID of the resolver.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Creating("CREATING"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Failed("FAILED"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The OCID of the default view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultViewId")
+    String defaultViewId;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverVnicEndpoint.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverVnicEndpoint.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver VNIC endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ResolverVnicEndpoint.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResolverVnicEndpoint extends ResolverEndpoint {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+        private String forwardingAddress;
+
+        public Builder forwardingAddress(String forwardingAddress) {
+            this.forwardingAddress = forwardingAddress;
+            this.__explicitlySet__.add("forwardingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+        private Boolean isForwarding;
+
+        public Builder isForwarding(Boolean isForwarding) {
+            this.isForwarding = isForwarding;
+            this.__explicitlySet__.add("isForwarding");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+        private Boolean isListening;
+
+        public Builder isListening(Boolean isListening) {
+            this.isListening = isListening;
+            this.__explicitlySet__.add("isListening");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+        private String listeningAddress;
+
+        public Builder listeningAddress(String listeningAddress) {
+            this.listeningAddress = listeningAddress;
+            this.__explicitlySet__.add("listeningAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResolverVnicEndpoint build() {
+            ResolverVnicEndpoint __instance__ =
+                    new ResolverVnicEndpoint(
+                            name,
+                            forwardingAddress,
+                            isForwarding,
+                            isListening,
+                            listeningAddress,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            self,
+                            subnetId,
+                            nsgIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResolverVnicEndpoint o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .forwardingAddress(o.getForwardingAddress())
+                            .isForwarding(o.getIsForwarding())
+                            .isListening(o.getIsListening())
+                            .listeningAddress(o.getListeningAddress())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .self(o.getSelf())
+                            .subnetId(o.getSubnetId())
+                            .nsgIds(o.getNsgIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ResolverVnicEndpoint(
+            String name,
+            String forwardingAddress,
+            Boolean isForwarding,
+            Boolean isListening,
+            String listeningAddress,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String self,
+            String subnetId,
+            java.util.List<String> nsgIds) {
+        super(
+                name,
+                forwardingAddress,
+                isForwarding,
+                isListening,
+                listeningAddress,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                self);
+        this.subnetId = subnetId;
+        this.nsgIds = nsgIds;
+    }
+
+    /**
+     * The OCID of a subnet. Must be part of the VCN that the resolver is attached to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * An array of NSG OCIDs for the resolver endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverVnicEndpointSummary.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ResolverVnicEndpointSummary.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS resolver VNIC endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ResolverVnicEndpointSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResolverVnicEndpointSummary extends ResolverEndpointSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("forwardingAddress")
+        private String forwardingAddress;
+
+        public Builder forwardingAddress(String forwardingAddress) {
+            this.forwardingAddress = forwardingAddress;
+            this.__explicitlySet__.add("forwardingAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isForwarding")
+        private Boolean isForwarding;
+
+        public Builder isForwarding(Boolean isForwarding) {
+            this.isForwarding = isForwarding;
+            this.__explicitlySet__.add("isForwarding");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isListening")
+        private Boolean isListening;
+
+        public Builder isListening(Boolean isListening) {
+            this.isListening = isListening;
+            this.__explicitlySet__.add("isListening");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("listeningAddress")
+        private String listeningAddress;
+
+        public Builder listeningAddress(String listeningAddress) {
+            this.listeningAddress = listeningAddress;
+            this.__explicitlySet__.add("listeningAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResolverVnicEndpointSummary build() {
+            ResolverVnicEndpointSummary __instance__ =
+                    new ResolverVnicEndpointSummary(
+                            name,
+                            forwardingAddress,
+                            isForwarding,
+                            isListening,
+                            listeningAddress,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            self,
+                            subnetId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResolverVnicEndpointSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .forwardingAddress(o.getForwardingAddress())
+                            .isForwarding(o.getIsForwarding())
+                            .isListening(o.getIsListening())
+                            .listeningAddress(o.getListeningAddress())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .self(o.getSelf())
+                            .subnetId(o.getSubnetId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ResolverVnicEndpointSummary(
+            String name,
+            String forwardingAddress,
+            Boolean isForwarding,
+            Boolean isListening,
+            String listeningAddress,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            String self,
+            String subnetId) {
+        super(
+                name,
+                forwardingAddress,
+                isForwarding,
+                isListening,
+                listeningAddress,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                self);
+        this.subnetId = subnetId;
+    }
+
+    /**
+     * The OCID of a subnet. Must be part of the VCN that the resolver is attached to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Scope.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Scope.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The DNS scope of the resource.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.extern.slf4j.Slf4j
+public enum Scope {
+    Global("GLOBAL"),
+    Private("PRIVATE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, Scope> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (Scope v : Scope.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    Scope(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static Scope create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn("Received unknown value '{}' for enum 'Scope', returning UnknownEnumValue", key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/SteeringPolicyAnswer.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/SteeringPolicyAnswer.java
@@ -130,7 +130,7 @@ public class SteeringPolicyAnswer {
     String name;
 
     /**
-     * The canonical name for the record's type. Only A, AAAA, and CNAME are supported. For more
+     * The type of DNS record, such as A or CNAME. Only A, AAAA, and CNAME are supported. For more
      * information, see [Supported DNS Resource Record Types](https://docs.cloud.oracle.com/iaas/Content/DNS/Reference/supporteddnsresource.htm).
      *
      **/

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverDetails.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for updating an existing resolver.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateResolverDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateResolverDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("attachedViews")
+        private java.util.List<AttachedViewDetails> attachedViews;
+
+        public Builder attachedViews(java.util.List<AttachedViewDetails> attachedViews) {
+            this.attachedViews = attachedViews;
+            this.__explicitlySet__.add("attachedViews");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<ResolverRuleDetails> rules;
+
+        public Builder rules(java.util.List<ResolverRuleDetails> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateResolverDetails build() {
+            UpdateResolverDetails __instance__ =
+                    new UpdateResolverDetails(
+                            displayName, freeformTags, definedTags, attachedViews, rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateResolverDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .attachedViews(o.getAttachedViews())
+                            .rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the resolver.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The attached views. Views are evaluated in order.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("attachedViews")
+    java.util.List<AttachedViewDetails> attachedViews;
+
+    /**
+     * Rules for the resolver. Rules are evaluated in order.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<ResolverRuleDetails> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverEndpointDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverEndpointDetails.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for updating an existing resolver endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType",
+    defaultImpl = UpdateResolverEndpointDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateResolverVnicEndpointDetails.class,
+        name = "VNIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateResolverEndpointDetails {
+
+    /**
+     * The type of resolver endpoint. VNIC is currently the only supported type.
+     *
+     **/
+    public enum EndpointType {
+        Vnic("VNIC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, EndpointType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (EndpointType v : EndpointType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        EndpointType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static EndpointType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid EndpointType: " + key);
+        }
+    };
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverVnicEndpointDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateResolverVnicEndpointDetails.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for updating an existing resolver VNIC endpoint.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateResolverVnicEndpointDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "endpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateResolverVnicEndpointDetails extends UpdateResolverEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateResolverVnicEndpointDetails build() {
+            UpdateResolverVnicEndpointDetails __instance__ =
+                    new UpdateResolverVnicEndpointDetails(nsgIds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateResolverVnicEndpointDetails o) {
+            Builder copiedBuilder = nsgIds(o.getNsgIds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateResolverVnicEndpointDetails(java.util.List<String> nsgIds) {
+        super();
+        this.nsgIds = nsgIds;
+    }
+
+    /**
+     * An array of NSG OCIDs for the resolver endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateViewDetails.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/UpdateViewDetails.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * The body for updating an existing view.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateViewDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateViewDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateViewDetails build() {
+            UpdateViewDetails __instance__ =
+                    new UpdateViewDetails(displayName, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateViewDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/View.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/View.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS view.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = View.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class View {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public View build() {
+            View __instance__ =
+                    new View(
+                            compartmentId,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            id,
+                            self,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            isProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(View o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .id(o.getId())
+                            .self(o.getSelf())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .isProtected(o.getIsProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the owning compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The display name of the view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The OCID of the view.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ViewSummary.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ViewSummary.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.model;
+
+/**
+ * An OCI DNS view.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ViewSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ViewSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("self")
+        private String self;
+
+        public Builder self(String self) {
+            this.self = self;
+            this.__explicitlySet__.add("self");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ViewSummary build() {
+            ViewSummary __instance__ =
+                    new ViewSummary(
+                            compartmentId,
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            id,
+                            self,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            isProtected);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ViewSummary o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .id(o.getId())
+                            .self(o.getSelf())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .isProtected(o.getIsProtected());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the owning compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The display name of the view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     *
+     * **Example:** `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The OCID of the view.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The canonical absolute URL of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    String self;
+
+    /**
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
+     * with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the resource was last updated in \"YYYY-MM-ddThh:mm:ssZ\"
+     * format with a Z offset, as defined by RFC 3339.
+     * <p>
+     **Example:** `2016-07-22T17:23:59:60Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the resource.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Active("ACTIVE"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+        Updating("UPDATING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Zone.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/Zone.java
@@ -54,6 +54,24 @@ public class Zone {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+        private String viewId;
+
+        public Builder viewId(String viewId) {
+            this.viewId = viewId;
+            this.__explicitlySet__.add("viewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scope")
+        private Scope scope;
+
+        public Builder scope(Scope scope) {
+            this.scope = scope;
+            this.__explicitlySet__.add("scope");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -136,6 +154,15 @@ public class Zone {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("nameservers")
         private java.util.List<Nameserver> nameservers;
 
@@ -154,6 +181,8 @@ public class Zone {
                             name,
                             zoneType,
                             compartmentId,
+                            viewId,
+                            scope,
                             freeformTags,
                             definedTags,
                             externalMasters,
@@ -163,6 +192,7 @@ public class Zone {
                             version,
                             serial,
                             lifecycleState,
+                            isProtected,
                             nameservers);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -174,6 +204,8 @@ public class Zone {
                     name(o.getName())
                             .zoneType(o.getZoneType())
                             .compartmentId(o.getCompartmentId())
+                            .viewId(o.getViewId())
+                            .scope(o.getScope())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .externalMasters(o.getExternalMasters())
@@ -183,6 +215,7 @@ public class Zone {
                             .version(o.getVersion())
                             .serial(o.getSerial())
                             .lifecycleState(o.getLifecycleState())
+                            .isProtected(o.getIsProtected())
                             .nameservers(o.getNameservers());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -203,7 +236,7 @@ public class Zone {
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL zones.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -250,7 +283,7 @@ public class Zone {
         }
     };
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL zones.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("zoneType")
@@ -261,6 +294,21 @@ public class Zone {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The OCID of the private view containing the zone. This value will
+     * be null for zones in the global DNS, which are publicly resolvable and
+     * not part of a private view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+    String viewId;
+
+    /**
+     * The scope of the zone.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scope")
+    Scope scope;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
@@ -305,7 +353,7 @@ public class Zone {
     String id;
 
     /**
-     * The date and time the resource was created in \"YYYY-MM-ddThh:mmZ\" format
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
      * with a Z offset, as defined by RFC 3339.
      * <p>
      **Example:** `2016-07-22T17:23:59:60Z`
@@ -383,6 +431,13 @@ public class Zone {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
 
     /**
      * The authoritative nameservers for the zone.

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ZoneSummary.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/model/ZoneSummary.java
@@ -54,6 +54,24 @@ public class ZoneSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+        private String viewId;
+
+        public Builder viewId(String viewId) {
+            this.viewId = viewId;
+            this.__explicitlySet__.add("viewId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scope")
+        private Scope scope;
+
+        public Builder scope(Scope scope) {
+            this.scope = scope;
+            this.__explicitlySet__.add("scope");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -127,6 +145,15 @@ public class ZoneSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+        private Boolean isProtected;
+
+        public Builder isProtected(Boolean isProtected) {
+            this.isProtected = isProtected;
+            this.__explicitlySet__.add("isProtected");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -136,6 +163,8 @@ public class ZoneSummary {
                             name,
                             zoneType,
                             compartmentId,
+                            viewId,
+                            scope,
                             freeformTags,
                             definedTags,
                             self,
@@ -143,7 +172,8 @@ public class ZoneSummary {
                             timeCreated,
                             version,
                             serial,
-                            lifecycleState);
+                            lifecycleState,
+                            isProtected);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -154,6 +184,8 @@ public class ZoneSummary {
                     name(o.getName())
                             .zoneType(o.getZoneType())
                             .compartmentId(o.getCompartmentId())
+                            .viewId(o.getViewId())
+                            .scope(o.getScope())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .self(o.getSelf())
@@ -161,7 +193,8 @@ public class ZoneSummary {
                             .timeCreated(o.getTimeCreated())
                             .version(o.getVersion())
                             .serial(o.getSerial())
-                            .lifecycleState(o.getLifecycleState());
+                            .lifecycleState(o.getLifecycleState())
+                            .isProtected(o.getIsProtected());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -181,7 +214,7 @@ public class ZoneSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL zones.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -228,7 +261,7 @@ public class ZoneSummary {
         }
     };
     /**
-     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`.
+     * The type of the zone. Must be either `PRIMARY` or `SECONDARY`. `SECONDARY` is only supported for GLOBAL zones.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("zoneType")
@@ -239,6 +272,21 @@ public class ZoneSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The OCID of the private view containing the zone. This value will
+     * be null for zones in the global DNS, which are publicly resolvable and
+     * not part of a private view.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("viewId")
+    String viewId;
+
+    /**
+     * The scope of the zone.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scope")
+    Scope scope;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
@@ -275,7 +323,7 @@ public class ZoneSummary {
     String id;
 
     /**
-     * The date and time the resource was created in \"YYYY-MM-ddThh:mmZ\" format
+     * The date and time the resource was created in \"YYYY-MM-ddThh:mm:ssZ\" format
      * with a Z offset, as defined by RFC 3339.
      * <p>
      **Example:** `2016-07-22T17:23:59:60Z`
@@ -353,6 +401,13 @@ public class ZoneSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * A Boolean flag indicating whether or not parts of the resource are unable to be explicitly managed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isProtected")
+    Boolean isProtected;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeResolverCompartmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeResolverCompartmentRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeResolverCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeResolverCompartmentDetails> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * Details for moving a resolver, along with its protected default view and endpoints, into a
+     * different compartment.
+     *
+     */
+    private ChangeResolverCompartmentDetails changeResolverCompartmentDetails;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeResolverCompartmentDetails getBody$() {
+        return changeResolverCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeResolverCompartmentRequest, ChangeResolverCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeResolverCompartmentRequest o) {
+            resolverId(o.getResolverId());
+            changeResolverCompartmentDetails(o.getChangeResolverCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeResolverCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeResolverCompartmentRequest
+         */
+        public ChangeResolverCompartmentRequest build() {
+            ChangeResolverCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeResolverCompartmentDetails body) {
+            changeResolverCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeSteeringPolicyCompartmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeSteeringPolicyCompartmentRequest.java
@@ -52,6 +52,12 @@ public class ChangeSteeringPolicyCompartmentRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -102,6 +108,7 @@ public class ChangeSteeringPolicyCompartmentRequest
             ifMatch(o.getIfMatch());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeTsigKeyCompartmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeTsigKeyCompartmentRequest.java
@@ -52,6 +52,12 @@ public class ChangeTsigKeyCompartmentRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -101,6 +107,7 @@ public class ChangeTsigKeyCompartmentRequest
             ifMatch(o.getIfMatch());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeViewCompartmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeViewCompartmentRequest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeViewCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeViewCompartmentDetails> {
+
+    /**
+     * The OCID of the target view.
+     */
+    private String viewId;
+
+    /**
+     * Details for moving a view into a different compartment.
+     */
+    private ChangeViewCompartmentDetails changeViewCompartmentDetails;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeViewCompartmentDetails getBody$() {
+        return changeViewCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeViewCompartmentRequest, ChangeViewCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeViewCompartmentRequest o) {
+            viewId(o.getViewId());
+            changeViewCompartmentDetails(o.getChangeViewCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeViewCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeViewCompartmentRequest
+         */
+        public ChangeViewCompartmentRequest build() {
+            ChangeViewCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeViewCompartmentDetails body) {
+            changeViewCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeZoneCompartmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ChangeZoneCompartmentRequest.java
@@ -52,6 +52,12 @@ public class ChangeZoneCompartmentRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -101,6 +107,7 @@ public class ChangeZoneCompartmentRequest
             ifMatch(o.getIfMatch());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateResolverEndpointRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateResolverEndpointRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateResolverEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateResolverEndpointDetails> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * Details for creating a new resolver endpoint.
+     */
+    private CreateResolverEndpointDetails createResolverEndpointDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateResolverEndpointDetails getBody$() {
+        return createResolverEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateResolverEndpointRequest, CreateResolverEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateResolverEndpointRequest o) {
+            resolverId(o.getResolverId());
+            createResolverEndpointDetails(o.getCreateResolverEndpointDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateResolverEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateResolverEndpointRequest
+         */
+        public CreateResolverEndpointRequest build() {
+            CreateResolverEndpointRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateResolverEndpointDetails body) {
+            createResolverEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateSteeringPolicyAttachmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateSteeringPolicyAttachmentRequest.java
@@ -37,6 +37,12 @@ public class CreateSteeringPolicyAttachmentRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -84,6 +90,7 @@ public class CreateSteeringPolicyAttachmentRequest
             createSteeringPolicyAttachmentDetails(o.getCreateSteeringPolicyAttachmentDetails());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateSteeringPolicyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateSteeringPolicyRequest.java
@@ -37,6 +37,12 @@ public class CreateSteeringPolicyRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -84,6 +90,7 @@ public class CreateSteeringPolicyRequest
             createSteeringPolicyDetails(o.getCreateSteeringPolicyDetails());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateTsigKeyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateTsigKeyRequest.java
@@ -25,6 +25,12 @@ public class CreateTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<Cre
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -71,6 +77,7 @@ public class CreateTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<Cre
         public Builder copy(CreateTsigKeyRequest o) {
             createTsigKeyDetails(o.getCreateTsigKeyDetails());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateViewRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateViewRequest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateViewRequest extends com.oracle.bmc.requests.BmcRequest<CreateViewDetails> {
+
+    /**
+     * Details for creating a new view.
+     */
+    private CreateViewDetails createViewDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateViewDetails getBody$() {
+        return createViewDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateViewRequest, CreateViewDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateViewRequest o) {
+            createViewDetails(o.getCreateViewDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateViewRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateViewRequest
+         */
+        public CreateViewRequest build() {
+            CreateViewRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateViewDetails body) {
+            createViewDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateZoneRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/CreateZoneRequest.java
@@ -30,6 +30,17 @@ public class CreateZoneRequest extends com.oracle.bmc.requests.BmcRequest<Create
     private String compartmentId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -77,6 +88,8 @@ public class CreateZoneRequest extends com.oracle.bmc.requests.BmcRequest<Create
             createZoneDetails(o.getCreateZoneDetails());
             opcRequestId(o.getOpcRequestId());
             compartmentId(o.getCompartmentId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteDomainRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteDomainRecordsRequest.java
@@ -50,6 +50,17 @@ public class DeleteDomainRecordsRequest extends com.oracle.bmc.requests.BmcReque
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -94,6 +105,8 @@ public class DeleteDomainRecordsRequest extends com.oracle.bmc.requests.BmcReque
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteRRSetRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteRRSetRequest.java
@@ -59,6 +59,17 @@ public class DeleteRRSetRequest extends com.oracle.bmc.requests.BmcRequest<java.
      */
     private String compartmentId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     DeleteRRSetRequest, java.lang.Void> {
@@ -101,6 +112,8 @@ public class DeleteRRSetRequest extends com.oracle.bmc.requests.BmcRequest<java.
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
             compartmentId(o.getCompartmentId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteResolverEndpointRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteResolverEndpointRequest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteResolverEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * The name of the target resolver endpoint.
+     */
+    private String resolverEndpointName;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The `If-Unmodified-Since` header field makes the request method
+     * conditional on the selected representation's last modification date being
+     * earlier than or equal to the date provided in the field-value.  This
+     * field accomplishes the same purpose as If-Match for cases where the user
+     * agent does not have an entity-tag for the representation.
+     *
+     */
+    private String ifUnmodifiedSince;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteResolverEndpointRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteResolverEndpointRequest o) {
+            resolverId(o.getResolverId());
+            resolverEndpointName(o.getResolverEndpointName());
+            ifMatch(o.getIfMatch());
+            ifUnmodifiedSince(o.getIfUnmodifiedSince());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteResolverEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteResolverEndpointRequest
+         */
+        public DeleteResolverEndpointRequest build() {
+            DeleteResolverEndpointRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteSteeringPolicyAttachmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteSteeringPolicyAttachmentRequest.java
@@ -45,6 +45,12 @@ public class DeleteSteeringPolicyAttachmentRequest
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     DeleteSteeringPolicyAttachmentRequest, java.lang.Void> {
@@ -84,6 +90,7 @@ public class DeleteSteeringPolicyAttachmentRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteSteeringPolicyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteSteeringPolicyRequest.java
@@ -45,6 +45,12 @@ public class DeleteSteeringPolicyRequest
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     DeleteSteeringPolicyRequest, java.lang.Void> {
@@ -84,6 +90,7 @@ public class DeleteSteeringPolicyRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteTsigKeyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteTsigKeyRequest.java
@@ -44,6 +44,12 @@ public class DeleteTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<jav
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     DeleteTsigKeyRequest, java.lang.Void> {
@@ -83,6 +89,7 @@ public class DeleteTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<jav
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteViewRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteViewRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteViewRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target view.
+     */
+    private String viewId;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The `If-Unmodified-Since` header field makes the request method
+     * conditional on the selected representation's last modification date being
+     * earlier than or equal to the date provided in the field-value.  This
+     * field accomplishes the same purpose as If-Match for cases where the user
+     * agent does not have an entity-tag for the representation.
+     *
+     */
+    private String ifUnmodifiedSince;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteViewRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteViewRequest o) {
+            viewId(o.getViewId());
+            ifMatch(o.getIfMatch());
+            ifUnmodifiedSince(o.getIfUnmodifiedSince());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteViewRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteViewRequest
+         */
+        public DeleteViewRequest build() {
+            DeleteViewRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteZoneRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/DeleteZoneRequest.java
@@ -45,6 +45,17 @@ public class DeleteZoneRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -88,6 +99,8 @@ public class DeleteZoneRequest extends com.oracle.bmc.requests.BmcRequest<java.l
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetDomainRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetDomainRecordsRequest.java
@@ -73,6 +73,17 @@ public class GetDomainRecordsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String rtype;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The field by which to sort records.
      */
     private SortBy sortBy;
@@ -167,6 +178,8 @@ public class GetDomainRecordsRequest extends com.oracle.bmc.requests.BmcRequest<
             page(o.getPage());
             zoneVersion(o.getZoneVersion());
             rtype(o.getRtype());
+            scope(o.getScope());
+            viewId(o.getViewId());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             compartmentId(o.getCompartmentId());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetRRSetRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetRRSetRequest.java
@@ -75,6 +75,17 @@ public class GetRRSetRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
      */
     private String compartmentId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<GetRRSetRequest, java.lang.Void> {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
@@ -119,6 +130,8 @@ public class GetRRSetRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
             page(o.getPage());
             zoneVersion(o.getZoneVersion());
             compartmentId(o.getCompartmentId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetResolverEndpointRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetResolverEndpointRequest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetResolverEndpointRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * The name of the target resolver endpoint.
+     */
+    private String resolverEndpointName;
+
+    /**
+     * The `If-Modified-Since` header field makes a GET or HEAD request method
+     * conditional on the selected representation's modification date being more
+     * recent than the date provided in the field-value.  Transfer of the
+     * selected representation's data is avoided if that data has not changed.
+     *
+     */
+    private String ifModifiedSince;
+
+    /**
+     * The `If-None-Match` header field makes the request method conditional on
+     * the absence of any current representation of the target resource, when
+     * the field-value is `*`, or having a selected representation with an
+     * entity-tag that does not match any of those listed in the field-value.
+     *
+     */
+    private String ifNoneMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetResolverEndpointRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetResolverEndpointRequest o) {
+            resolverId(o.getResolverId());
+            resolverEndpointName(o.getResolverEndpointName());
+            ifModifiedSince(o.getIfModifiedSince());
+            ifNoneMatch(o.getIfNoneMatch());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetResolverEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetResolverEndpointRequest
+         */
+        public GetResolverEndpointRequest build() {
+            GetResolverEndpointRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetResolverRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetResolverRequest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetResolverRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * The `If-Modified-Since` header field makes a GET or HEAD request method
+     * conditional on the selected representation's modification date being more
+     * recent than the date provided in the field-value.  Transfer of the
+     * selected representation's data is avoided if that data has not changed.
+     *
+     */
+    private String ifModifiedSince;
+
+    /**
+     * The `If-None-Match` header field makes the request method conditional on
+     * the absence of any current representation of the target resource, when
+     * the field-value is `*`, or having a selected representation with an
+     * entity-tag that does not match any of those listed in the field-value.
+     *
+     */
+    private String ifNoneMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetResolverRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetResolverRequest o) {
+            resolverId(o.getResolverId());
+            ifModifiedSince(o.getIfModifiedSince());
+            ifNoneMatch(o.getIfNoneMatch());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetResolverRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetResolverRequest
+         */
+        public GetResolverRequest build() {
+            GetResolverRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetSteeringPolicyAttachmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetSteeringPolicyAttachmentRequest.java
@@ -43,6 +43,12 @@ public class GetSteeringPolicyAttachmentRequest
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     GetSteeringPolicyAttachmentRequest, java.lang.Void> {
@@ -82,6 +88,7 @@ public class GetSteeringPolicyAttachmentRequest
             ifNoneMatch(o.getIfNoneMatch());
             ifModifiedSince(o.getIfModifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetSteeringPolicyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetSteeringPolicyRequest.java
@@ -42,6 +42,12 @@ public class GetSteeringPolicyRequest extends com.oracle.bmc.requests.BmcRequest
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     GetSteeringPolicyRequest, java.lang.Void> {
@@ -81,6 +87,7 @@ public class GetSteeringPolicyRequest extends com.oracle.bmc.requests.BmcRequest
             ifNoneMatch(o.getIfNoneMatch());
             ifModifiedSince(o.getIfModifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetTsigKeyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetTsigKeyRequest.java
@@ -42,6 +42,12 @@ public class GetTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<java.l
      */
     private String opcRequestId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     GetTsigKeyRequest, java.lang.Void> {
@@ -81,6 +87,7 @@ public class GetTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<java.l
             ifNoneMatch(o.getIfNoneMatch());
             ifModifiedSince(o.getIfModifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetViewRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetViewRequest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetViewRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target view.
+     */
+    private String viewId;
+
+    /**
+     * The `If-Modified-Since` header field makes a GET or HEAD request method
+     * conditional on the selected representation's modification date being more
+     * recent than the date provided in the field-value.  Transfer of the
+     * selected representation's data is avoided if that data has not changed.
+     *
+     */
+    private String ifModifiedSince;
+
+    /**
+     * The `If-None-Match` header field makes the request method conditional on
+     * the absence of any current representation of the target resource, when
+     * the field-value is `*`, or having a selected representation with an
+     * entity-tag that does not match any of those listed in the field-value.
+     *
+     */
+    private String ifNoneMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<GetViewRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetViewRequest o) {
+            viewId(o.getViewId());
+            ifModifiedSince(o.getIfModifiedSince());
+            ifNoneMatch(o.getIfNoneMatch());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetViewRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetViewRequest
+         */
+        public GetViewRequest build() {
+            GetViewRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetZoneRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetZoneRecordsRequest.java
@@ -133,6 +133,17 @@ public class GetZoneRecordsRequest extends com.oracle.bmc.requests.BmcRequest<ja
      */
     private String compartmentId;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     GetZoneRecordsRequest, java.lang.Void> {
@@ -181,6 +192,8 @@ public class GetZoneRecordsRequest extends com.oracle.bmc.requests.BmcRequest<ja
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             compartmentId(o.getCompartmentId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetZoneRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/GetZoneRequest.java
@@ -43,6 +43,17 @@ public class GetZoneRequest extends com.oracle.bmc.requests.BmcRequest<java.lang
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -85,6 +96,8 @@ public class GetZoneRequest extends com.oracle.bmc.requests.BmcRequest<java.lang
             ifNoneMatch(o.getIfNoneMatch());
             ifModifiedSince(o.getIfModifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListResolverEndpointsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListResolverEndpointsRequest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListResolverEndpointsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The name of a resource.
+     */
+    private String name;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return in a page of the collection.
+     *
+     */
+    private Long limit;
+
+    /**
+     * The order to sort the resources.
+     *
+     */
+    private com.oracle.bmc.dns.model.SortOrder sortOrder;
+
+    /**
+     * The field by which to sort resolver endpoints.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field by which to sort resolver endpoints.
+     **/
+    public enum SortBy {
+        Name("name"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The state of a resource.
+     */
+    private ResolverEndpointSummary.LifecycleState lifecycleState;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListResolverEndpointsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListResolverEndpointsRequest o) {
+            resolverId(o.getResolverId());
+            opcRequestId(o.getOpcRequestId());
+            name(o.getName());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            lifecycleState(o.getLifecycleState());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListResolverEndpointsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListResolverEndpointsRequest
+         */
+        public ListResolverEndpointsRequest build() {
+            ListResolverEndpointsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListResolversRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListResolversRequest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListResolversRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the compartment the resource belongs to.
+     */
+    private String compartmentId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The displayName of a resource.
+     */
+    private String displayName;
+
+    /**
+     * The OCID of a resource.
+     */
+    private String id;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return in a page of the collection.
+     *
+     */
+    private Long limit;
+
+    /**
+     * The order to sort the resources.
+     *
+     */
+    private com.oracle.bmc.dns.model.SortOrder sortOrder;
+
+    /**
+     * The field by which to sort resolvers.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field by which to sort resolvers.
+     **/
+    public enum SortBy {
+        DisplayName("displayName"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The state of a resource.
+     */
+    private ResolverSummary.LifecycleState lifecycleState;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListResolversRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListResolversRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            displayName(o.getDisplayName());
+            id(o.getId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            lifecycleState(o.getLifecycleState());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListResolversRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListResolversRequest
+         */
+        public ListResolversRequest build() {
+            ListResolversRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListSteeringPoliciesRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListSteeringPoliciesRequest.java
@@ -134,6 +134,12 @@ public class ListSteeringPoliciesRequest
      */
     private com.oracle.bmc.dns.model.SortOrder sortOrder;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListSteeringPoliciesRequest, java.lang.Void> {
@@ -183,6 +189,7 @@ public class ListSteeringPoliciesRequest
             lifecycleState(o.getLifecycleState());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListSteeringPolicyAttachmentsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListSteeringPolicyAttachmentsRequest.java
@@ -141,6 +141,12 @@ public class ListSteeringPolicyAttachmentsRequest
      */
     private com.oracle.bmc.dns.model.SortOrder sortOrder;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListSteeringPolicyAttachmentsRequest, java.lang.Void> {
@@ -191,6 +197,7 @@ public class ListSteeringPolicyAttachmentsRequest
             lifecycleState(o.getLifecycleState());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListTsigKeysRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListTsigKeysRequest.java
@@ -97,6 +97,12 @@ public class ListTsigKeysRequest extends com.oracle.bmc.requests.BmcRequest<java
      */
     private com.oracle.bmc.dns.model.SortOrder sortOrder;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListTsigKeysRequest, java.lang.Void> {
@@ -141,6 +147,7 @@ public class ListTsigKeysRequest extends com.oracle.bmc.requests.BmcRequest<java
             lifecycleState(o.getLifecycleState());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListViewsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListViewsRequest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListViewsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the compartment the resource belongs to.
+     */
+    private String compartmentId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The displayName of a resource.
+     */
+    private String displayName;
+
+    /**
+     * The OCID of a resource.
+     */
+    private String id;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return in a page of the collection.
+     *
+     */
+    private Long limit;
+
+    /**
+     * The order to sort the resources.
+     *
+     */
+    private com.oracle.bmc.dns.model.SortOrder sortOrder;
+
+    /**
+     * The field by which to sort views.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field by which to sort views.
+     **/
+    public enum SortBy {
+        DisplayName("displayName"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The state of a resource.
+     */
+    private ViewSummary.LifecycleState lifecycleState;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListViewsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListViewsRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            displayName(o.getDisplayName());
+            id(o.getId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            lifecycleState(o.getLifecycleState());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListViewsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListViewsRequest
+         */
+        public ListViewsRequest build() {
+            ListViewsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListZonesRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/ListZonesRequest.java
@@ -198,6 +198,17 @@ public class ListZonesRequest extends com.oracle.bmc.requests.BmcRequest<java.la
      */
     private com.oracle.bmc.dns.model.SortOrder sortOrder;
 
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListZonesRequest, java.lang.Void> {
@@ -245,6 +256,8 @@ public class ListZonesRequest extends com.oracle.bmc.requests.BmcRequest<java.la
             lifecycleState(o.getLifecycleState());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
+            scope(o.getScope());
+            viewId(o.getViewId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchDomainRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchDomainRecordsRequest.java
@@ -56,6 +56,17 @@ public class PatchDomainRecordsRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -111,6 +122,8 @@ public class PatchDomainRecordsRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchRRSetRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchRRSetRequest.java
@@ -60,6 +60,17 @@ public class PatchRRSetRequest extends com.oracle.bmc.requests.BmcRequest<PatchR
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -116,6 +127,8 @@ public class PatchRRSetRequest extends com.oracle.bmc.requests.BmcRequest<PatchR
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchZoneRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/PatchZoneRecordsRequest.java
@@ -52,6 +52,17 @@ public class PatchZoneRecordsRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -106,6 +117,8 @@ public class PatchZoneRecordsRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateDomainRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateDomainRecordsRequest.java
@@ -56,6 +56,17 @@ public class UpdateDomainRecordsRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -111,6 +122,8 @@ public class UpdateDomainRecordsRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateRRSetRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateRRSetRequest.java
@@ -60,6 +60,17 @@ public class UpdateRRSetRequest extends com.oracle.bmc.requests.BmcRequest<Updat
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -116,6 +127,8 @@ public class UpdateRRSetRequest extends com.oracle.bmc.requests.BmcRequest<Updat
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateResolverEndpointRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateResolverEndpointRequest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateResolverEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateResolverEndpointDetails> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * The name of the target resolver endpoint.
+     */
+    private String resolverEndpointName;
+
+    /**
+     * New data for the resolver endpoint.
+     */
+    private UpdateResolverEndpointDetails updateResolverEndpointDetails;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The `If-Unmodified-Since` header field makes the request method
+     * conditional on the selected representation's last modification date being
+     * earlier than or equal to the date provided in the field-value.  This
+     * field accomplishes the same purpose as If-Match for cases where the user
+     * agent does not have an entity-tag for the representation.
+     *
+     */
+    private String ifUnmodifiedSince;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateResolverEndpointDetails getBody$() {
+        return updateResolverEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateResolverEndpointRequest, UpdateResolverEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateResolverEndpointRequest o) {
+            resolverId(o.getResolverId());
+            resolverEndpointName(o.getResolverEndpointName());
+            updateResolverEndpointDetails(o.getUpdateResolverEndpointDetails());
+            ifMatch(o.getIfMatch());
+            ifUnmodifiedSince(o.getIfUnmodifiedSince());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateResolverEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateResolverEndpointRequest
+         */
+        public UpdateResolverEndpointRequest build() {
+            UpdateResolverEndpointRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateResolverEndpointDetails body) {
+            updateResolverEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateResolverRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateResolverRequest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateResolverRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateResolverDetails> {
+
+    /**
+     * The OCID of the target resolver.
+     */
+    private String resolverId;
+
+    /**
+     * New data for the resolver.
+     */
+    private UpdateResolverDetails updateResolverDetails;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The `If-Unmodified-Since` header field makes the request method
+     * conditional on the selected representation's last modification date being
+     * earlier than or equal to the date provided in the field-value.  This
+     * field accomplishes the same purpose as If-Match for cases where the user
+     * agent does not have an entity-tag for the representation.
+     *
+     */
+    private String ifUnmodifiedSince;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateResolverDetails getBody$() {
+        return updateResolverDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateResolverRequest, UpdateResolverDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateResolverRequest o) {
+            resolverId(o.getResolverId());
+            updateResolverDetails(o.getUpdateResolverDetails());
+            ifMatch(o.getIfMatch());
+            ifUnmodifiedSince(o.getIfUnmodifiedSince());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateResolverRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateResolverRequest
+         */
+        public UpdateResolverRequest build() {
+            UpdateResolverRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateResolverDetails body) {
+            updateResolverDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateSteeringPolicyAttachmentRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateSteeringPolicyAttachmentRequest.java
@@ -51,6 +51,12 @@ public class UpdateSteeringPolicyAttachmentRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -100,6 +106,7 @@ public class UpdateSteeringPolicyAttachmentRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateSteeringPolicyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateSteeringPolicyRequest.java
@@ -51,6 +51,12 @@ public class UpdateSteeringPolicyRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -100,6 +106,7 @@ public class UpdateSteeringPolicyRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateTsigKeyRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateTsigKeyRequest.java
@@ -50,6 +50,12 @@ public class UpdateTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<Upd
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -99,6 +105,7 @@ public class UpdateTsigKeyRequest extends com.oracle.bmc.requests.BmcRequest<Upd
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateViewRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateViewRequest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.requests;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateViewRequest extends com.oracle.bmc.requests.BmcRequest<UpdateViewDetails> {
+
+    /**
+     * The OCID of the target view.
+     */
+    private String viewId;
+
+    /**
+     * New data for the view.
+     */
+    private UpdateViewDetails updateViewDetails;
+
+    /**
+     * The `If-Match` header field makes the request method conditional on the
+     * existence of at least one current representation of the target resource,
+     * when the field-value is `*`, or having a current representation of the
+     * target resource that has an entity-tag matching a member of the list of
+     * entity-tags provided in the field-value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The `If-Unmodified-Since` header field makes the request method
+     * conditional on the selected representation's last modification date being
+     * earlier than or equal to the date provided in the field-value.  This
+     * field accomplishes the same purpose as If-Match for cases where the user
+     * agent does not have an entity-tag for the representation.
+     *
+     */
+    private String ifUnmodifiedSince;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateViewDetails getBody$() {
+        return updateViewDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateViewRequest, UpdateViewDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateViewRequest o) {
+            viewId(o.getViewId());
+            updateViewDetails(o.getUpdateViewDetails());
+            ifMatch(o.getIfMatch());
+            ifUnmodifiedSince(o.getIfUnmodifiedSince());
+            opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateViewRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateViewRequest
+         */
+        public UpdateViewRequest build() {
+            UpdateViewRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateViewDetails body) {
+            updateViewDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateZoneRecordsRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateZoneRecordsRequest.java
@@ -51,6 +51,17 @@ public class UpdateZoneRecordsRequest
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -105,6 +116,8 @@ public class UpdateZoneRecordsRequest
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateZoneRequest.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/requests/UpdateZoneRequest.java
@@ -50,6 +50,17 @@ public class UpdateZoneRequest extends com.oracle.bmc.requests.BmcRequest<Update
     private String opcRequestId;
 
     /**
+     * Specifies to operate only on resources that have a matching DNS scope.
+     *
+     */
+    private com.oracle.bmc.dns.model.Scope scope;
+
+    /**
+     * The OCID of the view the resource is associated with.
+     */
+    private String viewId;
+
+    /**
      * The OCID of the compartment the resource belongs to.
      */
     private String compartmentId;
@@ -104,6 +115,8 @@ public class UpdateZoneRequest extends com.oracle.bmc.requests.BmcRequest<Update
             ifMatch(o.getIfMatch());
             ifUnmodifiedSince(o.getIfUnmodifiedSince());
             opcRequestId(o.getOpcRequestId());
+            scope(o.getScope());
+            viewId(o.getViewId());
             compartmentId(o.getCompartmentId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeResolverCompartmentResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeResolverCompartmentResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeResolverCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeResolverCompartmentResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeViewCompartmentResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeViewCompartmentResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeViewCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeViewCompartmentResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeZoneCompartmentResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ChangeZoneCompartmentResponse.java
@@ -19,6 +19,13 @@ public class ChangeZoneCompartmentResponse {
      */
     private String opcRequestId;
 
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
     public static class Builder {
         /**
          * Copy method to populate the builder with values from the given instance.
@@ -26,6 +33,7 @@ public class ChangeZoneCompartmentResponse {
          */
         public Builder copy(ChangeZoneCompartmentResponse o) {
             opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;
         }

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateResolverEndpointResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateResolverEndpointResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateResolverEndpointResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned ResolverEndpoint instance.
+     */
+    private ResolverEndpoint resolverEndpoint;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateResolverEndpointResponse o) {
+            etag(o.getEtag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            resolverEndpoint(o.getResolverEndpoint());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateSteeringPolicyAttachmentResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateSteeringPolicyAttachmentResponse.java
@@ -12,20 +12,26 @@ import com.oracle.bmc.dns.model.*;
 public class CreateSteeringPolicyAttachmentResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to
-     * contact Oracle about a particular request, please provide the request
-     * ID.
-     *
-     */
-    private String opcRequestId;
-
-    /**
      * The current version of the resource, ending with a
      * representation-specific suffix. This value may be used in If-Match
      * and If-None-Match headers for later requests of the same resource.
      *
      */
     private String eTag;
+
+    /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * ID.
+     *
+     */
+    private String opcRequestId;
 
     /**
      * The returned SteeringPolicyAttachment instance.
@@ -38,8 +44,9 @@ public class CreateSteeringPolicyAttachmentResponse {
          * @return this builder instance
          */
         public Builder copy(CreateSteeringPolicyAttachmentResponse o) {
-            opcRequestId(o.getOpcRequestId());
             eTag(o.getETag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
             steeringPolicyAttachment(o.getSteeringPolicyAttachment());
 
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateSteeringPolicyResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateSteeringPolicyResponse.java
@@ -12,20 +12,26 @@ import com.oracle.bmc.dns.model.*;
 public class CreateSteeringPolicyResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to
-     * contact Oracle about a particular request, please provide the request
-     * ID.
-     *
-     */
-    private String opcRequestId;
-
-    /**
      * The current version of the resource, ending with a
      * representation-specific suffix. This value may be used in If-Match
      * and If-None-Match headers for later requests of the same resource.
      *
      */
     private String eTag;
+
+    /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request
+     * ID.
+     *
+     */
+    private String opcRequestId;
 
     /**
      * The returned SteeringPolicy instance.
@@ -38,8 +44,9 @@ public class CreateSteeringPolicyResponse {
          * @return this builder instance
          */
         public Builder copy(CreateSteeringPolicyResponse o) {
-            opcRequestId(o.getOpcRequestId());
             eTag(o.getETag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
             steeringPolicy(o.getSteeringPolicy());
 
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateTsigKeyResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateTsigKeyResponse.java
@@ -20,12 +20,25 @@ public class CreateTsigKeyResponse {
     private String eTag;
 
     /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
      * Unique Oracle-assigned identifier for the request. If you need to
      * contact Oracle about a particular request, please provide the request
      * ID.
      *
      */
     private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
 
     /**
      * The returned TsigKey instance.
@@ -39,7 +52,9 @@ public class CreateTsigKeyResponse {
          */
         public Builder copy(CreateTsigKeyResponse o) {
             eTag(o.getETag());
+            location(o.getLocation());
             opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
             tsigKey(o.getTsigKey());
 
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateViewResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateViewResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateViewResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned View instance.
+     */
+    private View view;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateViewResponse o) {
+            etag(o.getEtag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            view(o.getView());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateZoneResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/CreateZoneResponse.java
@@ -12,6 +12,20 @@ import com.oracle.bmc.dns.model.*;
 public class CreateZoneResponse {
 
     /**
+     * The current version of the zone, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String eTag;
+
+    /**
+     * The full URI of the resource related to the request.
+     *
+     */
+    private String location;
+
+    /**
      * Unique Oracle-assigned identifier for the request. If you need to
      * contact Oracle about a particular request, please provide the request ID.
      *
@@ -19,12 +33,11 @@ public class CreateZoneResponse {
     private String opcRequestId;
 
     /**
-     * The current version of the zone, ending with a
-     * representation-specific suffix. This value may be used in If-Match
-     * and If-None-Match headers for later requests of the same resource.
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
      *
      */
-    private String eTag;
+    private String opcWorkRequestId;
 
     /**
      * The returned Zone instance.
@@ -37,8 +50,10 @@ public class CreateZoneResponse {
          * @return this builder instance
          */
         public Builder copy(CreateZoneResponse o) {
-            opcRequestId(o.getOpcRequestId());
             eTag(o.getETag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
             zone(o.getZone());
 
             return this;

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteResolverEndpointResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteResolverEndpointResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteResolverEndpointResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteResolverEndpointResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteViewResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteViewResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteViewResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need
+     * to contact Oracle about a particular request, please provide
+     * the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteViewResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteZoneResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/DeleteZoneResponse.java
@@ -19,6 +19,13 @@ public class DeleteZoneResponse {
      */
     private String opcRequestId;
 
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
     public static class Builder {
         /**
          * Copy method to populate the builder with values from the given instance.
@@ -26,6 +33,7 @@ public class DeleteZoneResponse {
          */
         public Builder copy(DeleteZoneResponse o) {
             opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
 
             return this;
         }

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetResolverEndpointResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetResolverEndpointResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetResolverEndpointResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ResolverEndpoint instance, or null if {@link #isNotModified()} is true.
+     */
+    private ResolverEndpoint resolverEndpoint;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetResolverEndpointResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            resolverEndpoint(o.getResolverEndpoint());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetResolverResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetResolverResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetResolverResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Resolver instance, or null if {@link #isNotModified()} is true.
+     */
+    private Resolver resolver;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetResolverResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            resolver(o.getResolver());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetViewResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/GetViewResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetViewResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned View instance, or null if {@link #isNotModified()} is true.
+     */
+    private View view;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetViewResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            view(o.getView());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListResolverEndpointsResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListResolverEndpointsResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListResolverEndpointsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of ResolverEndpointSummary instances.
+     */
+    private java.util.List<ResolverEndpointSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListResolverEndpointsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListResolversResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListResolversResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListResolversResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of ResolverSummary instances.
+     */
+    private java.util.List<ResolverSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListResolversResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListViewsResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/ListViewsResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListViewsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works,
+     * see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of ViewSummary instances.
+     */
+    private java.util.List<ViewSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListViewsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateResolverEndpointResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateResolverEndpointResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateResolverEndpointResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned ResolverEndpoint instance.
+     */
+    private ResolverEndpoint resolverEndpoint;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateResolverEndpointResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            resolverEndpoint(o.getResolverEndpoint());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateResolverResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateResolverResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateResolverResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned Resolver instance.
+     */
+    private Resolver resolver;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateResolverResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            resolver(o.getResolver());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateViewResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateViewResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dns.responses;
+
+import com.oracle.bmc.dns.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateViewResponse {
+
+    /**
+     * The current version of the resource, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to
+     * contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned View instance.
+     */
+    private View view;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateViewResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            view(o.getView());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateZoneResponse.java
+++ b/bmc-dns/src/main/java/com/oracle/bmc/dns/responses/UpdateZoneResponse.java
@@ -12,6 +12,14 @@ import com.oracle.bmc.dns.model.*;
 public class UpdateZoneResponse {
 
     /**
+     * The current version of the zone, ending with a
+     * representation-specific suffix. This value may be used in If-Match
+     * and If-None-Match headers for later requests of the same resource.
+     *
+     */
+    private String eTag;
+
+    /**
      * Unique Oracle-assigned identifier for the request. If you need to
      * contact Oracle about a particular request, please provide the request ID.
      *
@@ -19,12 +27,11 @@ public class UpdateZoneResponse {
     private String opcRequestId;
 
     /**
-     * The current version of the zone, ending with a
-     * representation-specific suffix. This value may be used in If-Match
-     * and If-None-Match headers for later requests of the same resource.
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
      *
      */
-    private String eTag;
+    private String opcWorkRequestId;
 
     /**
      * The returned Zone instance.
@@ -37,8 +44,9 @@ public class UpdateZoneResponse {
          * @return this builder instance
          */
         public Builder copy(UpdateZoneResponse o) {
-            opcRequestId(o.getOpcRequestId());
             eTag(o.getETag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
             zone(o.getZone());
 
             return this;

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.25.3</version>
+        <version>1.25.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpRequestHeaderRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpRequestHeaderRule.java
@@ -7,11 +7,12 @@ package com.oracle.bmc.loadbalancer.model;
 /**
  * An object that represents the action of adding a header to a request.
  * This rule applies only to HTTP listeners.
- * <p>
- **NOTES:**
+ * **NOTES:**
  * <p>
  *  If a matching header already exists in the request, the system removes all of its occurrences, and then adds the
  *    new header.
+ * <p>
+ * If a customer adds empty value, it has the same effect as dropping that header.
  * <p>
  *  The system does not distinquish between underscore and dash characters in headers. That is, it treats
  *   `example_header_name` and `example-header-name` as identical. Oracle recommends that you do not rely on underscore

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateLoadBalancerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateLoadBalancerDetails.java
@@ -74,6 +74,15 @@ public class CreateLoadBalancerDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("reservedIps")
+        private java.util.List<ReservedIP> reservedIps;
+
+        public Builder reservedIps(java.util.List<ReservedIP> reservedIps) {
+            this.reservedIps = reservedIps;
+            this.__explicitlySet__.add("reservedIps");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("listeners")
         private java.util.Map<String, ListenerDetails> listeners;
 
@@ -186,6 +195,7 @@ public class CreateLoadBalancerDetails {
                             shapeName,
                             isPrivate,
                             ipMode,
+                            reservedIps,
                             listeners,
                             hostnames,
                             backendSets,
@@ -209,6 +219,7 @@ public class CreateLoadBalancerDetails {
                             .shapeName(o.getShapeName())
                             .isPrivate(o.getIsPrivate())
                             .ipMode(o.getIpMode())
+                            .reservedIps(o.getReservedIps())
                             .listeners(o.getListeners())
                             .hostnames(o.getHostnames())
                             .backendSets(o.getBackendSets())
@@ -330,6 +341,13 @@ public class CreateLoadBalancerDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ipMode")
     IpMode ipMode;
+
+    /**
+     * An array of reserved Ips.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reservedIps")
+    java.util.List<ReservedIP> reservedIps;
 
     @com.fasterxml.jackson.annotation.JsonProperty("listeners")
     java.util.Map<String, ListenerDetails> listeners;

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/IpAddress.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/IpAddress.java
@@ -42,18 +42,30 @@ public class IpAddress {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("reservedIp")
+        private ReservedIP reservedIp;
+
+        public Builder reservedIp(ReservedIP reservedIp) {
+            this.reservedIp = reservedIp;
+            this.__explicitlySet__.add("reservedIp");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public IpAddress build() {
-            IpAddress __instance__ = new IpAddress(ipAddress, isPublic);
+            IpAddress __instance__ = new IpAddress(ipAddress, isPublic, reservedIp);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(IpAddress o) {
-            Builder copiedBuilder = ipAddress(o.getIpAddress()).isPublic(o.getIsPublic());
+            Builder copiedBuilder =
+                    ipAddress(o.getIpAddress())
+                            .isPublic(o.getIsPublic())
+                            .reservedIp(o.getReservedIp());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -86,6 +98,9 @@ public class IpAddress {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
     Boolean isPublic;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("reservedIp")
+    ReservedIP reservedIp;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RemoveHttpRequestHeaderRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RemoveHttpRequestHeaderRule.java
@@ -6,10 +6,8 @@ package com.oracle.bmc.loadbalancer.model;
 
 /**
  * An object that represents the action of removing a header from a request. This rule applies only to HTTP listeners.
- * <p>
  * If the same header appears more than once in the request, the load balancer removes all occurances of the specified header.
- * <p>
- **Note:** The system does not distinquish between underscore and dash characters in headers. That is, it treats
+ * **Note:** The system does not distinquish between underscore and dash characters in headers. That is, it treats
  * `example_header_name` and `example-header-name` as identical. Oracle recommends that you do not rely on underscore
  * or dash characters to uniquely distinguish header names.
  *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ReservedIP.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ReservedIP.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ReservedIP.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ReservedIP {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ReservedIP build() {
+            ReservedIP __instance__ = new ReservedIP(id);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ReservedIP o) {
+            Builder copiedBuilder = id(o.getId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateLoadBalancerShapeDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateLoadBalancerShapeDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.loadbalancer.model;
 
 /**
- * The configuration details for update a load balancer to a different shape.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -63,11 +62,13 @@ public class UpdateLoadBalancerShapeDetails {
     }
 
     /**
-     * A template that determines the total pre-provisioned bandwidth (ingress plus egress).
-     * To get a list of available shapes, use the {@link #listShapes(ListShapesRequest) listShapes}
-     * operation.
+     * The new shape name for the load balancer.
      * <p>
-     * Example: `100Mbps`
+     * Allowed values are :
+     *   *  10Mbps
+     *   *  100Mbps
+     *   *  400Mbps
+     *   *  8000Mbps
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shapeName")

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystem.java
@@ -46,6 +46,15 @@ public interface DbSystem extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Adds an Analytics Cluster to the DB System.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    AddAnalyticsClusterResponse addAnalyticsCluster(AddAnalyticsClusterRequest request);
+
+    /**
      * Creates and launches a DB System.
      *
      * @param request The request object containing the details to send
@@ -53,6 +62,16 @@ public interface DbSystem extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     CreateDbSystemResponse createDbSystem(CreateDbSystemRequest request);
+
+    /**
+     * Deletes the Analytics Cluster including terminating, detaching, removing, finalizing and
+     * otherwise deleting all related resources.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteAnalyticsClusterResponse deleteAnalyticsCluster(DeleteAnalyticsClusterRequest request);
 
     /**
      * Delete a DB System, including terminating, detaching,
@@ -63,6 +82,35 @@ public interface DbSystem extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     DeleteDbSystemResponse deleteDbSystem(DeleteDbSystemRequest request);
+
+    /**
+     * Sends a request to estimate the memory footprints of user tables when loaded to Analytics Cluster memory.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GenerateAnalyticsClusterMemoryEstimateResponse generateAnalyticsClusterMemoryEstimate(
+            GenerateAnalyticsClusterMemoryEstimateRequest request);
+
+    /**
+     * Gets information about the Analytics Cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetAnalyticsClusterResponse getAnalyticsCluster(GetAnalyticsClusterRequest request);
+
+    /**
+     * Gets the most recent Analytics Cluster memory estimate that can be used to determine a suitable
+     * Analytics Cluster size.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetAnalyticsClusterMemoryEstimateResponse getAnalyticsClusterMemoryEstimate(
+            GetAnalyticsClusterMemoryEstimateRequest request);
 
     /**
      * Get information about the specified DB System.
@@ -83,6 +131,14 @@ public interface DbSystem extends AutoCloseable {
     ListDbSystemsResponse listDbSystems(ListDbSystemsRequest request);
 
     /**
+     * Restarts the Analytics Cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    RestartAnalyticsClusterResponse restartAnalyticsCluster(RestartAnalyticsClusterRequest request);
+
+    /**
      * Restarts the specified DB System.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -91,12 +147,28 @@ public interface DbSystem extends AutoCloseable {
     RestartDbSystemResponse restartDbSystem(RestartDbSystemRequest request);
 
     /**
+     * Starts the Analytics Cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    StartAnalyticsClusterResponse startAnalyticsCluster(StartAnalyticsClusterRequest request);
+
+    /**
      * Start the specified DB System.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
      */
     StartDbSystemResponse startDbSystem(StartDbSystemRequest request);
+
+    /**
+     * Stops the Analytics Cluster.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    StopAnalyticsClusterResponse stopAnalyticsCluster(StopAnalyticsClusterRequest request);
 
     /**
      * Stops the specified DB System.
@@ -108,6 +180,15 @@ public interface DbSystem extends AutoCloseable {
      * @throws BmcException when an error occurs.
      */
     StopDbSystemResponse stopDbSystem(StopDbSystemRequest request);
+
+    /**
+     * Updates the Analytics Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateAnalyticsClusterResponse updateAnalyticsCluster(UpdateAnalyticsClusterRequest request);
 
     /**
      * Update the configuration of a DB System.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemAsync.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemAsync.java
@@ -46,6 +46,23 @@ public interface DbSystemAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Adds an Analytics Cluster to the DB System.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AddAnalyticsClusterResponse> addAnalyticsCluster(
+            AddAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            AddAnalyticsClusterRequest, AddAnalyticsClusterResponse>
+                    handler);
+
+    /**
      * Creates and launches a DB System.
      *
      *
@@ -59,6 +76,24 @@ public interface DbSystemAsync extends AutoCloseable {
     java.util.concurrent.Future<CreateDbSystemResponse> createDbSystem(
             CreateDbSystemRequest request,
             com.oracle.bmc.responses.AsyncHandler<CreateDbSystemRequest, CreateDbSystemResponse>
+                    handler);
+
+    /**
+     * Deletes the Analytics Cluster including terminating, detaching, removing, finalizing and
+     * otherwise deleting all related resources.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteAnalyticsClusterResponse> deleteAnalyticsCluster(
+            DeleteAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteAnalyticsClusterRequest, DeleteAnalyticsClusterResponse>
                     handler);
 
     /**
@@ -77,6 +112,61 @@ public interface DbSystemAsync extends AutoCloseable {
             DeleteDbSystemRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeleteDbSystemRequest, DeleteDbSystemResponse>
                     handler);
+
+    /**
+     * Sends a request to estimate the memory footprints of user tables when loaded to Analytics Cluster memory.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GenerateAnalyticsClusterMemoryEstimateResponse>
+            generateAnalyticsClusterMemoryEstimate(
+                    GenerateAnalyticsClusterMemoryEstimateRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateAnalyticsClusterMemoryEstimateRequest,
+                                    GenerateAnalyticsClusterMemoryEstimateResponse>
+                            handler);
+
+    /**
+     * Gets information about the Analytics Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAnalyticsClusterResponse> getAnalyticsCluster(
+            GetAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+                    handler);
+
+    /**
+     * Gets the most recent Analytics Cluster memory estimate that can be used to determine a suitable
+     * Analytics Cluster size.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAnalyticsClusterMemoryEstimateResponse>
+            getAnalyticsClusterMemoryEstimate(
+                    GetAnalyticsClusterMemoryEstimateRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetAnalyticsClusterMemoryEstimateRequest,
+                                    GetAnalyticsClusterMemoryEstimateResponse>
+                            handler);
 
     /**
      * Get information about the specified DB System.
@@ -110,6 +200,22 @@ public interface DbSystemAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Restarts the Analytics Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RestartAnalyticsClusterResponse> restartAnalyticsCluster(
+            RestartAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RestartAnalyticsClusterRequest, RestartAnalyticsClusterResponse>
+                    handler);
+
+    /**
      * Restarts the specified DB System.
      *
      * @param request The request object containing the details to send
@@ -122,6 +228,22 @@ public interface DbSystemAsync extends AutoCloseable {
     java.util.concurrent.Future<RestartDbSystemResponse> restartDbSystem(
             RestartDbSystemRequest request,
             com.oracle.bmc.responses.AsyncHandler<RestartDbSystemRequest, RestartDbSystemResponse>
+                    handler);
+
+    /**
+     * Starts the Analytics Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<StartAnalyticsClusterResponse> startAnalyticsCluster(
+            StartAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            StartAnalyticsClusterRequest, StartAnalyticsClusterResponse>
                     handler);
 
     /**
@@ -140,6 +262,22 @@ public interface DbSystemAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Stops the Analytics Cluster.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<StopAnalyticsClusterResponse> stopAnalyticsCluster(
+            StopAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            StopAnalyticsClusterRequest, StopAnalyticsClusterResponse>
+                    handler);
+
+    /**
      * Stops the specified DB System.
      * <p>
      * A stopped DB System is not billed.
@@ -155,6 +293,23 @@ public interface DbSystemAsync extends AutoCloseable {
     java.util.concurrent.Future<StopDbSystemResponse> stopDbSystem(
             StopDbSystemRequest request,
             com.oracle.bmc.responses.AsyncHandler<StopDbSystemRequest, StopDbSystemResponse>
+                    handler);
+
+    /**
+     * Updates the Analytics Cluster.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateAnalyticsClusterResponse> updateAnalyticsCluster(
+            UpdateAnalyticsClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterResponse>
                     handler);
 
     /**

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemAsyncClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemAsyncClient.java
@@ -325,6 +325,48 @@ public class DbSystemAsyncClient implements DbSystemAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AddAnalyticsClusterResponse> addAnalyticsCluster(
+            AddAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            AddAnalyticsClusterRequest, AddAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async addAnalyticsCluster");
+        final AddAnalyticsClusterRequest interceptedRequest =
+                AddAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AddAnalyticsClusterResponse>
+                transformer = AddAnalyticsClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AddAnalyticsClusterRequest, AddAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                AddAnalyticsClusterRequest, AddAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<AddAnalyticsClusterResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    AddAnalyticsClusterRequest, AddAnalyticsClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateDbSystemResponse> createDbSystem(
             CreateDbSystemRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -365,6 +407,47 @@ public class DbSystemAsyncClient implements DbSystemAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteAnalyticsClusterResponse> deleteAnalyticsCluster(
+            DeleteAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteAnalyticsClusterRequest, DeleteAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async deleteAnalyticsCluster");
+        final DeleteAnalyticsClusterRequest interceptedRequest =
+                DeleteAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteAnalyticsClusterResponse>
+                transformer = DeleteAnalyticsClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteAnalyticsClusterRequest, DeleteAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteAnalyticsClusterRequest, DeleteAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<DeleteAnalyticsClusterResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteAnalyticsClusterRequest, DeleteAnalyticsClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteDbSystemResponse> deleteDbSystem(
             DeleteDbSystemRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -391,6 +474,141 @@ public class DbSystemAsyncClient implements DbSystemAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteDbSystemRequest, DeleteDbSystemResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GenerateAnalyticsClusterMemoryEstimateResponse>
+            generateAnalyticsClusterMemoryEstimate(
+                    GenerateAnalyticsClusterMemoryEstimateRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateAnalyticsClusterMemoryEstimateRequest,
+                                    GenerateAnalyticsClusterMemoryEstimateResponse>
+                            handler) {
+        LOG.trace("Called async generateAnalyticsClusterMemoryEstimate");
+        final GenerateAnalyticsClusterMemoryEstimateRequest interceptedRequest =
+                GenerateAnalyticsClusterMemoryEstimateConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateAnalyticsClusterMemoryEstimateConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateAnalyticsClusterMemoryEstimateResponse>
+                transformer = GenerateAnalyticsClusterMemoryEstimateConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GenerateAnalyticsClusterMemoryEstimateRequest,
+                        GenerateAnalyticsClusterMemoryEstimateResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GenerateAnalyticsClusterMemoryEstimateRequest,
+                                GenerateAnalyticsClusterMemoryEstimateResponse>,
+                        java.util.concurrent.Future<GenerateAnalyticsClusterMemoryEstimateResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GenerateAnalyticsClusterMemoryEstimateRequest,
+                    GenerateAnalyticsClusterMemoryEstimateResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetAnalyticsClusterResponse> getAnalyticsCluster(
+            GetAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async getAnalyticsCluster");
+        final GetAnalyticsClusterRequest interceptedRequest =
+                GetAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetAnalyticsClusterResponse>
+                transformer = GetAnalyticsClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<GetAnalyticsClusterResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetAnalyticsClusterMemoryEstimateResponse>
+            getAnalyticsClusterMemoryEstimate(
+                    GetAnalyticsClusterMemoryEstimateRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetAnalyticsClusterMemoryEstimateRequest,
+                                    GetAnalyticsClusterMemoryEstimateResponse>
+                            handler) {
+        LOG.trace("Called async getAnalyticsClusterMemoryEstimate");
+        final GetAnalyticsClusterMemoryEstimateRequest interceptedRequest =
+                GetAnalyticsClusterMemoryEstimateConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAnalyticsClusterMemoryEstimateConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetAnalyticsClusterMemoryEstimateResponse>
+                transformer = GetAnalyticsClusterMemoryEstimateConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetAnalyticsClusterMemoryEstimateRequest,
+                        GetAnalyticsClusterMemoryEstimateResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAnalyticsClusterMemoryEstimateRequest,
+                                GetAnalyticsClusterMemoryEstimateResponse>,
+                        java.util.concurrent.Future<GetAnalyticsClusterMemoryEstimateResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAnalyticsClusterMemoryEstimateRequest,
+                    GetAnalyticsClusterMemoryEstimateResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -480,6 +698,48 @@ public class DbSystemAsyncClient implements DbSystemAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<RestartAnalyticsClusterResponse> restartAnalyticsCluster(
+            RestartAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RestartAnalyticsClusterRequest, RestartAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async restartAnalyticsCluster");
+        final RestartAnalyticsClusterRequest interceptedRequest =
+                RestartAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RestartAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RestartAnalyticsClusterResponse>
+                transformer = RestartAnalyticsClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RestartAnalyticsClusterRequest, RestartAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RestartAnalyticsClusterRequest, RestartAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<RestartAnalyticsClusterResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RestartAnalyticsClusterRequest, RestartAnalyticsClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RestartDbSystemResponse> restartDbSystem(
             RestartDbSystemRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -507,6 +767,48 @@ public class DbSystemAsyncClient implements DbSystemAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     RestartDbSystemRequest, RestartDbSystemResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<StartAnalyticsClusterResponse> startAnalyticsCluster(
+            StartAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            StartAnalyticsClusterRequest, StartAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async startAnalyticsCluster");
+        final StartAnalyticsClusterRequest interceptedRequest =
+                StartAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StartAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, StartAnalyticsClusterResponse>
+                transformer = StartAnalyticsClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        StartAnalyticsClusterRequest, StartAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                StartAnalyticsClusterRequest, StartAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<StartAnalyticsClusterResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    StartAnalyticsClusterRequest, StartAnalyticsClusterResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -559,6 +861,48 @@ public class DbSystemAsyncClient implements DbSystemAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<StopAnalyticsClusterResponse> stopAnalyticsCluster(
+            StopAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            StopAnalyticsClusterRequest, StopAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async stopAnalyticsCluster");
+        final StopAnalyticsClusterRequest interceptedRequest =
+                StopAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StopAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, StopAnalyticsClusterResponse>
+                transformer = StopAnalyticsClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        StopAnalyticsClusterRequest, StopAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                StopAnalyticsClusterRequest, StopAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<StopAnalyticsClusterResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    StopAnalyticsClusterRequest, StopAnalyticsClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<StopDbSystemResponse> stopDbSystem(
             StopDbSystemRequest request,
             final com.oracle.bmc.responses.AsyncHandler<StopDbSystemRequest, StopDbSystemResponse>
@@ -585,6 +929,47 @@ public class DbSystemAsyncClient implements DbSystemAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     StopDbSystemRequest, StopDbSystemResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateAnalyticsClusterResponse> updateAnalyticsCluster(
+            UpdateAnalyticsClusterRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterResponse>
+                    handler) {
+        LOG.trace("Called async updateAnalyticsCluster");
+        final UpdateAnalyticsClusterRequest interceptedRequest =
+                UpdateAnalyticsClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateAnalyticsClusterResponse>
+                transformer = UpdateAnalyticsClusterConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterResponse>,
+                        java.util.concurrent.Future<UpdateAnalyticsClusterResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemClient.java
@@ -441,6 +441,39 @@ public class DbSystemClient implements DbSystem {
     }
 
     @Override
+    public AddAnalyticsClusterResponse addAnalyticsCluster(AddAnalyticsClusterRequest request) {
+        LOG.trace("Called addAnalyticsCluster");
+        final AddAnalyticsClusterRequest interceptedRequest =
+                AddAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AddAnalyticsClusterResponse>
+                transformer = AddAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAddAnalyticsClusterDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateDbSystemResponse createDbSystem(CreateDbSystemRequest request) {
         LOG.trace("Called createDbSystem");
         final CreateDbSystemRequest interceptedRequest =
@@ -474,6 +507,36 @@ public class DbSystemClient implements DbSystem {
     }
 
     @Override
+    public DeleteAnalyticsClusterResponse deleteAnalyticsCluster(
+            DeleteAnalyticsClusterRequest request) {
+        LOG.trace("Called deleteAnalyticsCluster");
+        final DeleteAnalyticsClusterRequest interceptedRequest =
+                DeleteAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteAnalyticsClusterResponse>
+                transformer = DeleteAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteDbSystemResponse deleteDbSystem(DeleteDbSystemRequest request) {
         LOG.trace("Called deleteDbSystem");
         final DeleteDbSystemRequest interceptedRequest =
@@ -497,6 +560,97 @@ public class DbSystemClient implements DbSystem {
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
                                         client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GenerateAnalyticsClusterMemoryEstimateResponse generateAnalyticsClusterMemoryEstimate(
+            GenerateAnalyticsClusterMemoryEstimateRequest request) {
+        LOG.trace("Called generateAnalyticsClusterMemoryEstimate");
+        final GenerateAnalyticsClusterMemoryEstimateRequest interceptedRequest =
+                GenerateAnalyticsClusterMemoryEstimateConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateAnalyticsClusterMemoryEstimateConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateAnalyticsClusterMemoryEstimateResponse>
+                transformer = GenerateAnalyticsClusterMemoryEstimateConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetAnalyticsClusterResponse getAnalyticsCluster(GetAnalyticsClusterRequest request) {
+        LOG.trace("Called getAnalyticsCluster");
+        final GetAnalyticsClusterRequest interceptedRequest =
+                GetAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetAnalyticsClusterResponse>
+                transformer = GetAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetAnalyticsClusterMemoryEstimateResponse getAnalyticsClusterMemoryEstimate(
+            GetAnalyticsClusterMemoryEstimateRequest request) {
+        LOG.trace("Called getAnalyticsClusterMemoryEstimate");
+        final GetAnalyticsClusterMemoryEstimateRequest interceptedRequest =
+                GetAnalyticsClusterMemoryEstimateConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAnalyticsClusterMemoryEstimateConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetAnalyticsClusterMemoryEstimateResponse>
+                transformer = GetAnalyticsClusterMemoryEstimateConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -559,6 +713,37 @@ public class DbSystemClient implements DbSystem {
     }
 
     @Override
+    public RestartAnalyticsClusterResponse restartAnalyticsCluster(
+            RestartAnalyticsClusterRequest request) {
+        LOG.trace("Called restartAnalyticsCluster");
+        final RestartAnalyticsClusterRequest interceptedRequest =
+                RestartAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RestartAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RestartAnalyticsClusterResponse>
+                transformer = RestartAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RestartDbSystemResponse restartDbSystem(RestartDbSystemRequest request) {
         LOG.trace("Called restartDbSystem");
         final RestartDbSystemRequest interceptedRequest =
@@ -592,6 +777,37 @@ public class DbSystemClient implements DbSystem {
     }
 
     @Override
+    public StartAnalyticsClusterResponse startAnalyticsCluster(
+            StartAnalyticsClusterRequest request) {
+        LOG.trace("Called startAnalyticsCluster");
+        final StartAnalyticsClusterRequest interceptedRequest =
+                StartAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StartAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, StartAnalyticsClusterResponse>
+                transformer = StartAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public StartDbSystemResponse startDbSystem(StartDbSystemRequest request) {
         LOG.trace("Called startDbSystem");
         final StartDbSystemRequest interceptedRequest =
@@ -600,6 +816,36 @@ public class DbSystemClient implements DbSystem {
                 StartDbSystemConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, StartDbSystemResponse>
                 transformer = StartDbSystemConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public StopAnalyticsClusterResponse stopAnalyticsCluster(StopAnalyticsClusterRequest request) {
+        LOG.trace("Called stopAnalyticsCluster");
+        final StopAnalyticsClusterRequest interceptedRequest =
+                StopAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StopAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, StopAnalyticsClusterResponse>
+                transformer = StopAnalyticsClusterConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -648,6 +894,39 @@ public class DbSystemClient implements DbSystem {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getStopDbSystemDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateAnalyticsClusterResponse updateAnalyticsCluster(
+            UpdateAnalyticsClusterRequest request) {
+        LOG.trace("Called updateAnalyticsCluster");
+        final UpdateAnalyticsClusterRequest interceptedRequest =
+                UpdateAnalyticsClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateAnalyticsClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateAnalyticsClusterResponse>
+                transformer = UpdateAnalyticsClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateAnalyticsClusterDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemWaiters.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbSystemWaiters.java
@@ -26,6 +26,110 @@ public class DbSystemWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+            forAnalyticsCluster(
+                    GetAnalyticsClusterRequest request,
+                    com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forAnalyticsCluster(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+            forAnalyticsCluster(
+                    GetAnalyticsClusterRequest request,
+                    com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forAnalyticsCluster(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+            forAnalyticsCluster(
+                    GetAnalyticsClusterRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forAnalyticsCluster(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for AnalyticsCluster.
+    private com.oracle.bmc.waiter.Waiter<GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>
+            forAnalyticsCluster(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetAnalyticsClusterRequest request,
+                    final com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetAnalyticsClusterRequest, GetAnalyticsClusterResponse>() {
+                            @Override
+                            public GetAnalyticsClusterResponse apply(
+                                    GetAnalyticsClusterRequest request) {
+                                return client.getAnalyticsCluster(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetAnalyticsClusterResponse>() {
+                            @Override
+                            public boolean apply(GetAnalyticsClusterResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getAnalyticsCluster().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.mysql.model.AnalyticsCluster.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetDbSystemRequest, GetDbSystemResponse> forDbSystem(
             GetDbSystemRequest request,
             com.oracle.bmc.mysql.model.DbSystem.LifecycleState... targetStates) {

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/AddAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/AddAnalyticsClusterConverter.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class AddAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.AddAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.AddAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.AddAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+        Validate.notNull(
+                request.getAddAnalyticsClusterDetails(), "addAnalyticsClusterDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster")
+                        .path("actions")
+                        .path("add");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AnalyticsCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AnalyticsCluster.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AnalyticsCluster>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .AddAnalyticsClusterResponse.builder();
+
+                                builder.analyticsCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.AddAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/DeleteAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/DeleteAnalyticsClusterConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class DeleteAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.DeleteAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.DeleteAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.DeleteAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .DeleteAnalyticsClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.DeleteAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GenerateAnalyticsClusterMemoryEstimateConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GenerateAnalyticsClusterMemoryEstimateConverter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class GenerateAnalyticsClusterMemoryEstimateConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.GenerateAnalyticsClusterMemoryEstimateRequest
+            interceptRequest(
+                    com.oracle.bmc.mysql.requests.GenerateAnalyticsClusterMemoryEstimateRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.GenerateAnalyticsClusterMemoryEstimateRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsClusterMemoryEstimate")
+                        .path("actions")
+                        .path("generate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.GenerateAnalyticsClusterMemoryEstimateResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses
+                                .GenerateAnalyticsClusterMemoryEstimateResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses
+                                        .GenerateAnalyticsClusterMemoryEstimateResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses
+                                            .GenerateAnalyticsClusterMemoryEstimateResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.GenerateAnalyticsClusterMemoryEstimateResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AnalyticsClusterMemoryEstimate>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AnalyticsClusterMemoryEstimate.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AnalyticsClusterMemoryEstimate>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses
+                                                .GenerateAnalyticsClusterMemoryEstimateResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .GenerateAnalyticsClusterMemoryEstimateResponse
+                                                        .builder();
+
+                                builder.analyticsClusterMemoryEstimate(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses
+                                                .GenerateAnalyticsClusterMemoryEstimateResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetAnalyticsClusterConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class GetAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.GetAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.GetAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.GetAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfNoneMatch() != null) {
+            ib.header("if-none-match", request.getIfNoneMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AnalyticsCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AnalyticsCluster.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AnalyticsCluster>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .GetAnalyticsClusterResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.analyticsCluster(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.GetAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetAnalyticsClusterMemoryEstimateConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetAnalyticsClusterMemoryEstimateConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class GetAnalyticsClusterMemoryEstimateConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.GetAnalyticsClusterMemoryEstimateRequest
+            interceptRequest(
+                    com.oracle.bmc.mysql.requests.GetAnalyticsClusterMemoryEstimateRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.GetAnalyticsClusterMemoryEstimateRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsClusterMemoryEstimate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.GetAnalyticsClusterMemoryEstimateResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.GetAnalyticsClusterMemoryEstimateResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses
+                                        .GetAnalyticsClusterMemoryEstimateResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses
+                                            .GetAnalyticsClusterMemoryEstimateResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.GetAnalyticsClusterMemoryEstimateResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AnalyticsClusterMemoryEstimate>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AnalyticsClusterMemoryEstimate.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AnalyticsClusterMemoryEstimate>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses
+                                                .GetAnalyticsClusterMemoryEstimateResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .GetAnalyticsClusterMemoryEstimateResponse
+                                                        .builder();
+
+                                builder.analyticsClusterMemoryEstimate(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses
+                                                .GetAnalyticsClusterMemoryEstimateResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListDbSystemsConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListDbSystemsConverter.java
@@ -32,6 +32,14 @@ public class ListDbSystemsConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20190415").path("dbSystems");
 
+        if (request.getIsAnalyticsClusterAttached() != null) {
+            target =
+                    target.queryParam(
+                            "isAnalyticsClusterAttached",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsAnalyticsClusterAttached()));
+        }
+
         target =
                 target.queryParam(
                         "compartmentId",

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListShapesConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListShapesConverter.java
@@ -32,6 +32,15 @@ public class ListShapesConverter {
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20190415").path("shapes");
 
+        if (request.getIsSupportedFor() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "isSupportedFor",
+                            request.getIsSupportedFor(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
         if (request.getAvailabilityDomain() != null) {
             target =
                     target.queryParam(

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/RestartAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/RestartAnalyticsClusterConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class RestartAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.RestartAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.RestartAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.RestartAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster")
+                        .path("actions")
+                        .path("restart");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .RestartAnalyticsClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.RestartAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/StartAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/StartAnalyticsClusterConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class StartAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.StartAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.StartAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.StartAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster")
+                        .path("actions")
+                        .path("start");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .StartAnalyticsClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.StartAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/StopAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/StopAnalyticsClusterConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class StopAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.StopAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.StopAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.StopAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster")
+                        .path("actions")
+                        .path("stop");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .StopAnalyticsClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.StopAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/UpdateAnalyticsClusterConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/UpdateAnalyticsClusterConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class UpdateAnalyticsClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.UpdateAnalyticsClusterRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.UpdateAnalyticsClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.UpdateAnalyticsClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDbSystemId(), "dbSystemId must not be blank");
+        Validate.notNull(
+                request.getUpdateAnalyticsClusterDetails(),
+                "updateAnalyticsClusterDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("dbSystems")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbSystemId()))
+                        .path("analyticsCluster");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .UpdateAnalyticsClusterResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.UpdateAnalyticsClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AddAnalyticsClusterDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AddAnalyticsClusterDetails.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Details required to add an Analytics Cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AddAnalyticsClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AddAnalyticsClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+        private Integer clusterSize;
+
+        public Builder clusterSize(Integer clusterSize) {
+            this.clusterSize = clusterSize;
+            this.__explicitlySet__.add("clusterSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AddAnalyticsClusterDetails build() {
+            AddAnalyticsClusterDetails __instance__ =
+                    new AddAnalyticsClusterDetails(shapeName, clusterSize);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AddAnalyticsClusterDetails o) {
+            Builder copiedBuilder = shapeName(o.getShapeName()).clusterSize(o.getClusterSize());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shape determines resources to allocate to the Analytics
+     * Cluster nodes - CPU cores, memory.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * The number of analytics-processing nodes provisioned for the
+     * Analytics Cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+    Integer clusterSize;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsCluster.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsCluster.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * An Analytics Cluster is a database accelerator for a DB System.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AnalyticsCluster.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsCluster {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+        private Integer clusterSize;
+
+        public Builder clusterSize(Integer clusterSize) {
+            this.clusterSize = clusterSize;
+            this.__explicitlySet__.add("clusterSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterNodes")
+        private java.util.List<AnalyticsClusterNode> clusterNodes;
+
+        public Builder clusterNodes(java.util.List<AnalyticsClusterNode> clusterNodes) {
+            this.clusterNodes = clusterNodes;
+            this.__explicitlySet__.add("clusterNodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsCluster build() {
+            AnalyticsCluster __instance__ =
+                    new AnalyticsCluster(
+                            dbSystemId,
+                            shapeName,
+                            clusterSize,
+                            clusterNodes,
+                            lifecycleState,
+                            lifecycleDetails,
+                            timeCreated,
+                            timeUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsCluster o) {
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .shapeName(o.getShapeName())
+                            .clusterSize(o.getClusterSize())
+                            .clusterNodes(o.getClusterNodes())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the parent DB System this Analytics Cluster is attached to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    /**
+     * The shape determines resources to allocate to the Analytics
+     * Cluster nodes - CPU cores, memory.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * The number of analytics-processing compute instances, of the
+     * specified shape, in the Analytics Cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+    Integer clusterSize;
+
+    /**
+     * An Analytics Cluster Node is a compute host that is part of an Analytics Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterNodes")
+    java.util.List<AnalyticsClusterNode> clusterNodes;
+    /**
+     * The current state of the Analytics Cluster.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Analytics Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycleState.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The date and time the Analytics Cluster was created, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the Analytics Cluster was last updated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterMemoryEstimate.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterMemoryEstimate.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Analytics Cluster memory estimate
+ * that can be used to determine a suitable Analytics Cluster size. For each MySQL user table the estimated memory
+ * footprint when the table is loaded to the Analytics Cluster memory is returned.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AnalyticsClusterMemoryEstimate.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsClusterMemoryEstimate {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private AnalyticsClusterMemoryEstimateStatus status;
+
+        public Builder status(AnalyticsClusterMemoryEstimateStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tableSchemas")
+        private java.util.List<AnalyticsClusterSchemaMemoryEstimate> tableSchemas;
+
+        public Builder tableSchemas(
+                java.util.List<AnalyticsClusterSchemaMemoryEstimate> tableSchemas) {
+            this.tableSchemas = tableSchemas;
+            this.__explicitlySet__.add("tableSchemas");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsClusterMemoryEstimate build() {
+            AnalyticsClusterMemoryEstimate __instance__ =
+                    new AnalyticsClusterMemoryEstimate(
+                            dbSystemId, status, timeCreated, timeUpdated, tableSchemas);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsClusterMemoryEstimate o) {
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .status(o.getStatus())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .tableSchemas(o.getTableSchemas());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the DB System the Analytics Cluster memory estimate is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    /**
+     * Current status of the Work Request generating the Analytics Cluster memory estimate.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    AnalyticsClusterMemoryEstimateStatus status;
+
+    /**
+     * The date and time that the Work Request to generate the Analytics Cluster memory estimate was issued, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc333).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time that the Analytics Cluster memory estimate was generated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc333).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * Collection of schemas with estimated memory footprints for MySQL user tables of each schema
+     * when loaded to Analytics Cluster memory.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tableSchemas")
+    java.util.List<AnalyticsClusterSchemaMemoryEstimate> tableSchemas;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterMemoryEstimateStatus.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterMemoryEstimateStatus.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Possible operation status.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public enum AnalyticsClusterMemoryEstimateStatus {
+    Accepted("ACCEPTED"),
+    InProgress("IN_PROGRESS"),
+    Failed("FAILED"),
+    Succeeded("SUCCEEDED"),
+    Canceling("CANCELING"),
+    Canceled("CANCELED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, AnalyticsClusterMemoryEstimateStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (AnalyticsClusterMemoryEstimateStatus v :
+                AnalyticsClusterMemoryEstimateStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    AnalyticsClusterMemoryEstimateStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AnalyticsClusterMemoryEstimateStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'AnalyticsClusterMemoryEstimateStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterNode.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterNode.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * An Analytics Cluster Node is a compute host that is part of an Analytics Cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AnalyticsClusterNode.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsClusterNode {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeId")
+        private String nodeId;
+
+        public Builder nodeId(String nodeId) {
+            this.nodeId = nodeId;
+            this.__explicitlySet__.add("nodeId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsClusterNode build() {
+            AnalyticsClusterNode __instance__ =
+                    new AnalyticsClusterNode(nodeId, lifecycleState, timeCreated, timeUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsClusterNode o) {
+            Builder copiedBuilder =
+                    nodeId(o.getNodeId())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The ID of the node within MySQL Analytics Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeId")
+    String nodeId;
+    /**
+     * The current state of the MySQL Analytics Cluster node.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the MySQL Analytics Cluster node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The date and time the MySQL Analytics Cluster node was created, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the MySQL Analytics Cluster node was updated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterSchemaMemoryEstimate.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterSchemaMemoryEstimate.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Schema with estimated memory footprints for each MySQL user table
+ * of the schema when loaded to Analytics Cluster memory.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AnalyticsClusterSchemaMemoryEstimate.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsClusterSchemaMemoryEstimate {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaName")
+        private String schemaName;
+
+        public Builder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            this.__explicitlySet__.add("schemaName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("perTableEstimates")
+        private java.util.List<AnalyticsClusterTableMemoryEstimate> perTableEstimates;
+
+        public Builder perTableEstimates(
+                java.util.List<AnalyticsClusterTableMemoryEstimate> perTableEstimates) {
+            this.perTableEstimates = perTableEstimates;
+            this.__explicitlySet__.add("perTableEstimates");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsClusterSchemaMemoryEstimate build() {
+            AnalyticsClusterSchemaMemoryEstimate __instance__ =
+                    new AnalyticsClusterSchemaMemoryEstimate(schemaName, perTableEstimates);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsClusterSchemaMemoryEstimate o) {
+            Builder copiedBuilder =
+                    schemaName(o.getSchemaName()).perTableEstimates(o.getPerTableEstimates());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the schema.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaName")
+    String schemaName;
+
+    /**
+     * Estimated memory footprints for MySQL user tables of the schema
+     * when loaded to Analytics Cluster memory.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("perTableEstimates")
+    java.util.List<AnalyticsClusterTableMemoryEstimate> perTableEstimates;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterSummary.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * A summary of an Analytics Cluster.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AnalyticsClusterSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsClusterSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+        private Integer clusterSize;
+
+        public Builder clusterSize(Integer clusterSize) {
+            this.clusterSize = clusterSize;
+            this.__explicitlySet__.add("clusterSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private AnalyticsCluster.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(AnalyticsCluster.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsClusterSummary build() {
+            AnalyticsClusterSummary __instance__ =
+                    new AnalyticsClusterSummary(
+                            shapeName, clusterSize, lifecycleState, timeCreated, timeUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsClusterSummary o) {
+            Builder copiedBuilder =
+                    shapeName(o.getShapeName())
+                            .clusterSize(o.getClusterSize())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shape determines resources to allocate to the Analytics
+     * Cluster nodes - CPU cores, memory.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * The number of analytics-processing compute instances, of the
+     * specified shape, in the Analytics Cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+    Integer clusterSize;
+
+    /**
+     * The current state of the MySQL Analytics Cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    AnalyticsCluster.LifecycleState lifecycleState;
+
+    /**
+     * The date and time the Analytics Cluster was created, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the Analytics Cluster was last updated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterTableMemoryEstimate.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/AnalyticsClusterTableMemoryEstimate.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Estimated memory footprint for a MySQL user table
+ * when loaded to the Analytics Cluster memory.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AnalyticsClusterTableMemoryEstimate.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AnalyticsClusterTableMemoryEstimate {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("tableName")
+        private String tableName;
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            this.__explicitlySet__.add("tableName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("toLoadColumnCount")
+        private Integer toLoadColumnCount;
+
+        public Builder toLoadColumnCount(Integer toLoadColumnCount) {
+            this.toLoadColumnCount = toLoadColumnCount;
+            this.__explicitlySet__.add("toLoadColumnCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("varlenColumnCount")
+        private Integer varlenColumnCount;
+
+        public Builder varlenColumnCount(Integer varlenColumnCount) {
+            this.varlenColumnCount = varlenColumnCount;
+            this.__explicitlySet__.add("varlenColumnCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedRowCount")
+        private Long estimatedRowCount;
+
+        public Builder estimatedRowCount(Long estimatedRowCount) {
+            this.estimatedRowCount = estimatedRowCount;
+            this.__explicitlySet__.add("estimatedRowCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("analyticalFootprintInMbs")
+        private Long analyticalFootprintInMbs;
+
+        public Builder analyticalFootprintInMbs(Long analyticalFootprintInMbs) {
+            this.analyticalFootprintInMbs = analyticalFootprintInMbs;
+            this.__explicitlySet__.add("analyticalFootprintInMbs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorComment")
+        private String errorComment;
+
+        public Builder errorComment(String errorComment) {
+            this.errorComment = errorComment;
+            this.__explicitlySet__.add("errorComment");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AnalyticsClusterTableMemoryEstimate build() {
+            AnalyticsClusterTableMemoryEstimate __instance__ =
+                    new AnalyticsClusterTableMemoryEstimate(
+                            tableName,
+                            toLoadColumnCount,
+                            varlenColumnCount,
+                            estimatedRowCount,
+                            analyticalFootprintInMbs,
+                            errorComment);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AnalyticsClusterTableMemoryEstimate o) {
+            Builder copiedBuilder =
+                    tableName(o.getTableName())
+                            .toLoadColumnCount(o.getToLoadColumnCount())
+                            .varlenColumnCount(o.getVarlenColumnCount())
+                            .estimatedRowCount(o.getEstimatedRowCount())
+                            .analyticalFootprintInMbs(o.getAnalyticalFootprintInMbs())
+                            .errorComment(o.getErrorComment());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The table name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tableName")
+    String tableName;
+
+    /**
+     * The number of columns to be loaded to Analytics Cluster memory.
+     * These columns contribute to the analytical memory footprint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("toLoadColumnCount")
+    Integer toLoadColumnCount;
+
+    /**
+     * The number of variable-length columns to be loaded to Analytics Cluster memory.
+     * These columns contribute to the analytical memory footprint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("varlenColumnCount")
+    Integer varlenColumnCount;
+
+    /**
+     * The estimated number of rows in the table. This number was used to
+     * derive the analytical memory footprint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedRowCount")
+    Long estimatedRowCount;
+
+    /**
+     * The estimated memory footprint of the table in MBs when loaded to
+     * Analytics Cluster memory (null if the table cannot be loaded to the
+     * Analytics Cluster).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("analyticalFootprintInMbs")
+    Long analyticalFootprintInMbs;
+
+    /**
+     * Error comment (empty string if no errors occured).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorComment")
+    String errorComment;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
@@ -70,6 +70,24 @@ public class DbSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAnalyticsClusterAttached")
+        private Boolean isAnalyticsClusterAttached;
+
+        public Builder isAnalyticsClusterAttached(Boolean isAnalyticsClusterAttached) {
+            this.isAnalyticsClusterAttached = isAnalyticsClusterAttached;
+            this.__explicitlySet__.add("isAnalyticsClusterAttached");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("analyticsCluster")
+        private AnalyticsClusterSummary analyticsCluster;
+
+        public Builder analyticsCluster(AnalyticsClusterSummary analyticsCluster) {
+            this.analyticsCluster = analyticsCluster;
+            this.__explicitlySet__.add("analyticsCluster");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
         private String availabilityDomain;
 
@@ -262,6 +280,8 @@ public class DbSystem {
                             description,
                             compartmentId,
                             subnetId,
+                            isAnalyticsClusterAttached,
+                            analyticsCluster,
                             availabilityDomain,
                             faultDomain,
                             shapeName,
@@ -294,6 +314,8 @@ public class DbSystem {
                             .description(o.getDescription())
                             .compartmentId(o.getCompartmentId())
                             .subnetId(o.getSubnetId())
+                            .isAnalyticsClusterAttached(o.getIsAnalyticsClusterAttached())
+                            .analyticsCluster(o.getAnalyticsCluster())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .faultDomain(o.getFaultDomain())
                             .shapeName(o.getShapeName())
@@ -357,6 +379,16 @@ public class DbSystem {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;
+
+    /**
+     * If the DB System has an Analytics Cluster attached.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAnalyticsClusterAttached")
+    Boolean isAnalyticsClusterAttached;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("analyticsCluster")
+    AnalyticsClusterSummary analyticsCluster;
 
     /**
      * The Availability Domain where the primary DB System should be located.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
@@ -61,6 +61,24 @@ public class DbSystemSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAnalyticsClusterAttached")
+        private Boolean isAnalyticsClusterAttached;
+
+        public Builder isAnalyticsClusterAttached(Boolean isAnalyticsClusterAttached) {
+            this.isAnalyticsClusterAttached = isAnalyticsClusterAttached;
+            this.__explicitlySet__.add("isAnalyticsClusterAttached");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("analyticsCluster")
+        private AnalyticsClusterSummary analyticsCluster;
+
+        public Builder analyticsCluster(AnalyticsClusterSummary analyticsCluster) {
+            this.analyticsCluster = analyticsCluster;
+            this.__explicitlySet__.add("analyticsCluster");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
         private String availabilityDomain;
 
@@ -153,6 +171,8 @@ public class DbSystemSummary {
                             displayName,
                             description,
                             compartmentId,
+                            isAnalyticsClusterAttached,
+                            analyticsCluster,
                             availabilityDomain,
                             faultDomain,
                             endpoints,
@@ -173,6 +193,8 @@ public class DbSystemSummary {
                             .displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .compartmentId(o.getCompartmentId())
+                            .isAnalyticsClusterAttached(o.getIsAnalyticsClusterAttached())
+                            .analyticsCluster(o.getAnalyticsCluster())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .faultDomain(o.getFaultDomain())
                             .endpoints(o.getEndpoints())
@@ -218,6 +240,16 @@ public class DbSystemSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * If the DB System has an Analytics Cluster attached.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAnalyticsClusterAttached")
+    Boolean isAnalyticsClusterAttached;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("analyticsCluster")
+    AnalyticsClusterSummary analyticsCluster;
 
     /**
      * The Availability Domain where the primary DB System should be located.

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ShapeSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ShapeSummary.java
@@ -55,11 +55,21 @@ public class ShapeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isSupportedFor")
+        private java.util.List<IsSupportedFor> isSupportedFor;
+
+        public Builder isSupportedFor(java.util.List<IsSupportedFor> isSupportedFor) {
+            this.isSupportedFor = isSupportedFor;
+            this.__explicitlySet__.add("isSupportedFor");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ShapeSummary build() {
-            ShapeSummary __instance__ = new ShapeSummary(name, cpuCoreCount, memorySizeInGBs);
+            ShapeSummary __instance__ =
+                    new ShapeSummary(name, cpuCoreCount, memorySizeInGBs, isSupportedFor);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,7 +79,8 @@ public class ShapeSummary {
             Builder copiedBuilder =
                     name(o.getName())
                             .cpuCoreCount(o.getCpuCoreCount())
-                            .memorySizeInGBs(o.getMemorySizeInGBs());
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .isSupportedFor(o.getIsSupportedFor());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -100,6 +111,57 @@ public class ShapeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
     Integer memorySizeInGBs;
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum IsSupportedFor {
+        Dbsystem("DBSYSTEM"),
+        Analyticscluster("ANALYTICSCLUSTER"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, IsSupportedFor> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (IsSupportedFor v : IsSupportedFor.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        IsSupportedFor(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static IsSupportedFor create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'IsSupportedFor', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * What service features the shape is supported for.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSupportedFor")
+    java.util.List<IsSupportedFor> isSupportedFor;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateAnalyticsClusterDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateAnalyticsClusterDetails.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Details about the Analytics Cluster properties to be updated.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateAnalyticsClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateAnalyticsClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+        private Integer clusterSize;
+
+        public Builder clusterSize(Integer clusterSize) {
+            this.clusterSize = clusterSize;
+            this.__explicitlySet__.add("clusterSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateAnalyticsClusterDetails build() {
+            UpdateAnalyticsClusterDetails __instance__ =
+                    new UpdateAnalyticsClusterDetails(shapeName, clusterSize);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateAnalyticsClusterDetails o) {
+            Builder copiedBuilder = shapeName(o.getShapeName()).clusterSize(o.getClusterSize());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A change to the shape of the nodes in the Analytics Cluster will
+     * result in the entire cluster being torn down and re-created with
+     * Compute instances of the new Shape. This may result in significant
+     * downtime for the analytics capability while the Analytics Cluster is
+     * re-provisioned.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * A change to the number of nodes in the Analytics Cluster will result
+     * in the entire cluster being torn down and re-created with the new
+     * cluster of nodes. This may result in a significant downtime for the
+     * analytics capability while the Analytics Cluster is
+     * re-provisioned.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+    Integer clusterSize;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/WorkRequestOperationType.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/WorkRequestOperationType.java
@@ -16,6 +16,13 @@ public enum WorkRequestOperationType {
     StartDbsystem("START_DBSYSTEM"),
     StopDbsystem("STOP_DBSYSTEM"),
     RestartDbsystem("RESTART_DBSYSTEM"),
+    AddAnalyticsCluster("ADD_ANALYTICS_CLUSTER"),
+    UpdateAnalyticsCluster("UPDATE_ANALYTICS_CLUSTER"),
+    DeleteAnalyticsCluster("DELETE_ANALYTICS_CLUSTER"),
+    StartAnalyticsCluster("START_ANALYTICS_CLUSTER"),
+    StopAnalyticsCluster("STOP_ANALYTICS_CLUSTER"),
+    RestartAnalyticsCluster("RESTART_ANALYTICS_CLUSTER"),
+    GenerateAnalyticsClusterMemoryEstimate("GENERATE_ANALYTICS_CLUSTER_MEMORY_ESTIMATE"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/AddAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/AddAnalyticsClusterRequest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AddAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<AddAnalyticsClusterDetails> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * Request to add an Analytics Cluster.
+     */
+    private AddAnalyticsClusterDetails addAnalyticsClusterDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public AddAnalyticsClusterDetails getBody$() {
+        return addAnalyticsClusterDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AddAnalyticsClusterRequest, AddAnalyticsClusterDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            addAnalyticsClusterDetails(o.getAddAnalyticsClusterDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AddAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AddAnalyticsClusterRequest
+         */
+        public AddAnalyticsClusterRequest build() {
+            AddAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(AddAnalyticsClusterDetails body) {
+            addAnalyticsClusterDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/DeleteAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/DeleteAnalyticsClusterRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteAnalyticsClusterRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteAnalyticsClusterRequest
+         */
+        public DeleteAnalyticsClusterRequest build() {
+            DeleteAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GenerateAnalyticsClusterMemoryEstimateRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GenerateAnalyticsClusterMemoryEstimateRequest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GenerateAnalyticsClusterMemoryEstimateRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GenerateAnalyticsClusterMemoryEstimateRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateAnalyticsClusterMemoryEstimateRequest o) {
+            dbSystemId(o.getDbSystemId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GenerateAnalyticsClusterMemoryEstimateRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GenerateAnalyticsClusterMemoryEstimateRequest
+         */
+        public GenerateAnalyticsClusterMemoryEstimateRequest build() {
+            GenerateAnalyticsClusterMemoryEstimateRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetAnalyticsClusterMemoryEstimateRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetAnalyticsClusterMemoryEstimateRequest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetAnalyticsClusterMemoryEstimateRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAnalyticsClusterMemoryEstimateRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAnalyticsClusterMemoryEstimateRequest o) {
+            dbSystemId(o.getDbSystemId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAnalyticsClusterMemoryEstimateRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAnalyticsClusterMemoryEstimateRequest
+         */
+        public GetAnalyticsClusterMemoryEstimateRequest build() {
+            GetAnalyticsClusterMemoryEstimateRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetAnalyticsClusterRequest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetAnalyticsClusterRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For conditional requests. In the GET call for a resource, set the
+     * `If-None-Match` header to the value of the ETag from a previous GET (or
+     * POST or PUT) response for that resource. The server will return with
+     * either a 304 Not Modified response if the resource has not changed, or a
+     * 200 OK response with the updated representation.
+     *
+     */
+    private String ifNoneMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAnalyticsClusterRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            opcRequestId(o.getOpcRequestId());
+            ifNoneMatch(o.getIfNoneMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAnalyticsClusterRequest
+         */
+        public GetAnalyticsClusterRequest build() {
+            GetAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListDbSystemsRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListDbSystemsRequest.java
@@ -25,6 +25,14 @@ public class ListDbSystemsRequest extends com.oracle.bmc.requests.BmcRequest<jav
     private String opcRequestId;
 
     /**
+     * If true, return only DB Systems with an Analytics Cluster attached, if false
+     * return only DB Systems with no Analytics Cluster attached. If not
+     * present, return all DB Systems.
+     *
+     */
+    private Boolean isAnalyticsClusterAttached;
+
+    /**
      * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
      */
     private String dbSystemId;
@@ -185,6 +193,7 @@ public class ListDbSystemsRequest extends com.oracle.bmc.requests.BmcRequest<jav
         public Builder copy(ListDbSystemsRequest o) {
             compartmentId(o.getCompartmentId());
             opcRequestId(o.getOpcRequestId());
+            isAnalyticsClusterAttached(o.getIsAnalyticsClusterAttached());
             dbSystemId(o.getDbSystemId());
             displayName(o.getDisplayName());
             lifecycleState(o.getLifecycleState());

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListShapesRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListShapesRequest.java
@@ -25,6 +25,48 @@ public class ListShapesRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     private String opcRequestId;
 
     /**
+     * Return shapes that are supported by the service feature.
+     *
+     */
+    private java.util.List<IsSupportedFor> isSupportedFor;
+
+    /**
+     * Return shapes that are supported by the service feature.
+     *
+     **/
+    public enum IsSupportedFor {
+        Dbsystem("DBSYSTEM"),
+        Analyticscluster("ANALYTICSCLUSTER"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, IsSupportedFor> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (IsSupportedFor v : IsSupportedFor.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        IsSupportedFor(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static IsSupportedFor create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid IsSupportedFor: " + key);
+        }
+    };
+    /**
      * The name of the Availability Domain.
      */
     private String availabilityDomain;
@@ -71,6 +113,7 @@ public class ListShapesRequest extends com.oracle.bmc.requests.BmcRequest<java.l
         public Builder copy(ListShapesRequest o) {
             compartmentId(o.getCompartmentId());
             opcRequestId(o.getOpcRequestId());
+            isSupportedFor(o.getIsSupportedFor());
             availabilityDomain(o.getAvailabilityDomain());
             name(o.getName());
             invocationCallback(o.getInvocationCallback());

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/RestartAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/RestartAnalyticsClusterRequest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class RestartAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RestartAnalyticsClusterRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RestartAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RestartAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RestartAnalyticsClusterRequest
+         */
+        public RestartAnalyticsClusterRequest build() {
+            RestartAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/StartAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/StartAnalyticsClusterRequest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class StartAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    StartAnalyticsClusterRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StartAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of StartAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of StartAnalyticsClusterRequest
+         */
+        public StartAnalyticsClusterRequest build() {
+            StartAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/StopAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/StopAnalyticsClusterRequest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class StopAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    StopAnalyticsClusterRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StopAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of StopAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of StopAnalyticsClusterRequest
+         */
+        public StopAnalyticsClusterRequest build() {
+            StopAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/UpdateAnalyticsClusterRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/UpdateAnalyticsClusterRequest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateAnalyticsClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateAnalyticsClusterDetails> {
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * Request to update an Analytics Cluster.
+     */
+    private UpdateAnalyticsClusterDetails updateAnalyticsClusterDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateAnalyticsClusterDetails getBody$() {
+        return updateAnalyticsClusterDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateAnalyticsClusterRequest, UpdateAnalyticsClusterDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateAnalyticsClusterRequest o) {
+            dbSystemId(o.getDbSystemId());
+            updateAnalyticsClusterDetails(o.getUpdateAnalyticsClusterDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateAnalyticsClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateAnalyticsClusterRequest
+         */
+        public UpdateAnalyticsClusterRequest build() {
+            UpdateAnalyticsClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateAnalyticsClusterDetails body) {
+            updateAnalyticsClusterDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/AddAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/AddAnalyticsClusterResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AddAnalyticsClusterResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AnalyticsCluster instance.
+     */
+    private AnalyticsCluster analyticsCluster;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddAnalyticsClusterResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            analyticsCluster(o.getAnalyticsCluster());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteAnalyticsClusterResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteAnalyticsClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteAnalyticsClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GenerateAnalyticsClusterMemoryEstimateResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GenerateAnalyticsClusterMemoryEstimateResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GenerateAnalyticsClusterMemoryEstimateResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AnalyticsClusterMemoryEstimate instance.
+     */
+    private AnalyticsClusterMemoryEstimate analyticsClusterMemoryEstimate;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateAnalyticsClusterMemoryEstimateResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            analyticsClusterMemoryEstimate(o.getAnalyticsClusterMemoryEstimate());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterMemoryEstimateResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterMemoryEstimateResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetAnalyticsClusterMemoryEstimateResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AnalyticsClusterMemoryEstimate instance.
+     */
+    private AnalyticsClusterMemoryEstimate analyticsClusterMemoryEstimate;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAnalyticsClusterMemoryEstimateResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            analyticsClusterMemoryEstimate(o.getAnalyticsClusterMemoryEstimate());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetAnalyticsClusterResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AnalyticsCluster instance, or null if {@link #isNotModified()} is true.
+     */
+    private AnalyticsCluster analyticsCluster;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAnalyticsClusterResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            analyticsCluster(o.getAnalyticsCluster());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartAnalyticsClusterResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class RestartAnalyticsClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RestartAnalyticsClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartAnalyticsClusterResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class StartAnalyticsClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StartAnalyticsClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopAnalyticsClusterResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class StopAnalyticsClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StopAnalyticsClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateAnalyticsClusterResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateAnalyticsClusterResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a specific request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * OCID of the WorkRequest associated with this operation.
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateAnalyticsClusterResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.25.3</version>
+    <version>1.25.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.25.3</version>
+      <version>1.25.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.25.3</version>
+  <version>1.25.4</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for the 21C autonomous database version in the Database service

- Support for creating a Data Guard association with a standby database from a database software image in the Database service

- Support for specifying a TDE wallet password when creating a database or database system in the Database service

- Support for enabling access control lists for autonomous databases on Exadata Cloud At Customer in the Database service

- Support for private DNS resolvers, resolver endpoints, and views in the DNS service

- Support for getting a VCN and resolver association in the Networking service

- Support for additional parameters when updating subnets and VLANs in the Networking service

- Support for analytics clusters (database accelerators) in the MySQL Database service

- Support for migrations to Java Cloud Service and Oracle Weblogic Server instances that use existing databases in the Application Migration service

- Support for specifying reserved IPs when creating load balancers in the Load Balancing service