### PR TITLE
Releasing version 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.27.0 - 2020-12-1
+### Added
+- Support for calling Oracle Cloud Infrastructure services in the sa-santiago-1 region
+- Support for peer and OSN resources, as well as retry tokens, in the Blockchain Platform service
+- Support for getting the availability status of management agents in the Management Agent service
+- Support for the on-prem-connector resource type in the Data Safe service
+- Support for service channels in the MySQL Database service
+- Support for getting the creation type of backups, and for filtering backups by creation type in the MySQL Database service
+
+### Breaking Changes
+- Method `public java.util.Map getDefinedTags()` has been removed from EnableDataSafeConfigurationDetails in the Data Safe service
+- Method `public java.util.Map getFreeformTags()` has been removed from EnableDataSafeConfigurationDetails in the Data Safe service
+
 ## 1.26.0 - 2020-11-17
 ### Added
 - Support for specifying memory for AMD E3 shapes during node pool creation and update in the Container Engine for Kubernetes service

--- a/README.md
+++ b/README.md
@@ -49,7 +49,16 @@ Oracle gratefully acknowledges the contributions to oci-java-sdk that have been 
 
 ## Known Issues
 
-You can find information on any known issues with the SDK [here](https://docs.cloud.oracle.com/iaas/Content/knownissues.htm) and under the “Issues” tab of this GitHub repository.
+You can find information on any known issues with the SDK [here](https://docs.cloud.oracle.com/iaas/Content/knownissues.htm) and under the [“Issues” tab of this GitHub repository](https://github.com/oracle/oci-java-sdk/issues).
+
+### Potential data corruption issue with OCI Java SDK on binary data upload with `RefreshableOnNotAuthenticatedProvider`
+
+**Details**: When using version 1.25.1 or earlier of the OCI Java SDK clients that upload streams of data (for example `ObjectStorageClient` or `FunctionsInvokeClient`), either synchronously and asynchronously, and you use a `RefreshableOnNotAuthenticatedProvider` (for example, for Resource Principals or Instance Principals) you may be affected by **silent data corruption**.
+
+**Workaround**: Update the OCI Java SDK client to version 1.25.2 or later. For more information about this issue and workarounds, see [Potential data corruption issue for OCI Java SDK on binary data upload with `RefreshableOnNotAuthenticatedProvider`](https://github.com/oracle/oci-java-sdk/issues/255).
+
+**Direct link to this issue**: [Potential data corruption issue with OCI Java SDK on binary data upload with `RefreshableOnNotAuthenticatedProvider`](https://docs.cloud.oracle.com/en-us/iaas/Content/knownissues.htm#javaSDKStreamDataCorrupt)
+
 
 ## License
 

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/BlockchainPlatformAsyncClient.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/BlockchainPlatformAsyncClient.java
@@ -1129,6 +1129,7 @@ public class BlockchainPlatformAsyncClient implements BlockchainPlatformAsync {
         final com.google.common.base.Function<
                         javax.ws.rs.core.Response, StartBlockchainPlatformResponse>
                 transformer = StartBlockchainPlatformConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
 
         com.oracle.bmc.responses.AsyncHandler<
                         StartBlockchainPlatformRequest, StartBlockchainPlatformResponse>
@@ -1170,6 +1171,7 @@ public class BlockchainPlatformAsyncClient implements BlockchainPlatformAsync {
         final com.google.common.base.Function<
                         javax.ws.rs.core.Response, StopBlockchainPlatformResponse>
                 transformer = StopBlockchainPlatformConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
 
         com.oracle.bmc.responses.AsyncHandler<
                         StopBlockchainPlatformRequest, StopBlockchainPlatformResponse>
@@ -1211,6 +1213,7 @@ public class BlockchainPlatformAsyncClient implements BlockchainPlatformAsync {
         final com.google.common.base.Function<
                         javax.ws.rs.core.Response, UpdateBlockchainPlatformResponse>
                 transformer = UpdateBlockchainPlatformConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
 
         com.oracle.bmc.responses.AsyncHandler<
                         UpdateBlockchainPlatformRequest, UpdateBlockchainPlatformResponse>
@@ -1286,6 +1289,7 @@ public class BlockchainPlatformAsyncClient implements BlockchainPlatformAsync {
                 UpdatePeerConverter.fromRequest(client, interceptedRequest);
         final com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePeerResponse>
                 transformer = UpdatePeerConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
 
         com.oracle.bmc.responses.AsyncHandler<UpdatePeerRequest, UpdatePeerResponse> handlerToUse =
                 handler;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/BlockchainPlatformClient.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/BlockchainPlatformClient.java
@@ -1053,6 +1053,7 @@ public class BlockchainPlatformClient implements BlockchainPlatform {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {
@@ -1083,6 +1084,7 @@ public class BlockchainPlatformClient implements BlockchainPlatform {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {
@@ -1113,6 +1115,7 @@ public class BlockchainPlatformClient implements BlockchainPlatform {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {
@@ -1176,6 +1179,7 @@ public class BlockchainPlatformClient implements BlockchainPlatform {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/StartBlockchainPlatformConverter.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/StartBlockchainPlatformConverter.java
@@ -53,6 +53,10 @@ public class StartBlockchainPlatformConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
         return ib;
     }
 

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/StopBlockchainPlatformConverter.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/StopBlockchainPlatformConverter.java
@@ -52,6 +52,10 @@ public class StopBlockchainPlatformConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
         return ib;
     }
 

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/UpdateBlockchainPlatformConverter.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/UpdateBlockchainPlatformConverter.java
@@ -54,6 +54,10 @@ public class UpdateBlockchainPlatformConverter {
             ib.header("if-match", request.getIfMatch());
         }
 
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
         return ib;
     }
 

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/UpdatePeerConverter.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/internal/http/UpdatePeerConverter.java
@@ -56,6 +56,10 @@ public class UpdatePeerConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
         return ib;
     }
 

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatform.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatform.java
@@ -116,6 +116,15 @@ public class BlockchainPlatform {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("platformShapeType")
+        private PlatformShapeType platformShapeType;
+
+        public Builder platformShapeType(PlatformShapeType platformShapeType) {
+            this.platformShapeType = platformShapeType;
+            this.__explicitlySet__.add("platformShapeType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceEndpoint")
         private String serviceEndpoint;
 
@@ -242,6 +251,7 @@ public class BlockchainPlatform {
                             serviceVersion,
                             platformRole,
                             computeShape,
+                            platformShapeType,
                             serviceEndpoint,
                             lifecycleState,
                             lifecycleDetails,
@@ -271,6 +281,7 @@ public class BlockchainPlatform {
                             .serviceVersion(o.getServiceVersion())
                             .platformRole(o.getPlatformRole())
                             .computeShape(o.getComputeShape())
+                            .platformShapeType(o.getPlatformShapeType())
                             .serviceEndpoint(o.getServiceEndpoint())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
@@ -344,7 +355,7 @@ public class BlockchainPlatform {
     @com.fasterxml.jackson.annotation.JsonProperty("serviceVersion")
     String serviceVersion;
     /**
-     * Role of platform - founder or participant
+     * Role of platform - FOUNDER or PARTICIPANT
      **/
     @lombok.extern.slf4j.Slf4j
     public enum PlatformRole {
@@ -390,12 +401,12 @@ public class BlockchainPlatform {
         }
     };
     /**
-     * Role of platform - founder or participant
+     * Role of platform - FOUNDER or PARTICIPANT
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("platformRole")
     PlatformRole platformRole;
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
      **/
     @lombok.extern.slf4j.Slf4j
     public enum ComputeShape {
@@ -445,10 +456,61 @@ public class BlockchainPlatform {
         }
     };
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeShape")
     ComputeShape computeShape;
+    /**
+     * Type of Platform shape - DEFAULT or CUSTOM
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PlatformShapeType {
+        Default("DEFAULT"),
+        Custom("CUSTOM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PlatformShapeType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PlatformShapeType v : PlatformShapeType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PlatformShapeType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PlatformShapeType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PlatformShapeType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of Platform shape - DEFAULT or CUSTOM
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("platformShapeType")
+    PlatformShapeType platformShapeType;
 
     /**
      * Service endpoint URL, valid post-provisioning

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatformByHostname.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatformByHostname.java
@@ -245,7 +245,7 @@ public class BlockchainPlatformByHostname {
     BlockchainPlatform.PlatformRole platformRole;
 
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeShape")
     BlockchainPlatform.ComputeShape computeShape;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatformSummary.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/BlockchainPlatformSummary.java
@@ -239,7 +239,7 @@ public class BlockchainPlatformSummary {
     BlockchainPlatform.PlatformRole platformRole;
 
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeShape")
     BlockchainPlatform.ComputeShape computeShape;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/CreateBlockchainPlatformDetails.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/CreateBlockchainPlatformDetails.java
@@ -199,7 +199,7 @@ public class CreateBlockchainPlatformDetails {
     BlockchainPlatform.PlatformRole platformRole;
 
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeShape")
     BlockchainPlatform.ComputeShape computeShape;
@@ -211,7 +211,7 @@ public class CreateBlockchainPlatformDetails {
     Boolean isByol;
 
     /**
-     * IDCS access token
+     * IDCS access token with Identity Domain Administrator role
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("idcsAccessToken")
     String idcsAccessToken;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/ScaledBlockchainPlatformPreview.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/ScaledBlockchainPlatformPreview.java
@@ -257,7 +257,7 @@ public class ScaledBlockchainPlatformPreview {
     String description;
 
     /**
-     * Type of compute shape - one of Standard, (Enterprise) Small, Medium, Large or Extra Large
+     * Compute shape - STANDARD or ENTERPRISE_SMALL or ENTERPRISE_MEDIUM or ENTERPRISE_LARGE or ENTERPRISE_EXTRA_LARGE or ENTERPRISE_CUSTOM
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeShape")
     String computeShape;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequest.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequest.java
@@ -161,6 +161,7 @@ public class WorkRequest {
         StartPlatform("START_PLATFORM"),
         StopPlatform("STOP_PLATFORM"),
         CustomizePlatform("CUSTOMIZE_PLATFORM"),
+        ScaleStorage("SCALE_STORAGE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestResource.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestResource.java
@@ -62,12 +62,23 @@ public class WorkRequestResource {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("subTypeDetails")
+        private java.util.List<WorkRequestResourceSubTypeDetail> subTypeDetails;
+
+        public Builder subTypeDetails(
+                java.util.List<WorkRequestResourceSubTypeDetail> subTypeDetails) {
+            this.subTypeDetails = subTypeDetails;
+            this.__explicitlySet__.add("subTypeDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public WorkRequestResource build() {
             WorkRequestResource __instance__ =
-                    new WorkRequestResource(entityType, actionType, identifier, entityUri);
+                    new WorkRequestResource(
+                            entityType, actionType, identifier, entityUri, subTypeDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -78,7 +89,8 @@ public class WorkRequestResource {
                     entityType(o.getEntityType())
                             .actionType(o.getActionType())
                             .identifier(o.getIdentifier())
-                            .entityUri(o.getEntityUri());
+                            .entityUri(o.getEntityUri())
+                            .subTypeDetails(o.getSubTypeDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -171,6 +183,12 @@ public class WorkRequestResource {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
     String entityUri;
+
+    /**
+     * Collection of SubType information for a work request resource\u00A9
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subTypeDetails")
+    java.util.List<WorkRequestResourceSubTypeDetail> subTypeDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestResourceSubTypeDetail.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestResourceSubTypeDetail.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.blockchain.model;
+
+/**
+ * SubType information for a work request resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191010")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestResourceSubTypeDetail.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestResourceSubTypeDetail {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("subType")
+        private String subType;
+
+        public Builder subType(String subType) {
+            this.subType = subType;
+            this.__explicitlySet__.add("subType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subTypeKey")
+        private String subTypeKey;
+
+        public Builder subTypeKey(String subTypeKey) {
+            this.subTypeKey = subTypeKey;
+            this.__explicitlySet__.add("subTypeKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subTypeStatus")
+        private SubTypeStatus subTypeStatus;
+
+        public Builder subTypeStatus(SubTypeStatus subTypeStatus) {
+            this.subTypeStatus = subTypeStatus;
+            this.__explicitlySet__.add("subTypeStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestResourceSubTypeDetail build() {
+            WorkRequestResourceSubTypeDetail __instance__ =
+                    new WorkRequestResourceSubTypeDetail(subType, subTypeKey, subTypeStatus);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestResourceSubTypeDetail o) {
+            Builder copiedBuilder =
+                    subType(o.getSubType())
+                            .subTypeKey(o.getSubTypeKey())
+                            .subTypeStatus(o.getSubTypeStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Subtype of the work request resource like osn or peer.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subType")
+    String subType;
+
+    /**
+     * The identifier of the resource subType.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subTypeKey")
+    String subTypeKey;
+    /**
+     * Status of the resource subType, as a result of the work tracked in this work request.
+     * A resource subType would be CREATED, UPDATED or DELETED, after the work request is completed.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum SubTypeStatus {
+        Created("CREATED"),
+        Updated("UPDATED"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, SubTypeStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SubTypeStatus v : SubTypeStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        SubTypeStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SubTypeStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'SubTypeStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Status of the resource subType, as a result of the work tracked in this work request.
+     * A resource subType would be CREATED, UPDATED or DELETED, after the work request is completed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subTypeStatus")
+    SubTypeStatus subTypeStatus;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestSummary.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/model/WorkRequestSummary.java
@@ -163,6 +163,7 @@ public class WorkRequestSummary {
         StartPlatform("START_PLATFORM"),
         StopPlatform("STOP_PLATFORM"),
         CustomizePlatform("CUSTOMIZE_PLATFORM"),
+        ScaleStorage("SCALE_STORAGE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/StartBlockchainPlatformRequest.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/StartBlockchainPlatformRequest.java
@@ -32,6 +32,16 @@ public class StartBlockchainPlatformRequest
      */
     private String opcRequestId;
 
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     StartBlockchainPlatformRequest, java.lang.Void> {
@@ -70,6 +80,7 @@ public class StartBlockchainPlatformRequest
             blockchainPlatformId(o.getBlockchainPlatformId());
             ifMatch(o.getIfMatch());
             opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/StopBlockchainPlatformRequest.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/StopBlockchainPlatformRequest.java
@@ -32,6 +32,16 @@ public class StopBlockchainPlatformRequest
      */
     private String opcRequestId;
 
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     StopBlockchainPlatformRequest, java.lang.Void> {
@@ -70,6 +80,7 @@ public class StopBlockchainPlatformRequest
             blockchainPlatformId(o.getBlockchainPlatformId());
             ifMatch(o.getIfMatch());
             opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/UpdateBlockchainPlatformRequest.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/UpdateBlockchainPlatformRequest.java
@@ -38,6 +38,16 @@ public class UpdateBlockchainPlatformRequest
     private String ifMatch;
 
     /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -86,6 +96,7 @@ public class UpdateBlockchainPlatformRequest
             blockchainPlatformId(o.getBlockchainPlatformId());
             opcRequestId(o.getOpcRequestId());
             ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/UpdatePeerRequest.java
+++ b/bmc-blockchain/src/main/java/com/oracle/bmc/blockchain/requests/UpdatePeerRequest.java
@@ -43,6 +43,16 @@ public class UpdatePeerRequest extends com.oracle.bmc.requests.BmcRequest<Update
     private String opcRequestId;
 
     /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -92,6 +102,7 @@ public class UpdatePeerRequest extends com.oracle.bmc.requests.BmcRequest<Update
             updatePeerDetails(o.getUpdatePeerDetails());
             ifMatch(o.getIfMatch());
             opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,396 +19,396 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -98,6 +98,7 @@ public final class Region implements Serializable, Comparable<Region> {
     public static final Region US_PHOENIX_1 = register("us-phoenix-1", Realm.OC1, "phx");
     public static final Region US_SANJOSE_1 = register("us-sanjose-1", Realm.OC1, "sjc");
     public static final Region UK_CARDIFF_1 = register("uk-cardiff-1", Realm.OC1, "cwl");
+    public static final Region SA_SANTIAGO_1 = register("sa-santiago-1", Realm.OC1, "scl");
 
     // OC2
     public static final Region US_LANGLEY_1 = register("us-langley-1", Realm.OC2, "lfi");

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafe.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafe.java
@@ -55,6 +55,15 @@ public interface DataSafe extends AutoCloseable {
             ChangeDataSafePrivateEndpointCompartmentRequest request);
 
     /**
+     * Moves the specified on-premises connector into a different compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ChangeOnPremConnectorCompartmentResponse changeOnPremConnectorCompartment(
+            ChangeOnPremConnectorCompartmentRequest request);
+
+    /**
      * Creates a new Data Safe private endpoint.
      *
      * @param request The request object containing the details to send
@@ -63,6 +72,15 @@ public interface DataSafe extends AutoCloseable {
      */
     CreateDataSafePrivateEndpointResponse createDataSafePrivateEndpoint(
             CreateDataSafePrivateEndpointRequest request);
+
+    /**
+     * Creates a new on-premises connector.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateOnPremConnectorResponse createOnPremConnector(CreateOnPremConnectorRequest request);
 
     /**
      * Deletes the specified Data Safe private endpoint.
@@ -74,6 +92,14 @@ public interface DataSafe extends AutoCloseable {
             DeleteDataSafePrivateEndpointRequest request);
 
     /**
+     * Deletes the specified on-premises connector.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteOnPremConnectorResponse deleteOnPremConnector(DeleteOnPremConnectorRequest request);
+
+    /**
      * Enables Data Safe in the tenancy and region.
      *
      * @param request The request object containing the details to send
@@ -82,6 +108,16 @@ public interface DataSafe extends AutoCloseable {
      */
     EnableDataSafeConfigurationResponse enableDataSafeConfiguration(
             EnableDataSafeConfigurationRequest request);
+
+    /**
+     * Creates and downloads the configuration of the specified on-premises connector.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GenerateOnPremConnectorConfigurationResponse generateOnPremConnectorConfiguration(
+            GenerateOnPremConnectorConfigurationRequest request);
 
     /**
      * Gets the details of the Data Safe configuration.
@@ -102,6 +138,14 @@ public interface DataSafe extends AutoCloseable {
             GetDataSafePrivateEndpointRequest request);
 
     /**
+     * Gets the details of the specified on-premises connector.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetOnPremConnectorResponse getOnPremConnector(GetOnPremConnectorRequest request);
+
+    /**
      * Gets the details of the specified work request.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -118,6 +162,15 @@ public interface DataSafe extends AutoCloseable {
      */
     ListDataSafePrivateEndpointsResponse listDataSafePrivateEndpoints(
             ListDataSafePrivateEndpointsRequest request);
+
+    /**
+     * Gets a list of on-premises connectors.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListOnPremConnectorsResponse listOnPremConnectors(ListOnPremConnectorsRequest request);
 
     /**
      * Gets a list of errors for the specified work request.
@@ -154,6 +207,24 @@ public interface DataSafe extends AutoCloseable {
      */
     UpdateDataSafePrivateEndpointResponse updateDataSafePrivateEndpoint(
             UpdateDataSafePrivateEndpointRequest request);
+
+    /**
+     * Updates one or more attributes of the specified on-premises connector.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateOnPremConnectorResponse updateOnPremConnector(UpdateOnPremConnectorRequest request);
+
+    /**
+     * Updates the wallet for the specified on-premises connector to a new version.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateOnPremConnectorWalletResponse updateOnPremConnectorWallet(
+            UpdateOnPremConnectorWalletRequest request);
 
     /**
      * Gets the pre-configured waiters available for resources for this service.

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeAsync.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeAsync.java
@@ -64,6 +64,24 @@ public interface DataSafeAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Moves the specified on-premises connector into a different compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeOnPremConnectorCompartmentResponse>
+            changeOnPremConnectorCompartment(
+                    ChangeOnPremConnectorCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeOnPremConnectorCompartmentRequest,
+                                    ChangeOnPremConnectorCompartmentResponse>
+                            handler);
+
+    /**
      * Creates a new Data Safe private endpoint.
      *
      *
@@ -81,6 +99,23 @@ public interface DataSafeAsync extends AutoCloseable {
                                     CreateDataSafePrivateEndpointRequest,
                                     CreateDataSafePrivateEndpointResponse>
                             handler);
+
+    /**
+     * Creates a new on-premises connector.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateOnPremConnectorResponse> createOnPremConnector(
+            CreateOnPremConnectorRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateOnPremConnectorRequest, CreateOnPremConnectorResponse>
+                    handler);
 
     /**
      * Deletes the specified Data Safe private endpoint.
@@ -101,6 +136,22 @@ public interface DataSafeAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Deletes the specified on-premises connector.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteOnPremConnectorResponse> deleteOnPremConnector(
+            DeleteOnPremConnectorRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteOnPremConnectorRequest, DeleteOnPremConnectorResponse>
+                    handler);
+
+    /**
      * Enables Data Safe in the tenancy and region.
      *
      *
@@ -116,6 +167,25 @@ public interface DataSafeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             EnableDataSafeConfigurationRequest, EnableDataSafeConfigurationResponse>
                     handler);
+
+    /**
+     * Creates and downloads the configuration of the specified on-premises connector.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GenerateOnPremConnectorConfigurationResponse>
+            generateOnPremConnectorConfiguration(
+                    GenerateOnPremConnectorConfigurationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateOnPremConnectorConfigurationRequest,
+                                    GenerateOnPremConnectorConfigurationResponse>
+                            handler);
 
     /**
      * Gets the details of the Data Safe configuration.
@@ -150,6 +220,22 @@ public interface DataSafeAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets the details of the specified on-premises connector.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetOnPremConnectorResponse> getOnPremConnector(
+            GetOnPremConnectorRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+                    handler);
+
+    /**
      * Gets the details of the specified work request.
      *
      * @param request The request object containing the details to send
@@ -180,6 +266,23 @@ public interface DataSafeAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             ListDataSafePrivateEndpointsRequest,
                             ListDataSafePrivateEndpointsResponse>
+                    handler);
+
+    /**
+     * Gets a list of on-premises connectors.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListOnPremConnectorsResponse> listOnPremConnectors(
+            ListOnPremConnectorsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>
                     handler);
 
     /**
@@ -249,4 +352,37 @@ public interface DataSafeAsync extends AutoCloseable {
                                     UpdateDataSafePrivateEndpointRequest,
                                     UpdateDataSafePrivateEndpointResponse>
                             handler);
+
+    /**
+     * Updates one or more attributes of the specified on-premises connector.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateOnPremConnectorResponse> updateOnPremConnector(
+            UpdateOnPremConnectorRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateOnPremConnectorRequest, UpdateOnPremConnectorResponse>
+                    handler);
+
+    /**
+     * Updates the wallet for the specified on-premises connector to a new version.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateOnPremConnectorWalletResponse> updateOnPremConnectorWallet(
+            UpdateOnPremConnectorWalletRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateOnPremConnectorWalletRequest, UpdateOnPremConnectorWalletResponse>
+                    handler);
 }

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeAsyncClient.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeAsyncClient.java
@@ -373,6 +373,53 @@ public class DataSafeAsyncClient implements DataSafeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeOnPremConnectorCompartmentResponse>
+            changeOnPremConnectorCompartment(
+                    ChangeOnPremConnectorCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeOnPremConnectorCompartmentRequest,
+                                    ChangeOnPremConnectorCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeOnPremConnectorCompartment");
+        final ChangeOnPremConnectorCompartmentRequest interceptedRequest =
+                ChangeOnPremConnectorCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeOnPremConnectorCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeOnPremConnectorCompartmentResponse>
+                transformer = ChangeOnPremConnectorCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeOnPremConnectorCompartmentRequest,
+                        ChangeOnPremConnectorCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeOnPremConnectorCompartmentRequest,
+                                ChangeOnPremConnectorCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeOnPremConnectorCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeOnPremConnectorCompartmentRequest,
+                    ChangeOnPremConnectorCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateDataSafePrivateEndpointResponse>
             createDataSafePrivateEndpoint(
                     CreateDataSafePrivateEndpointRequest request,
@@ -405,6 +452,48 @@ public class DataSafeAsyncClient implements DataSafeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     CreateDataSafePrivateEndpointRequest, CreateDataSafePrivateEndpointResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateOnPremConnectorResponse> createOnPremConnector(
+            CreateOnPremConnectorRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateOnPremConnectorRequest, CreateOnPremConnectorResponse>
+                    handler) {
+        LOG.trace("Called async createOnPremConnector");
+        final CreateOnPremConnectorRequest interceptedRequest =
+                CreateOnPremConnectorConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateOnPremConnectorResponse>
+                transformer = CreateOnPremConnectorConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateOnPremConnectorRequest, CreateOnPremConnectorResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateOnPremConnectorRequest, CreateOnPremConnectorResponse>,
+                        java.util.concurrent.Future<CreateOnPremConnectorResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateOnPremConnectorRequest, CreateOnPremConnectorResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -462,6 +551,47 @@ public class DataSafeAsyncClient implements DataSafeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteOnPremConnectorResponse> deleteOnPremConnector(
+            DeleteOnPremConnectorRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteOnPremConnectorRequest, DeleteOnPremConnectorResponse>
+                    handler) {
+        LOG.trace("Called async deleteOnPremConnector");
+        final DeleteOnPremConnectorRequest interceptedRequest =
+                DeleteOnPremConnectorConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteOnPremConnectorResponse>
+                transformer = DeleteOnPremConnectorConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteOnPremConnectorRequest, DeleteOnPremConnectorResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteOnPremConnectorRequest, DeleteOnPremConnectorResponse>,
+                        java.util.concurrent.Future<DeleteOnPremConnectorResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteOnPremConnectorRequest, DeleteOnPremConnectorResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<EnableDataSafeConfigurationResponse>
             enableDataSafeConfiguration(
                     EnableDataSafeConfigurationRequest request,
@@ -493,6 +623,54 @@ public class DataSafeAsyncClient implements DataSafeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     EnableDataSafeConfigurationRequest, EnableDataSafeConfigurationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GenerateOnPremConnectorConfigurationResponse>
+            generateOnPremConnectorConfiguration(
+                    GenerateOnPremConnectorConfigurationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GenerateOnPremConnectorConfigurationRequest,
+                                    GenerateOnPremConnectorConfigurationResponse>
+                            handler) {
+        LOG.trace("Called async generateOnPremConnectorConfiguration");
+        final GenerateOnPremConnectorConfigurationRequest interceptedRequest =
+                GenerateOnPremConnectorConfigurationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateOnPremConnectorConfigurationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateOnPremConnectorConfigurationResponse>
+                transformer = GenerateOnPremConnectorConfigurationConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GenerateOnPremConnectorConfigurationRequest,
+                        GenerateOnPremConnectorConfigurationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GenerateOnPremConnectorConfigurationRequest,
+                                GenerateOnPremConnectorConfigurationResponse>,
+                        java.util.concurrent.Future<GenerateOnPremConnectorConfigurationResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GenerateOnPremConnectorConfigurationRequest,
+                    GenerateOnPremConnectorConfigurationResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -591,6 +769,45 @@ public class DataSafeAsyncClient implements DataSafeAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetOnPremConnectorResponse> getOnPremConnector(
+            GetOnPremConnectorRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+                    handler) {
+        LOG.trace("Called async getOnPremConnector");
+        final GetOnPremConnectorRequest interceptedRequest =
+                GetOnPremConnectorConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetOnPremConnectorResponse>
+                transformer = GetOnPremConnectorConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetOnPremConnectorRequest, GetOnPremConnectorResponse>,
+                        java.util.concurrent.Future<GetOnPremConnectorResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetOnPremConnectorRequest, GetOnPremConnectorResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
             GetWorkRequestRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -661,6 +878,47 @@ public class DataSafeAsyncClient implements DataSafeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListDataSafePrivateEndpointsRequest, ListDataSafePrivateEndpointsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListOnPremConnectorsResponse> listOnPremConnectors(
+            ListOnPremConnectorsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>
+                    handler) {
+        LOG.trace("Called async listOnPremConnectors");
+        final ListOnPremConnectorsRequest interceptedRequest =
+                ListOnPremConnectorsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListOnPremConnectorsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListOnPremConnectorsResponse>
+                transformer = ListOnPremConnectorsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>,
+                        java.util.concurrent.Future<ListOnPremConnectorsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -826,6 +1084,92 @@ public class DataSafeAsyncClient implements DataSafeAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateDataSafePrivateEndpointRequest, UpdateDataSafePrivateEndpointResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateOnPremConnectorResponse> updateOnPremConnector(
+            UpdateOnPremConnectorRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateOnPremConnectorRequest, UpdateOnPremConnectorResponse>
+                    handler) {
+        LOG.trace("Called async updateOnPremConnector");
+        final UpdateOnPremConnectorRequest interceptedRequest =
+                UpdateOnPremConnectorConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateOnPremConnectorResponse>
+                transformer = UpdateOnPremConnectorConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateOnPremConnectorRequest, UpdateOnPremConnectorResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateOnPremConnectorRequest, UpdateOnPremConnectorResponse>,
+                        java.util.concurrent.Future<UpdateOnPremConnectorResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateOnPremConnectorRequest, UpdateOnPremConnectorResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateOnPremConnectorWalletResponse>
+            updateOnPremConnectorWallet(
+                    UpdateOnPremConnectorWalletRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateOnPremConnectorWalletRequest,
+                                    UpdateOnPremConnectorWalletResponse>
+                            handler) {
+        LOG.trace("Called async updateOnPremConnectorWallet");
+        final UpdateOnPremConnectorWalletRequest interceptedRequest =
+                UpdateOnPremConnectorWalletConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOnPremConnectorWalletConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateOnPremConnectorWalletResponse>
+                transformer = UpdateOnPremConnectorWalletConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateOnPremConnectorWalletRequest, UpdateOnPremConnectorWalletResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateOnPremConnectorWalletRequest,
+                                UpdateOnPremConnectorWalletResponse>,
+                        java.util.concurrent.Future<UpdateOnPremConnectorWalletResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateOnPremConnectorWalletRequest, UpdateOnPremConnectorWalletResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeClient.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeClient.java
@@ -478,6 +478,42 @@ public class DataSafeClient implements DataSafe {
     }
 
     @Override
+    public ChangeOnPremConnectorCompartmentResponse changeOnPremConnectorCompartment(
+            ChangeOnPremConnectorCompartmentRequest request) {
+        LOG.trace("Called changeOnPremConnectorCompartment");
+        final ChangeOnPremConnectorCompartmentRequest interceptedRequest =
+                ChangeOnPremConnectorCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeOnPremConnectorCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeOnPremConnectorCompartmentResponse>
+                transformer = ChangeOnPremConnectorCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeOnPremConnectorCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateDataSafePrivateEndpointResponse createDataSafePrivateEndpoint(
             CreateDataSafePrivateEndpointRequest request) {
         LOG.trace("Called createDataSafePrivateEndpoint");
@@ -514,6 +550,40 @@ public class DataSafeClient implements DataSafe {
     }
 
     @Override
+    public CreateOnPremConnectorResponse createOnPremConnector(
+            CreateOnPremConnectorRequest request) {
+        LOG.trace("Called createOnPremConnector");
+        final CreateOnPremConnectorRequest interceptedRequest =
+                CreateOnPremConnectorConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateOnPremConnectorResponse>
+                transformer = CreateOnPremConnectorConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateOnPremConnectorDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteDataSafePrivateEndpointResponse deleteDataSafePrivateEndpoint(
             DeleteDataSafePrivateEndpointRequest request) {
         LOG.trace("Called deleteDataSafePrivateEndpoint");
@@ -524,6 +594,36 @@ public class DataSafeClient implements DataSafe {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, DeleteDataSafePrivateEndpointResponse>
                 transformer = DeleteDataSafePrivateEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteOnPremConnectorResponse deleteOnPremConnector(
+            DeleteOnPremConnectorRequest request) {
+        LOG.trace("Called deleteOnPremConnector");
+        final DeleteOnPremConnectorRequest interceptedRequest =
+                DeleteOnPremConnectorConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteOnPremConnectorResponse>
+                transformer = DeleteOnPremConnectorConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -573,6 +673,43 @@ public class DataSafeClient implements DataSafe {
                                                 ib,
                                                 retriedRequest
                                                         .getEnableDataSafeConfigurationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GenerateOnPremConnectorConfigurationResponse generateOnPremConnectorConfiguration(
+            GenerateOnPremConnectorConfigurationRequest request) {
+        LOG.trace("Called generateOnPremConnectorConfiguration");
+        final GenerateOnPremConnectorConfigurationRequest interceptedRequest =
+                GenerateOnPremConnectorConfigurationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GenerateOnPremConnectorConfigurationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GenerateOnPremConnectorConfigurationResponse>
+                transformer = GenerateOnPremConnectorConfigurationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getGenerateOnPremConnectorConfigurationDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -639,6 +776,34 @@ public class DataSafeClient implements DataSafe {
     }
 
     @Override
+    public GetOnPremConnectorResponse getOnPremConnector(GetOnPremConnectorRequest request) {
+        LOG.trace("Called getOnPremConnector");
+        final GetOnPremConnectorRequest interceptedRequest =
+                GetOnPremConnectorConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetOnPremConnectorResponse>
+                transformer = GetOnPremConnectorConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request) {
         LOG.trace("Called getWorkRequest");
         final GetWorkRequestRequest interceptedRequest =
@@ -677,6 +842,34 @@ public class DataSafeClient implements DataSafe {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, ListDataSafePrivateEndpointsResponse>
                 transformer = ListDataSafePrivateEndpointsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListOnPremConnectorsResponse listOnPremConnectors(ListOnPremConnectorsRequest request) {
+        LOG.trace("Called listOnPremConnectors");
+        final ListOnPremConnectorsRequest interceptedRequest =
+                ListOnPremConnectorsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListOnPremConnectorsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListOnPremConnectorsResponse>
+                transformer = ListOnPremConnectorsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -810,6 +1003,75 @@ public class DataSafeClient implements DataSafe {
                                                 ib,
                                                 retriedRequest
                                                         .getUpdateDataSafePrivateEndpointDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateOnPremConnectorResponse updateOnPremConnector(
+            UpdateOnPremConnectorRequest request) {
+        LOG.trace("Called updateOnPremConnector");
+        final UpdateOnPremConnectorRequest interceptedRequest =
+                UpdateOnPremConnectorConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOnPremConnectorConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateOnPremConnectorResponse>
+                transformer = UpdateOnPremConnectorConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateOnPremConnectorDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateOnPremConnectorWalletResponse updateOnPremConnectorWallet(
+            UpdateOnPremConnectorWalletRequest request) {
+        LOG.trace("Called updateOnPremConnectorWallet");
+        final UpdateOnPremConnectorWalletRequest interceptedRequest =
+                UpdateOnPremConnectorWalletConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateOnPremConnectorWalletConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateOnPremConnectorWalletResponse>
+                transformer = UpdateOnPremConnectorWalletConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateOnPremConnectorWalletDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafePaginators.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafePaginators.java
@@ -155,6 +155,119 @@ public class DataSafePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listOnPremConnectors operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListOnPremConnectorsResponse> listOnPremConnectorsResponseIterator(
+            final ListOnPremConnectorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListOnPremConnectorsRequest.Builder, ListOnPremConnectorsRequest,
+                ListOnPremConnectorsResponse>(
+                new com.google.common.base.Supplier<ListOnPremConnectorsRequest.Builder>() {
+                    @Override
+                    public ListOnPremConnectorsRequest.Builder get() {
+                        return ListOnPremConnectorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListOnPremConnectorsResponse, String>() {
+                    @Override
+                    public String apply(ListOnPremConnectorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListOnPremConnectorsRequest.Builder>,
+                        ListOnPremConnectorsRequest>() {
+                    @Override
+                    public ListOnPremConnectorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListOnPremConnectorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>() {
+                    @Override
+                    public ListOnPremConnectorsResponse apply(ListOnPremConnectorsRequest request) {
+                        return client.listOnPremConnectors(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datasafe.model.OnPremConnectorSummary} objects
+     * contained in responses from the listOnPremConnectors operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datasafe.model.OnPremConnectorSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datasafe.model.OnPremConnectorSummary>
+            listOnPremConnectorsRecordIterator(final ListOnPremConnectorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListOnPremConnectorsRequest.Builder, ListOnPremConnectorsRequest,
+                ListOnPremConnectorsResponse, com.oracle.bmc.datasafe.model.OnPremConnectorSummary>(
+                new com.google.common.base.Supplier<ListOnPremConnectorsRequest.Builder>() {
+                    @Override
+                    public ListOnPremConnectorsRequest.Builder get() {
+                        return ListOnPremConnectorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListOnPremConnectorsResponse, String>() {
+                    @Override
+                    public String apply(ListOnPremConnectorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListOnPremConnectorsRequest.Builder>,
+                        ListOnPremConnectorsRequest>() {
+                    @Override
+                    public ListOnPremConnectorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListOnPremConnectorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOnPremConnectorsRequest, ListOnPremConnectorsResponse>() {
+                    @Override
+                    public ListOnPremConnectorsResponse apply(ListOnPremConnectorsRequest request) {
+                        return client.listOnPremConnectors(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListOnPremConnectorsResponse,
+                        java.util.List<com.oracle.bmc.datasafe.model.OnPremConnectorSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.datasafe.model.OnPremConnectorSummary>
+                            apply(ListOnPremConnectorsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listWorkRequestErrors operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeWaiters.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/DataSafeWaiters.java
@@ -234,6 +234,108 @@ public class DataSafeWaiters {
     }
 
     /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+            forOnPremConnector(
+                    GetOnPremConnectorRequest request,
+                    com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forOnPremConnector(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+            forOnPremConnector(
+                    GetOnPremConnectorRequest request,
+                    com.oracle.bmc.datasafe.model.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forOnPremConnector(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+            forOnPremConnector(
+                    GetOnPremConnectorRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forOnPremConnector(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for OnPremConnector.
+    private com.oracle.bmc.waiter.Waiter<GetOnPremConnectorRequest, GetOnPremConnectorResponse>
+            forOnPremConnector(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetOnPremConnectorRequest request,
+                    final com.oracle.bmc.datasafe.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.datasafe.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetOnPremConnectorRequest, GetOnPremConnectorResponse>() {
+                            @Override
+                            public GetOnPremConnectorResponse apply(
+                                    GetOnPremConnectorRequest request) {
+                                return client.getOnPremConnector(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetOnPremConnectorResponse>() {
+                            @Override
+                            public boolean apply(GetOnPremConnectorResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getOnPremConnector().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datasafe.model.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using default configuration.
      *
      * @param request the request to send

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ChangeOnPremConnectorCompartmentConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ChangeOnPremConnectorCompartmentConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class ChangeOnPremConnectorCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.ChangeOnPremConnectorCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.datasafe.requests.ChangeOnPremConnectorCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.ChangeOnPremConnectorCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+        Validate.notNull(
+                request.getChangeOnPremConnectorCompartmentDetails(),
+                "changeOnPremConnectorCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.ChangeOnPremConnectorCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.ChangeOnPremConnectorCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses
+                                        .ChangeOnPremConnectorCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses
+                                            .ChangeOnPremConnectorCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.ChangeOnPremConnectorCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses
+                                                .ChangeOnPremConnectorCompartmentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .ChangeOnPremConnectorCompartmentResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses
+                                                .ChangeOnPremConnectorCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/CreateDataSafePrivateEndpointConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/CreateDataSafePrivateEndpointConverter.java
@@ -70,11 +70,14 @@ public class CreateDataSafePrivateEndpointConverter {
                                         "Transform function invoked for com.oracle.bmc.datasafe.responses.CreateDataSafePrivateEndpointResponse");
                                 com.google.common.base.Function<
                                                 javax.ws.rs.core.Response,
-                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
-                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        DataSafePrivateEndpoint>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        DataSafePrivateEndpoint.class);
 
-                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
-                                        responseFn.apply(rawResponse);
+                                com.oracle.bmc.http.internal.WithHeaders<DataSafePrivateEndpoint>
+                                        response = responseFn.apply(rawResponse);
                                 javax.ws.rs.core.MultivaluedMap<String, String> headers =
                                         response.getHeaders();
 
@@ -84,6 +87,17 @@ public class CreateDataSafePrivateEndpointConverter {
                                                 com.oracle.bmc.datasafe.responses
                                                         .CreateDataSafePrivateEndpointResponse
                                                         .builder();
+
+                                builder.dataSafePrivateEndpoint(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
 
                                 com.google.common.base.Optional<java.util.List<String>>
                                         opcWorkRequestIdHeader =
@@ -106,6 +120,18 @@ public class CreateDataSafePrivateEndpointConverter {
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
                                                     "opc-request-id",
                                                     opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
                                                     String.class));
                                 }
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/CreateOnPremConnectorConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/CreateOnPremConnectorConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class CreateOnPremConnectorConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.CreateOnPremConnectorRequest interceptRequest(
+            com.oracle.bmc.datasafe.requests.CreateOnPremConnectorRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.CreateOnPremConnectorRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateOnPremConnectorDetails(),
+                "createOnPremConnectorDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20181201").path("onPremConnectors");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        OnPremConnector>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        OnPremConnector.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<OnPremConnector> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .CreateOnPremConnectorResponse.builder();
+
+                                builder.onPremConnector(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses.CreateOnPremConnectorResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/DeleteOnPremConnectorConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/DeleteOnPremConnectorConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class DeleteOnPremConnectorConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.DeleteOnPremConnectorRequest interceptRequest(
+            com.oracle.bmc.datasafe.requests.DeleteOnPremConnectorRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.DeleteOnPremConnectorRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .DeleteOnPremConnectorResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses.DeleteOnPremConnectorResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/GenerateOnPremConnectorConfigurationConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/GenerateOnPremConnectorConfigurationConverter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class GenerateOnPremConnectorConfigurationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.GenerateOnPremConnectorConfigurationRequest
+            interceptRequest(
+                    com.oracle.bmc.datasafe.requests.GenerateOnPremConnectorConfigurationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.GenerateOnPremConnectorConfigurationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getGenerateOnPremConnectorConfigurationDetails(),
+                "generateOnPremConnectorConfigurationDetails is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()))
+                        .path("actions")
+                        .path("generateConfiguration");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept("application/octet-stream");
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.GenerateOnPremConnectorConfigurationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses
+                                .GenerateOnPremConnectorConfigurationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses
+                                        .GenerateOnPremConnectorConfigurationResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses
+                                            .GenerateOnPremConnectorConfigurationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.GenerateOnPremConnectorConfigurationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses
+                                                .GenerateOnPremConnectorConfigurationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .GenerateOnPremConnectorConfigurationResponse
+                                                        .builder();
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLengthHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-length");
+                                if (contentLengthHeader.isPresent()) {
+                                    builder.contentLength(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-length",
+                                                    contentLengthHeader.get().get(0),
+                                                    Long.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        lastModifiedHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "last-modified");
+                                if (lastModifiedHeader.isPresent()) {
+                                    builder.lastModified(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "last-modified",
+                                                    lastModifiedHeader.get().get(0),
+                                                    java.util.Date.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses
+                                                .GenerateOnPremConnectorConfigurationResponse
+                                        responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/GetOnPremConnectorConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/GetOnPremConnectorConverter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class GetOnPremConnectorConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.GetOnPremConnectorRequest interceptRequest(
+            com.oracle.bmc.datasafe.requests.GetOnPremConnectorRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.GetOnPremConnectorRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        OnPremConnector>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        OnPremConnector.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<OnPremConnector> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .GetOnPremConnectorResponse.builder();
+
+                                builder.onPremConnector(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses.GetOnPremConnectorResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListDataSafePrivateEndpointsConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListDataSafePrivateEndpointsConverter.java
@@ -28,17 +28,16 @@ public class ListDataSafePrivateEndpointsConverter {
             com.oracle.bmc.http.internal.RestClient client,
             com.oracle.bmc.datasafe.requests.ListDataSafePrivateEndpointsRequest request) {
         Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20181201").path("dataSafePrivateEndpoints");
 
-        if (request.getCompartmentId() != null) {
-            target =
-                    target.queryParam(
-                            "compartmentId",
-                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getCompartmentId()));
-        }
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
 
         if (request.getDisplayName() != null) {
             target =

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListOnPremConnectorsConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListOnPremConnectorsConverter.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class ListOnPremConnectorsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.ListOnPremConnectorsRequest interceptRequest(
+            com.oracle.bmc.datasafe.requests.ListOnPremConnectorsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.ListOnPremConnectorsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20181201").path("onPremConnectors");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getOnPremConnectorId() != null) {
+            target =
+                    target.queryParam(
+                            "onPremConnectorId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOnPremConnectorId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getOnPremConnectorLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "onPremConnectorLifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOnPremConnectorLifecycleState().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<OnPremConnectorSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        OnPremConnectorSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<OnPremConnectorSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .ListOnPremConnectorsResponse.builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses.ListOnPremConnectorsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/ListWorkRequestsConverter.java
@@ -27,17 +27,16 @@ public class ListWorkRequestsConverter {
             com.oracle.bmc.http.internal.RestClient client,
             com.oracle.bmc.datasafe.requests.ListWorkRequestsRequest request) {
         Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20181201").path("workRequests");
 
-        if (request.getCompartmentId() != null) {
-            target =
-                    target.queryParam(
-                            "compartmentId",
-                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getCompartmentId()));
-        }
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
 
         if (request.getResourceId() != null) {
             target =

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/UpdateOnPremConnectorConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/UpdateOnPremConnectorConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class UpdateOnPremConnectorConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorRequest interceptRequest(
+            com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+        Validate.notNull(
+                request.getUpdateOnPremConnectorDetails(),
+                "updateOnPremConnectorDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .UpdateOnPremConnectorResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/UpdateOnPremConnectorWalletConverter.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/internal/http/UpdateOnPremConnectorWalletConverter.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datasafe.model.*;
+import com.oracle.bmc.datasafe.requests.*;
+import com.oracle.bmc.datasafe.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.extern.slf4j.Slf4j
+public class UpdateOnPremConnectorWalletConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorWalletRequest
+            interceptRequest(
+                    com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorWalletRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datasafe.requests.UpdateOnPremConnectorWalletRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getUpdateOnPremConnectorWalletDetails(),
+                "updateOnPremConnectorWalletDetails is required");
+        Validate.notBlank(request.getOnPremConnectorId(), "onPremConnectorId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20181201")
+                        .path("onPremConnectors")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getOnPremConnectorId()))
+                        .path("wallet");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorWalletResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorWalletResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datasafe.responses
+                                        .UpdateOnPremConnectorWalletResponse>() {
+                            @Override
+                            public com.oracle.bmc.datasafe.responses
+                                            .UpdateOnPremConnectorWalletResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datasafe.responses.UpdateOnPremConnectorWalletResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datasafe.responses
+                                                .UpdateOnPremConnectorWalletResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datasafe.responses
+                                                        .UpdateOnPremConnectorWalletResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datasafe.responses
+                                                .UpdateOnPremConnectorWalletResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/ChangeOnPremConnectorCompartmentDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/ChangeOnPremConnectorCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The details used to change the compartment of a on-premises connector.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeOnPremConnectorCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeOnPremConnectorCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeOnPremConnectorCompartmentDetails build() {
+            ChangeOnPremConnectorCompartmentDetails __instance__ =
+                    new ChangeOnPremConnectorCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeOnPremConnectorCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the new compartment where you want to move the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/CreateDataSafePrivateEndpointDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/CreateDataSafePrivateEndpointDetails.java
@@ -207,7 +207,7 @@ public class CreateDataSafePrivateEndpointDetails {
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
      * <p>
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/CreateOnPremConnectorDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/CreateOnPremConnectorDetails.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The details used to create a new on-premises connector.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOnPremConnectorDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOnPremConnectorDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOnPremConnectorDetails build() {
+            CreateOnPremConnectorDetails __instance__ =
+                    new CreateOnPremConnectorDetails(
+                            displayName, compartmentId, description, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOnPremConnectorDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the compartment where you want to create the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The description of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafeConfiguration.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafeConfiguration.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datasafe.model;
 
 /**
- * A Data Safe Configuration that allows customer to enable Data Safe in their tenancy.
+ * A Data Safe configuration for a tenancy and region.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -149,13 +149,13 @@ public class DataSafeConfiguration {
     String compartmentId;
 
     /**
-     * The specific time when Data Safe configuration was enabled.
+     * The date and time Data Safe was enabled, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeEnabled")
     java.util.Date timeEnabled;
 
     /**
-     * The current state of Data Safe configuration.
+     * The current state of Data Safe.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
@@ -172,7 +172,7 @@ public class DataSafeConfiguration {
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
      * <p>
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafePrivateEndpoint.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafePrivateEndpoint.java
@@ -263,7 +263,7 @@ public class DataSafePrivateEndpoint {
     String description;
 
     /**
-     * The date and time the private endpoint was created, in the format defined by RFC3339.
+     * The date and time the private endpoint was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
@@ -293,7 +293,7 @@ public class DataSafePrivateEndpoint {
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
      * <p>
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafePrivateEndpointSummary.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/DataSafePrivateEndpointSummary.java
@@ -194,7 +194,7 @@ public class DataSafePrivateEndpointSummary {
     String description;
 
     /**
-     * The date and time the private endpoint was created, in the format defined by RFC3339.
+     * The date and time the private endpoint was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/EnableDataSafeConfigurationDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/EnableDataSafeConfigurationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datasafe.model;
 
 /**
- * The information needed to enable Data Safe in the tenancy.
+ * The details used to enable Data Safe in the tenancy and region.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -35,41 +35,19 @@ public class EnableDataSafeConfigurationDetails {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
-        private java.util.Map<String, String> freeformTags;
-
-        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
-            this.freeformTags = freeformTags;
-            this.__explicitlySet__.add("freeformTags");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
-        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
-
-        public Builder definedTags(
-                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
-            this.definedTags = definedTags;
-            this.__explicitlySet__.add("definedTags");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public EnableDataSafeConfigurationDetails build() {
             EnableDataSafeConfigurationDetails __instance__ =
-                    new EnableDataSafeConfigurationDetails(isEnabled, freeformTags, definedTags);
+                    new EnableDataSafeConfigurationDetails(isEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(EnableDataSafeConfigurationDetails o) {
-            Builder copiedBuilder =
-                    isEnabled(o.getIsEnabled())
-                            .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+            Builder copiedBuilder = isEnabled(o.getIsEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -88,24 +66,6 @@ public class EnableDataSafeConfigurationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
-
-    /**
-     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
-     * <p>
-     * Example: `{\"Department\": \"Finance\"}`
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
-    java.util.Map<String, String> freeformTags;
-
-    /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
-     * <p>
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
-    java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/GenerateOnPremConnectorConfigurationDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/GenerateOnPremConnectorConfigurationDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The details used to create and download on-premises connector's configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenerateOnPremConnectorConfigurationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenerateOnPremConnectorConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("password")
+        private String password;
+
+        public Builder password(String password) {
+            this.password = password;
+            this.__explicitlySet__.add("password");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenerateOnPremConnectorConfigurationDetails build() {
+            GenerateOnPremConnectorConfigurationDetails __instance__ =
+                    new GenerateOnPremConnectorConfigurationDetails(password);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenerateOnPremConnectorConfigurationDetails o) {
+            Builder copiedBuilder = password(o.getPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The password to encrypt the keys inside the wallet included as part of the configuration. The password must be between 12 and 30 characters long and must contain atleast 1 uppercase, 1 lowercase, 1 numeric, and 1 special character.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("password")
+    String password;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnector.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnector.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * A Data Safe on-premises connector that enables Data Safe to connect to on-premises databases.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = OnPremConnector.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OnPremConnector {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availableVersion")
+        private String availableVersion;
+
+        public Builder availableVersion(String availableVersion) {
+            this.availableVersion = availableVersion;
+            this.__explicitlySet__.add("availableVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdVersion")
+        private String createdVersion;
+
+        public Builder createdVersion(String createdVersion) {
+            this.createdVersion = createdVersion;
+            this.__explicitlySet__.add("createdVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OnPremConnector build() {
+            OnPremConnector __instance__ =
+                    new OnPremConnector(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            timeCreated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            availableVersion,
+                            createdVersion);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OnPremConnector o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .availableVersion(o.getAvailableVersion())
+                            .createdVersion(o.getCreatedVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The display name of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the compartment that contains the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The description of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The date and time the on-premises connector was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The current state of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Details about the current state of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Latest available version of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availableVersion")
+    String availableVersion;
+
+    /**
+     * Created version of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdVersion")
+    String createdVersion;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnectorLifecycleState.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnectorLifecycleState.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The current state of the on-premises connector.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+public enum OnPremConnectorLifecycleState {
+    Creating("CREATING"),
+    Updating("UPDATING"),
+    Active("ACTIVE"),
+    Inactive("INACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, OnPremConnectorLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (OnPremConnectorLifecycleState v : OnPremConnectorLifecycleState.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    OnPremConnectorLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static OnPremConnectorLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid OnPremConnectorLifecycleState: " + key);
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnectorSummary.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/OnPremConnectorSummary.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * Summary of a Data Safe on-premises connector.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OnPremConnectorSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OnPremConnectorSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdVersion")
+        private String createdVersion;
+
+        public Builder createdVersion(String createdVersion) {
+            this.createdVersion = createdVersion;
+            this.__explicitlySet__.add("createdVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OnPremConnectorSummary build() {
+            OnPremConnectorSummary __instance__ =
+                    new OnPremConnectorSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            timeCreated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            createdVersion);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OnPremConnectorSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .timeCreated(o.getTimeCreated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .createdVersion(o.getCreatedVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The display name of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the compartment that contains the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The description of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The date and time the on-premises connector was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The current state of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Details about the current state of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Created version of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdVersion")
+    String createdVersion;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/ServiceList.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/ServiceList.java
@@ -14,6 +14,7 @@ public enum ServiceList {
     DataSafeDev1("DataSafe-dev1"),
     DataSafeDev2("DataSafe-dev2"),
     DataSafeDev3("DataSafe-dev3"),
+    DataSafeDev4("DataSafe-dev4"),
     DataSafeLrg1("DataSafe-lrg1"),
     DataSafeLrg2("DataSafe-lrg2"),
     DataSafeLrg3("DataSafe-lrg3"),

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateDataSafePrivateEndpointDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateDataSafePrivateEndpointDetails.java
@@ -135,7 +135,7 @@ public class UpdateDataSafePrivateEndpointDetails {
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
      * <p>
-     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateOnPremConnectorDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateOnPremConnectorDetails.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The details used to update a on-premises connector.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOnPremConnectorDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOnPremConnectorDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOnPremConnectorDetails build() {
+            UpdateOnPremConnectorDetails __instance__ =
+                    new UpdateOnPremConnectorDetails(
+                            displayName, description, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOnPremConnectorDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the on-premises connector. The name does not have to be unique, and it's changeable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The description of the on-premises connector.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm)
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateOnPremConnectorWalletDetails.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/UpdateOnPremConnectorWalletDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.model;
+
+/**
+ * The details used to update an on-premises connector's wallet.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOnPremConnectorWalletDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOnPremConnectorWalletDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isUpdate")
+        private Boolean isUpdate;
+
+        public Builder isUpdate(Boolean isUpdate) {
+            this.isUpdate = isUpdate;
+            this.__explicitlySet__.add("isUpdate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOnPremConnectorWalletDetails build() {
+            UpdateOnPremConnectorWalletDetails __instance__ =
+                    new UpdateOnPremConnectorWalletDetails(isUpdate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOnPremConnectorWalletDetails o) {
+            Builder copiedBuilder = isUpdate(o.getIsUpdate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Indicates whether to update or not. If false, the wallet will not be updated. Default is false.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isUpdate")
+    Boolean isUpdate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequest.java
@@ -150,7 +150,7 @@ public class WorkRequest {
     }
 
     /**
-     * The asynchronous operation tracked by this work request.
+     * The resources that are affected by the work request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum OperationType {
@@ -159,6 +159,11 @@ public class WorkRequest {
         UpdatePrivateEndpoint("UPDATE_PRIVATE_ENDPOINT"),
         DeletePrivateEndpoint("DELETE_PRIVATE_ENDPOINT"),
         ChangePrivateEndpointCompartment("CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"),
+        CreateOnpremConnector("CREATE_ONPREM_CONNECTOR"),
+        UpdateOnpremConnector("UPDATE_ONPREM_CONNECTOR"),
+        DeleteOnpremConnector("DELETE_ONPREM_CONNECTOR"),
+        UpdateOnpremConnectorWallet("UPDATE_ONPREM_CONNECTOR_WALLET"),
+        ChangeOnpremConnectorCompartment("CHANGE_ONPREM_CONNECTOR_COMPARTMENT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -199,12 +204,12 @@ public class WorkRequest {
         }
     };
     /**
-     * The asynchronous operation tracked by this work request.
+     * The resources that are affected by the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("operationType")
     OperationType operationType;
     /**
-     * The status of the work request.
+     * The current status of the work request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Status {
@@ -252,7 +257,7 @@ public class WorkRequest {
         }
     };
     /**
-     * The status of the work request.
+     * The current status of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("status")
     Status status;
@@ -277,27 +282,27 @@ public class WorkRequest {
     java.util.List<WorkRequestResource> resources;
 
     /**
-     * Progress of the request in percentage.
+     * Progress of the work request in percentage.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
     Float percentComplete;
 
     /**
-     * The date and time the work request was created, in the format defined by RFC3339.
+     * The date and time the work request was accepted, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
     java.util.Date timeAccepted;
 
     /**
-     * The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+     * The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by RFC3339.
+     * The date and time the work request reached a terminal state, either FAILED or SUCCEEDED. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestError.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestError.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datasafe.model;
 
 /**
- * An error encountered while executing an operation that is tracked by a work request.
+ * An error related to a work request.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -78,8 +78,7 @@ public class WorkRequestError {
     }
 
     /**
-     * A machine-usable code for the error that occured. Error codes are listed on
-     * (https://docs.us-phoenix-1.oraclecloud.com/Content/API/References/apierrors.htm)
+     * A machine-usable error code. For a list of common errors, see [API Errors](https://docs.us-phoenix-1.oraclecloud.com/Content/API/References/apierrors.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("code")
@@ -92,7 +91,7 @@ public class WorkRequestError {
     String message;
 
     /**
-     * The date and time the error occurred, in the format defined by RFC3339.
+     * The date and time the error occurred, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
     java.util.Date timestamp;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestLogEntry.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestLogEntry.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datasafe.model;
 
 /**
- * A log message from the execution of a work request.
+ * A log entry related to a work request.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -70,13 +70,13 @@ public class WorkRequestLogEntry {
     }
 
     /**
-     * Human-readable log message.
+     * A human-readable log entry.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("message")
     String message;
 
     /**
-     * The time when the log message was created, in the format defined by RFC3339.
+     * The date and time the log entry was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
     java.util.Date timestamp;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestSummary.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/model/WorkRequestSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datasafe.model;
 
 /**
- * A summary of the work request status.
+ * Summary of a work request.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -161,6 +161,11 @@ public class WorkRequestSummary {
         UpdatePrivateEndpoint("UPDATE_PRIVATE_ENDPOINT"),
         DeletePrivateEndpoint("DELETE_PRIVATE_ENDPOINT"),
         ChangePrivateEndpointCompartment("CHANGE_PRIVATE_ENDPOINT_COMPARTMENT"),
+        CreateOnpremConnector("CREATE_ONPREM_CONNECTOR"),
+        UpdateOnpremConnector("UPDATE_ONPREM_CONNECTOR"),
+        DeleteOnpremConnector("DELETE_ONPREM_CONNECTOR"),
+        UpdateOnpremConnectorWallet("UPDATE_ONPREM_CONNECTOR_WALLET"),
+        ChangeOnpremConnectorCompartment("CHANGE_ONPREM_CONNECTOR_COMPARTMENT"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -206,7 +211,7 @@ public class WorkRequestSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("operationType")
     OperationType operationType;
     /**
-     * The status of the work request.
+     * The current status of the work request.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Status {
@@ -254,7 +259,7 @@ public class WorkRequestSummary {
         }
     };
     /**
-     * The status of the work request.
+     * The current status of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("status")
     Status status;
@@ -266,40 +271,40 @@ public class WorkRequestSummary {
     String id;
 
     /**
-     * The OCID of the compartment containing this work request.
+     * The OCID of the compartment that contains the work request.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The resources impacted by the work request.
+     * The resources that are affected by the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resources")
     java.util.List<WorkRequestResource> resources;
 
     /**
-     * Progress of the request in percentage.
+     * Progress of the work request in percentage.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
     Float percentComplete;
 
     /**
-     * The date and time the work request was created, in the format defined by RFC3339.
+     * The date and time the work request was accepted, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
     java.util.Date timeAccepted;
 
     /**
-     * The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by RFC3339.
+     * The date and time the work request transitioned from ACCEPTED to IN_PROGRESS, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by RFC3339.
+     * The date and time the work request reached a terminal state, either FAILED or SUCCEEDED, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ChangeOnPremConnectorCompartmentRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ChangeOnPremConnectorCompartmentRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeOnPremConnectorCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeOnPremConnectorCompartmentDetails> {
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * The details used to change the compartment of an on-premises connector.
+     */
+    private ChangeOnPremConnectorCompartmentDetails changeOnPremConnectorCompartmentDetails;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the if-match parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeOnPremConnectorCompartmentDetails getBody$() {
+        return changeOnPremConnectorCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeOnPremConnectorCompartmentRequest,
+                    ChangeOnPremConnectorCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeOnPremConnectorCompartmentRequest o) {
+            onPremConnectorId(o.getOnPremConnectorId());
+            changeOnPremConnectorCompartmentDetails(o.getChangeOnPremConnectorCompartmentDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeOnPremConnectorCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeOnPremConnectorCompartmentRequest
+         */
+        public ChangeOnPremConnectorCompartmentRequest build() {
+            ChangeOnPremConnectorCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeOnPremConnectorCompartmentDetails body) {
+            changeOnPremConnectorCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/CreateOnPremConnectorRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/CreateOnPremConnectorRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateOnPremConnectorRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateOnPremConnectorDetails> {
+
+    /**
+     * The details used to create a new on-premises connector.
+     */
+    private CreateOnPremConnectorDetails createOnPremConnectorDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateOnPremConnectorDetails getBody$() {
+        return createOnPremConnectorDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateOnPremConnectorRequest, CreateOnPremConnectorDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateOnPremConnectorRequest o) {
+            createOnPremConnectorDetails(o.getCreateOnPremConnectorDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateOnPremConnectorRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateOnPremConnectorRequest
+         */
+        public CreateOnPremConnectorRequest build() {
+            CreateOnPremConnectorRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateOnPremConnectorDetails body) {
+            createOnPremConnectorDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/DeleteOnPremConnectorRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/DeleteOnPremConnectorRequest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteOnPremConnectorRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the if-match parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteOnPremConnectorRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteOnPremConnectorRequest o) {
+            onPremConnectorId(o.getOnPremConnectorId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteOnPremConnectorRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteOnPremConnectorRequest
+         */
+        public DeleteOnPremConnectorRequest build() {
+            DeleteOnPremConnectorRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/GenerateOnPremConnectorConfigurationRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/GenerateOnPremConnectorConfigurationRequest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GenerateOnPremConnectorConfigurationRequest
+        extends com.oracle.bmc.requests.BmcRequest<GenerateOnPremConnectorConfigurationDetails> {
+
+    /**
+     * The details used to create and download on-premises connector's configuration.
+     */
+    private GenerateOnPremConnectorConfigurationDetails generateOnPremConnectorConfigurationDetails;
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the if-match parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public GenerateOnPremConnectorConfigurationDetails getBody$() {
+        return generateOnPremConnectorConfigurationDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GenerateOnPremConnectorConfigurationRequest,
+                    GenerateOnPremConnectorConfigurationDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateOnPremConnectorConfigurationRequest o) {
+            generateOnPremConnectorConfigurationDetails(
+                    o.getGenerateOnPremConnectorConfigurationDetails());
+            onPremConnectorId(o.getOnPremConnectorId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GenerateOnPremConnectorConfigurationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GenerateOnPremConnectorConfigurationRequest
+         */
+        public GenerateOnPremConnectorConfigurationRequest build() {
+            GenerateOnPremConnectorConfigurationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(GenerateOnPremConnectorConfigurationDetails body) {
+            generateOnPremConnectorConfigurationDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/GetOnPremConnectorRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/GetOnPremConnectorRequest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetOnPremConnectorRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetOnPremConnectorRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetOnPremConnectorRequest o) {
+            onPremConnectorId(o.getOnPremConnectorId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetOnPremConnectorRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetOnPremConnectorRequest
+         */
+        public GetOnPremConnectorRequest build() {
+            GetOnPremConnectorRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListDataSafePrivateEndpointsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListDataSafePrivateEndpointsRequest.java
@@ -24,7 +24,7 @@ public class ListDataSafePrivateEndpointsRequest
     private String displayName;
 
     /**
-     * A filter to return only the private endpoints that match the specified VCN OCID.
+     * A filter to return only resources that match the specified VCN OCID.
      */
     private String vcnId;
 
@@ -39,7 +39,7 @@ public class ListDataSafePrivateEndpointsRequest
     private Integer limit;
 
     /**
-     * The beginning page from which the results start retrieving.
+     * For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String page;
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListOnPremConnectorsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListOnPremConnectorsRequest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListOnPremConnectorsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * A filter to return only resources that match the specified compartment OCID.
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return only the on-premises connector that matches the specified id.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * A filter to return only resources that match the specified display name.
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only on-premises connector resources that match the specified lifecycle state.
+     */
+    private com.oracle.bmc.datasafe.model.OnPremConnectorLifecycleState
+            onPremConnectorLifecycleState;
+
+    /**
+     * For list pagination. The maximum number of items to return per page in a paginated \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending (ASC) or descending (DESC).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (ASC) or descending (DESC).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The field to sort by. You can specify only one sort order (sortOrder). The default order for TIMECREATED is descending. The default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can specify only one sort order (sortOrder). The default order for TIMECREATED is descending. The default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListOnPremConnectorsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListOnPremConnectorsRequest o) {
+            compartmentId(o.getCompartmentId());
+            onPremConnectorId(o.getOnPremConnectorId());
+            displayName(o.getDisplayName());
+            onPremConnectorLifecycleState(o.getOnPremConnectorLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListOnPremConnectorsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListOnPremConnectorsRequest
+         */
+        public ListOnPremConnectorsRequest build() {
+            ListOnPremConnectorsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestErrorsRequest.java
@@ -23,7 +23,7 @@ public class ListWorkRequestErrorsRequest
     private String opcRequestId;
 
     /**
-     * The beginning page from which the results start retrieving.
+     * For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String page;
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestLogsRequest.java
@@ -22,7 +22,7 @@ public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcReque
     private String opcRequestId;
 
     /**
-     * The beginning page from which the results start retrieving.
+     * For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String page;
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestsRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/ListWorkRequestsRequest.java
@@ -27,7 +27,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String opcRequestId;
 
     /**
-     * The beginning page from which the results start retrieving.
+     * For list pagination. The page token representing the page at which to start retrieving results. It is usually retrieved from a previous \"List\" call. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine).
      */
     private String page;
 

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/UpdateOnPremConnectorRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/UpdateOnPremConnectorRequest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateOnPremConnectorRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateOnPremConnectorDetails> {
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * The details used to update a on-premises connector.
+     */
+    private UpdateOnPremConnectorDetails updateOnPremConnectorDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the if-match parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateOnPremConnectorDetails getBody$() {
+        return updateOnPremConnectorDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateOnPremConnectorRequest, UpdateOnPremConnectorDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOnPremConnectorRequest o) {
+            onPremConnectorId(o.getOnPremConnectorId());
+            updateOnPremConnectorDetails(o.getUpdateOnPremConnectorDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateOnPremConnectorRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateOnPremConnectorRequest
+         */
+        public UpdateOnPremConnectorRequest build() {
+            UpdateOnPremConnectorRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateOnPremConnectorDetails body) {
+            updateOnPremConnectorDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/UpdateOnPremConnectorWalletRequest.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/requests/UpdateOnPremConnectorWalletRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.requests;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateOnPremConnectorWalletRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateOnPremConnectorWalletDetails> {
+
+    /**
+     * The details used to update an on-premises connector's wallet.
+     */
+    private UpdateOnPremConnectorWalletDetails updateOnPremConnectorWalletDetails;
+
+    /**
+     * The OCID of the on-premises connector.
+     */
+    private String onPremConnectorId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the if-match parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateOnPremConnectorWalletDetails getBody$() {
+        return updateOnPremConnectorWalletDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateOnPremConnectorWalletRequest, UpdateOnPremConnectorWalletDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOnPremConnectorWalletRequest o) {
+            updateOnPremConnectorWalletDetails(o.getUpdateOnPremConnectorWalletDetails());
+            onPremConnectorId(o.getOnPremConnectorId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateOnPremConnectorWalletRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateOnPremConnectorWalletRequest
+         */
+        public UpdateOnPremConnectorWalletRequest build() {
+            UpdateOnPremConnectorWalletRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateOnPremConnectorWalletDetails body) {
+            updateOnPremConnectorWalletDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ChangeDataSafePrivateEndpointCompartmentResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ChangeDataSafePrivateEndpointCompartmentResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class ChangeDataSafePrivateEndpointCompartmentResponse {
 
     /**
-     * The OCID of the work request. Use GetWorkRequest with this OCID to track the status of the request.
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
      *
      */
     private String opcWorkRequestId;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ChangeOnPremConnectorCompartmentResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ChangeOnPremConnectorCompartmentResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeOnPremConnectorCompartmentResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeOnPremConnectorCompartmentResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/CreateDataSafePrivateEndpointResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/CreateDataSafePrivateEndpointResponse.java
@@ -12,7 +12,13 @@ import com.oracle.bmc.datasafe.model.*;
 public class CreateDataSafePrivateEndpointResponse {
 
     /**
-     * The OCID of the work request. Use GetWorkRequest with this OCID to track the status of the request.
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     *
+     */
+    private String etag;
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
      *
      */
     private String opcWorkRequestId;
@@ -23,14 +29,28 @@ public class CreateDataSafePrivateEndpointResponse {
      */
     private String opcRequestId;
 
+    /**
+     * The full URI of the Data Safe private endpoint.
+     *
+     */
+    private String location;
+
+    /**
+     * The returned DataSafePrivateEndpoint instance.
+     */
+    private DataSafePrivateEndpoint dataSafePrivateEndpoint;
+
     public static class Builder {
         /**
          * Copy method to populate the builder with values from the given instance.
          * @return this builder instance
          */
         public Builder copy(CreateDataSafePrivateEndpointResponse o) {
+            etag(o.getEtag());
             opcWorkRequestId(o.getOpcWorkRequestId());
             opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            dataSafePrivateEndpoint(o.getDataSafePrivateEndpoint());
 
             return this;
         }

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/CreateOnPremConnectorResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/CreateOnPremConnectorResponse.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateOnPremConnectorResponse {
+
+    /**
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     *
+     */
+    private String etag;
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The full URI of the on-premises connector.
+     *
+     */
+    private String location;
+
+    /**
+     * The returned OnPremConnector instance.
+     */
+    private OnPremConnector onPremConnector;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateOnPremConnectorResponse o) {
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            onPremConnector(o.getOnPremConnector());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/DeleteDataSafePrivateEndpointResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/DeleteDataSafePrivateEndpointResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class DeleteDataSafePrivateEndpointResponse {
 
     /**
-     * The OCID of the work request. Use GetWorkRequest with this OCID to track the status of the request.
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
      *
      */
     private String opcWorkRequestId;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/DeleteOnPremConnectorResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/DeleteOnPremConnectorResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteOnPremConnectorResponse {
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteOnPremConnectorResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/EnableDataSafeConfigurationResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/EnableDataSafeConfigurationResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class EnableDataSafeConfigurationResponse {
 
     /**
-     * The OCID of the work request. Use GetWorkRequest with this OCID to track the status of the request.
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
      *
      */
     private String opcWorkRequestId;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GenerateOnPremConnectorConfigurationResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GenerateOnPremConnectorConfigurationResponse.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GenerateOnPremConnectorConfigurationResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Size of the file.
+     */
+    private Long contentLength;
+
+    /**
+     * The date and time the on-premises connector configuration was last modified, in the format defined by HTTP-date.
+     */
+    private java.util.Date lastModified;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GenerateOnPremConnectorConfigurationResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            contentLength(o.getContentLength());
+            lastModified(o.getLastModified());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetDataSafeConfigurationResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetDataSafeConfigurationResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class GetDataSafeConfigurationResponse {
 
     /**
-     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
      *
      */
     private String etag;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetDataSafePrivateEndpointResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetDataSafePrivateEndpointResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class GetDataSafePrivateEndpointResponse {
 
     /**
-     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
      *
      */
     private String etag;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetOnPremConnectorResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetOnPremConnectorResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetOnPremConnectorResponse {
+
+    /**
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned OnPremConnector instance.
+     */
+    private OnPremConnector onPremConnector;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetOnPremConnectorResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            onPremConnector(o.getOnPremConnector());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetWorkRequestResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/GetWorkRequestResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class GetWorkRequestResponse {
 
     /**
-     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
+     * For optimistic concurrency control. For more information, see [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven)
      *
      */
     private String etag;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ListOnPremConnectorsResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/ListOnPremConnectorsResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListOnPremConnectorsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain. Include opc-next-page value as the page parameter for the subsequent GET request to get the next batch of items. For details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of OnPremConnectorSummary instances.
+     */
+    private java.util.List<OnPremConnectorSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListOnPremConnectorsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateDataSafePrivateEndpointResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateDataSafePrivateEndpointResponse.java
@@ -12,7 +12,7 @@ import com.oracle.bmc.datasafe.model.*;
 public class UpdateDataSafePrivateEndpointResponse {
 
     /**
-     * The OCID of the work request. Use GetWorkRequest with this OCID to track the status of the request.
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
      *
      */
     private String opcWorkRequestId;

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateOnPremConnectorResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateOnPremConnectorResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateOnPremConnectorResponse {
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOnPremConnectorResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateOnPremConnectorWalletResponse.java
+++ b/bmc-datasafe/src/main/java/com/oracle/bmc/datasafe/responses/UpdateOnPremConnectorWalletResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datasafe.responses;
+
+import com.oracle.bmc.datasafe.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181201")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateOnPremConnectorWalletResponse {
+
+    /**
+     * The OCID of the work request. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with this OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateOnPremConnectorWalletResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgent.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgent.java
@@ -125,6 +125,15 @@ public interface ManagementAgent extends AutoCloseable {
     GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
 
     /**
+     * Lists the availability history records of Management Agent
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListAvailabilityHistoriesResponse listAvailabilityHistories(
+            ListAvailabilityHistoriesRequest request);
+
+    /**
      * Get supported agent image information
      *
      * @param request The request object containing the details to send

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsync.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsync.java
@@ -198,6 +198,22 @@ public interface ManagementAgentAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the availability history records of Management Agent
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAvailabilityHistoriesResponse> listAvailabilityHistories(
+            ListAvailabilityHistoriesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>
+                    handler);
+
+    /**
      * Get supported agent image information
      *
      *

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsyncClient.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsyncClient.java
@@ -708,6 +708,48 @@ public class ManagementAgentAsyncClient implements ManagementAgentAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListAvailabilityHistoriesResponse> listAvailabilityHistories(
+            ListAvailabilityHistoriesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>
+                    handler) {
+        LOG.trace("Called async listAvailabilityHistories");
+        final ListAvailabilityHistoriesRequest interceptedRequest =
+                ListAvailabilityHistoriesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAvailabilityHistoriesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAvailabilityHistoriesResponse>
+                transformer = ListAvailabilityHistoriesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListAvailabilityHistoriesRequest,
+                                ListAvailabilityHistoriesResponse>,
+                        java.util.concurrent.Future<ListAvailabilityHistoriesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListManagementAgentImagesResponse> listManagementAgentImages(
             ListManagementAgentImagesRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentClient.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentClient.java
@@ -718,6 +718,36 @@ public class ManagementAgentClient implements ManagementAgent {
     }
 
     @Override
+    public ListAvailabilityHistoriesResponse listAvailabilityHistories(
+            ListAvailabilityHistoriesRequest request) {
+        LOG.trace("Called listAvailabilityHistories");
+        final ListAvailabilityHistoriesRequest interceptedRequest =
+                ListAvailabilityHistoriesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAvailabilityHistoriesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListAvailabilityHistoriesResponse>
+                transformer = ListAvailabilityHistoriesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListManagementAgentImagesResponse listManagementAgentImages(
             ListManagementAgentImagesRequest request) {
         LOG.trace("Called listManagementAgentImages");

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentPaginators.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentPaginators.java
@@ -31,6 +31,126 @@ public class ManagementAgentPaginators {
     private final ManagementAgent client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listAvailabilityHistories operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListAvailabilityHistoriesResponse> listAvailabilityHistoriesResponseIterator(
+            final ListAvailabilityHistoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListAvailabilityHistoriesRequest.Builder, ListAvailabilityHistoriesRequest,
+                ListAvailabilityHistoriesResponse>(
+                new com.google.common.base.Supplier<ListAvailabilityHistoriesRequest.Builder>() {
+                    @Override
+                    public ListAvailabilityHistoriesRequest.Builder get() {
+                        return ListAvailabilityHistoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListAvailabilityHistoriesResponse, String>() {
+                    @Override
+                    public String apply(ListAvailabilityHistoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAvailabilityHistoriesRequest.Builder>,
+                        ListAvailabilityHistoriesRequest>() {
+                    @Override
+                    public ListAvailabilityHistoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAvailabilityHistoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>() {
+                    @Override
+                    public ListAvailabilityHistoriesResponse apply(
+                            ListAvailabilityHistoriesRequest request) {
+                        return client.listAvailabilityHistories(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.managementagent.model.AvailabilityHistorySummary} objects
+     * contained in responses from the listAvailabilityHistories operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.managementagent.model.AvailabilityHistorySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.managementagent.model.AvailabilityHistorySummary>
+            listAvailabilityHistoriesRecordIterator(
+                    final ListAvailabilityHistoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListAvailabilityHistoriesRequest.Builder, ListAvailabilityHistoriesRequest,
+                ListAvailabilityHistoriesResponse,
+                com.oracle.bmc.managementagent.model.AvailabilityHistorySummary>(
+                new com.google.common.base.Supplier<ListAvailabilityHistoriesRequest.Builder>() {
+                    @Override
+                    public ListAvailabilityHistoriesRequest.Builder get() {
+                        return ListAvailabilityHistoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListAvailabilityHistoriesResponse, String>() {
+                    @Override
+                    public String apply(ListAvailabilityHistoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListAvailabilityHistoriesRequest.Builder>,
+                        ListAvailabilityHistoriesRequest>() {
+                    @Override
+                    public ListAvailabilityHistoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListAvailabilityHistoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAvailabilityHistoriesRequest, ListAvailabilityHistoriesResponse>() {
+                    @Override
+                    public ListAvailabilityHistoriesResponse apply(
+                            ListAvailabilityHistoriesRequest request) {
+                        return client.listAvailabilityHistories(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListAvailabilityHistoriesResponse,
+                        java.util.List<
+                                com.oracle.bmc.managementagent.model
+                                        .AvailabilityHistorySummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.managementagent.model.AvailabilityHistorySummary>
+                            apply(ListAvailabilityHistoriesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listManagementAgentImages operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListAvailabilityHistoriesConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListAvailabilityHistoriesConverter.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.managementagent.model.*;
+import com.oracle.bmc.managementagent.requests.*;
+import com.oracle.bmc.managementagent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.extern.slf4j.Slf4j
+public class ListAvailabilityHistoriesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.managementagent.requests.ListAvailabilityHistoriesRequest
+            interceptRequest(
+                    com.oracle.bmc.managementagent.requests.ListAvailabilityHistoriesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.managementagent.requests.ListAvailabilityHistoriesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagementAgentId(), "managementAgentId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200202")
+                        .path("managementAgents")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagementAgentId()))
+                        .path("availabilityHistories");
+
+        if (request.getTimeAvailabilityStatusEndedGreaterThan() != null) {
+            target =
+                    target.queryParam(
+                            "timeAvailabilityStatusEndedGreaterThan",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeAvailabilityStatusEndedGreaterThan()));
+        }
+
+        if (request.getTimeAvailabilityStatusStartedLessThan() != null) {
+            target =
+                    target.queryParam(
+                            "timeAvailabilityStatusStartedLessThan",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeAvailabilityStatusStartedLessThan()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.managementagent.responses.ListAvailabilityHistoriesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.managementagent.responses.ListAvailabilityHistoriesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.managementagent.responses
+                                        .ListAvailabilityHistoriesResponse>() {
+                            @Override
+                            public com.oracle.bmc.managementagent.responses
+                                            .ListAvailabilityHistoriesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.managementagent.responses.ListAvailabilityHistoriesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<AvailabilityHistorySummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        AvailabilityHistorySummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<AvailabilityHistorySummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.managementagent.responses
+                                                .ListAvailabilityHistoriesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.managementagent.responses
+                                                        .ListAvailabilityHistoriesResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.managementagent.responses
+                                                .ListAvailabilityHistoriesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AvailabilityHistorySummary.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AvailabilityHistorySummary.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.model;
+
+/**
+ * Availability history of Management Agent.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AvailabilityHistorySummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AvailabilityHistorySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("managementAgentId")
+        private String managementAgentId;
+
+        public Builder managementAgentId(String managementAgentId) {
+            this.managementAgentId = managementAgentId;
+            this.__explicitlySet__.add("managementAgentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+        private AvailabilityStatus availabilityStatus;
+
+        public Builder availabilityStatus(AvailabilityStatus availabilityStatus) {
+            this.availabilityStatus = availabilityStatus;
+            this.__explicitlySet__.add("availabilityStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAvailabilityStatusStarted")
+        private java.util.Date timeAvailabilityStatusStarted;
+
+        public Builder timeAvailabilityStatusStarted(java.util.Date timeAvailabilityStatusStarted) {
+            this.timeAvailabilityStatusStarted = timeAvailabilityStatusStarted;
+            this.__explicitlySet__.add("timeAvailabilityStatusStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAvailabilityStatusEnded")
+        private java.util.Date timeAvailabilityStatusEnded;
+
+        public Builder timeAvailabilityStatusEnded(java.util.Date timeAvailabilityStatusEnded) {
+            this.timeAvailabilityStatusEnded = timeAvailabilityStatusEnded;
+            this.__explicitlySet__.add("timeAvailabilityStatusEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AvailabilityHistorySummary build() {
+            AvailabilityHistorySummary __instance__ =
+                    new AvailabilityHistorySummary(
+                            managementAgentId,
+                            availabilityStatus,
+                            timeAvailabilityStatusStarted,
+                            timeAvailabilityStatusEnded);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AvailabilityHistorySummary o) {
+            Builder copiedBuilder =
+                    managementAgentId(o.getManagementAgentId())
+                            .availabilityStatus(o.getAvailabilityStatus())
+                            .timeAvailabilityStatusStarted(o.getTimeAvailabilityStatusStarted())
+                            .timeAvailabilityStatusEnded(o.getTimeAvailabilityStatusEnded());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * agent identifier
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("managementAgentId")
+    String managementAgentId;
+
+    /**
+     * The availability status of managementAgent
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+    AvailabilityStatus availabilityStatus;
+
+    /**
+     * The time at which the Management Agent moved to the availability status. An RFC3339 formatted datetime string
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAvailabilityStatusStarted")
+    java.util.Date timeAvailabilityStatusStarted;
+
+    /**
+     * The time till which the Management Agent was known to be in the availability status. An RFC3339 formatted datetime string
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAvailabilityStatusEnded")
+    java.util.Date timeAvailabilityStatusEnded;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AvailabilityStatus.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AvailabilityStatus.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.model;
+
+/**
+ * Possible availability status.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.extern.slf4j.Slf4j
+public enum AvailabilityStatus {
+    Active("ACTIVE"),
+    Silent("SILENT"),
+    NotAvailable("NOT_AVAILABLE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, AvailabilityStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (AvailabilityStatus v : AvailabilityStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    AvailabilityStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AvailabilityStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'AvailabilityStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgent.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgent.java
@@ -159,6 +159,15 @@ public class ManagementAgent {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+        private AvailabilityStatus availabilityStatus;
+
+        public Builder availabilityStatus(AvailabilityStatus availabilityStatus) {
+            this.availabilityStatus = availabilityStatus;
+            this.__explicitlySet__.add("availabilityStatus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleStates lifecycleState;
 
@@ -217,6 +226,7 @@ public class ManagementAgent {
                             timeCreated,
                             timeUpdated,
                             timeLastHeartbeat,
+                            availabilityStatus,
                             lifecycleState,
                             lifecycleDetails,
                             freeformTags,
@@ -243,6 +253,7 @@ public class ManagementAgent {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .timeLastHeartbeat(o.getTimeLastHeartbeat())
+                            .availabilityStatus(o.getAvailabilityStatus())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
@@ -349,6 +360,12 @@ public class ManagementAgent {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLastHeartbeat")
     java.util.Date timeLastHeartbeat;
+
+    /**
+     * The current availability status of managementAgent
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+    AvailabilityStatus availabilityStatus;
 
     /**
      * The current state of managementAgent

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentSummary.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentSummary.java
@@ -134,6 +134,24 @@ public class ManagementAgentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastHeartbeat")
+        private java.util.Date timeLastHeartbeat;
+
+        public Builder timeLastHeartbeat(java.util.Date timeLastHeartbeat) {
+            this.timeLastHeartbeat = timeLastHeartbeat;
+            this.__explicitlySet__.add("timeLastHeartbeat");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+        private AvailabilityStatus availabilityStatus;
+
+        public Builder availabilityStatus(AvailabilityStatus availabilityStatus) {
+            this.availabilityStatus = availabilityStatus;
+            this.__explicitlySet__.add("availabilityStatus");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleStates lifecycleState;
 
@@ -189,6 +207,8 @@ public class ManagementAgentSummary {
                             host,
                             pluginList,
                             compartmentId,
+                            timeLastHeartbeat,
+                            availabilityStatus,
                             lifecycleState,
                             lifecycleDetails,
                             freeformTags,
@@ -212,6 +232,8 @@ public class ManagementAgentSummary {
                             .host(o.getHost())
                             .pluginList(o.getPluginList())
                             .compartmentId(o.getCompartmentId())
+                            .timeLastHeartbeat(o.getTimeLastHeartbeat())
+                            .availabilityStatus(o.getAvailabilityStatus())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
@@ -300,6 +322,18 @@ public class ManagementAgentSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The time the Management Agent has last recorded its heartbeat. An RFC3339 formatted datetime string
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastHeartbeat")
+    java.util.Date timeLastHeartbeat;
+
+    /**
+     * The current availability status of managementAgent
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityStatus")
+    AvailabilityStatus availabilityStatus;
 
     /**
      * The current state of managementAgent

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListAvailabilityHistoriesRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListAvailabilityHistoriesRequest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.requests;
+
+import com.oracle.bmc.managementagent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListAvailabilityHistoriesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Management Agent identifier
+     */
+    private String managementAgentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Filter to limit the availability history results to that of time after the input time including the boundary record.
+     * Defaulted to current date minus one year.
+     * The date and time to be given as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     */
+    private java.util.Date timeAvailabilityStatusEndedGreaterThan;
+
+    /**
+     * Filter to limit the availability history results to that of time before the input time including the boundary record
+     * Defaulted to current date.
+     * The date and time to be given as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     */
+    private java.util.Date timeAvailabilityStatusStartedLessThan;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The field to sort by. Default order for timeAvailabilityStatusStarted is descending.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Default order for timeAvailabilityStatusStarted is descending.
+     *
+     **/
+    public enum SortBy {
+        TimeAvailabilityStatusStarted("timeAvailabilityStatusStarted"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAvailabilityHistoriesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAvailabilityHistoriesRequest o) {
+            managementAgentId(o.getManagementAgentId());
+            opcRequestId(o.getOpcRequestId());
+            timeAvailabilityStatusEndedGreaterThan(o.getTimeAvailabilityStatusEndedGreaterThan());
+            timeAvailabilityStatusStartedLessThan(o.getTimeAvailabilityStatusStartedLessThan());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAvailabilityHistoriesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAvailabilityHistoriesRequest
+         */
+        public ListAvailabilityHistoriesRequest build() {
+            ListAvailabilityHistoriesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/ListAvailabilityHistoriesResponse.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/ListAvailabilityHistoriesResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.responses;
+
+import com.oracle.bmc.managementagent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListAvailabilityHistoriesResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of AvailabilityHistorySummary instances.
+     */
+    private java.util.List<AvailabilityHistorySummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAvailabilityHistoriesResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Channels.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/Channels.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+/**
+ * The API for the MySQL Database Service
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+public interface Channels extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Creates a Channel to establish replication from a source to a target.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    CreateChannelResponse createChannel(CreateChannelRequest request);
+
+    /**
+     * Deletes the specified Channel.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    DeleteChannelResponse deleteChannel(DeleteChannelRequest request);
+
+    /**
+     * Gets the full details of the specified Channel, including the user-specified
+     * configuration parameters (passwords are omitted), as well as information about
+     * the state of the Channel, its sources and targets.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    GetChannelResponse getChannel(GetChannelRequest request);
+
+    /**
+     * Lists all the Channels that match the specified filters.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ListChannelsResponse listChannels(ListChannelsRequest request);
+
+    /**
+     * Resets the specified Channel by purging its cached information, leaving the Channel
+     * as if it had just been created. This operation is only accepted in Inactive Channels.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ResetChannelResponse resetChannel(ResetChannelRequest request);
+
+    /**
+     * Resumes an enabled Channel that has become Inactive due to an error. The resume operation
+     * requires that the error that cause the Channel to become Inactive has already been fixed,
+     * otherwise the operation may fail.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    ResumeChannelResponse resumeChannel(ResumeChannelRequest request);
+
+    /**
+     * Updates the properties of the specified Channel.
+     * If the Channel is Active the Update operation will asynchronously apply the new configuration
+     * parameters to the Channel and the Channel may become temporarily unavailable. Otherwise, the
+     * new configuration will be applied the next time the Channel becomes Active.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     */
+    UpdateChannelResponse updateChannel(UpdateChannelRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    ChannelsWaiters getWaiters();
+
+    /**
+     * Gets the pre-configured paginators available for list operations in this service which may return multiple
+     * pages of data. These paginators provide an {@link java.lang.Iterable} interface so that service responses, or
+     * resources/records, can be iterated through without having to manually deal with pagination and page tokens.
+     *
+     * @return The service paginators.
+     */
+    ChannelsPaginators getPaginators();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsAsync.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsAsync.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+/**
+ * The API for the MySQL Database Service
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+public interface ChannelsAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Creates a Channel to establish replication from a source to a target.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateChannelResponse> createChannel(
+            CreateChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateChannelRequest, CreateChannelResponse>
+                    handler);
+
+    /**
+     * Deletes the specified Channel.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteChannelResponse> deleteChannel(
+            DeleteChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteChannelRequest, DeleteChannelResponse>
+                    handler);
+
+    /**
+     * Gets the full details of the specified Channel, including the user-specified
+     * configuration parameters (passwords are omitted), as well as information about
+     * the state of the Channel, its sources and targets.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetChannelResponse> getChannel(
+            GetChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetChannelRequest, GetChannelResponse> handler);
+
+    /**
+     * Lists all the Channels that match the specified filters.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListChannelsResponse> listChannels(
+            ListChannelsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListChannelsRequest, ListChannelsResponse>
+                    handler);
+
+    /**
+     * Resets the specified Channel by purging its cached information, leaving the Channel
+     * as if it had just been created. This operation is only accepted in Inactive Channels.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ResetChannelResponse> resetChannel(
+            ResetChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ResetChannelRequest, ResetChannelResponse>
+                    handler);
+
+    /**
+     * Resumes an enabled Channel that has become Inactive due to an error. The resume operation
+     * requires that the error that cause the Channel to become Inactive has already been fixed,
+     * otherwise the operation may fail.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ResumeChannelResponse> resumeChannel(
+            ResumeChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ResumeChannelRequest, ResumeChannelResponse>
+                    handler);
+
+    /**
+     * Updates the properties of the specified Channel.
+     * If the Channel is Active the Update operation will asynchronously apply the new configuration
+     * parameters to the Channel and the Channel may become temporarily unavailable. Otherwise, the
+     * new configuration will be applied the next time the Channel becomes Active.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateChannelResponse> updateChannel(
+            UpdateChannelRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateChannelRequest, UpdateChannelResponse>
+                    handler);
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsAsyncClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsAsyncClient.java
@@ -1,0 +1,595 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.internal.http.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+/**
+ * Async client implementation for Channels service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ChannelsAsyncClient implements ChannelsAsync {
+    /**
+     * Service instance for Channels.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("CHANNELS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://mysql.{region}.ocp.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ChannelsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder()
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, ChannelsAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ChannelsAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ChannelsAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateChannelResponse> createChannel(
+            CreateChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateChannelRequest, CreateChannelResponse>
+                    handler) {
+        LOG.trace("Called async createChannel");
+        final CreateChannelRequest interceptedRequest =
+                CreateChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateChannelResponse>
+                transformer = CreateChannelConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateChannelRequest, CreateChannelResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateChannelRequest, CreateChannelResponse>,
+                        java.util.concurrent.Future<CreateChannelResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateChannelRequest, CreateChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteChannelResponse> deleteChannel(
+            DeleteChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteChannelRequest, DeleteChannelResponse>
+                    handler) {
+        LOG.trace("Called async deleteChannel");
+        final DeleteChannelRequest interceptedRequest =
+                DeleteChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteChannelResponse>
+                transformer = DeleteChannelConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteChannelRequest, DeleteChannelResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteChannelRequest, DeleteChannelResponse>,
+                        java.util.concurrent.Future<DeleteChannelResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteChannelRequest, DeleteChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetChannelResponse> getChannel(
+            GetChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetChannelRequest, GetChannelResponse>
+                    handler) {
+        LOG.trace("Called async getChannel");
+        final GetChannelRequest interceptedRequest = GetChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetChannelResponse>
+                transformer = GetChannelConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetChannelRequest, GetChannelResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetChannelRequest, GetChannelResponse>,
+                        java.util.concurrent.Future<GetChannelResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetChannelRequest, GetChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListChannelsResponse> listChannels(
+            ListChannelsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListChannelsRequest, ListChannelsResponse>
+                    handler) {
+        LOG.trace("Called async listChannels");
+        final ListChannelsRequest interceptedRequest =
+                ListChannelsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListChannelsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListChannelsResponse>
+                transformer = ListChannelsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListChannelsRequest, ListChannelsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListChannelsRequest, ListChannelsResponse>,
+                        java.util.concurrent.Future<ListChannelsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListChannelsRequest, ListChannelsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ResetChannelResponse> resetChannel(
+            ResetChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ResetChannelRequest, ResetChannelResponse>
+                    handler) {
+        LOG.trace("Called async resetChannel");
+        final ResetChannelRequest interceptedRequest =
+                ResetChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResetChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ResetChannelResponse>
+                transformer = ResetChannelConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<ResetChannelRequest, ResetChannelResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ResetChannelRequest, ResetChannelResponse>,
+                        java.util.concurrent.Future<ResetChannelResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ResetChannelRequest, ResetChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ResumeChannelResponse> resumeChannel(
+            ResumeChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ResumeChannelRequest, ResumeChannelResponse>
+                    handler) {
+        LOG.trace("Called async resumeChannel");
+        final ResumeChannelRequest interceptedRequest =
+                ResumeChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResumeChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ResumeChannelResponse>
+                transformer = ResumeChannelConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<ResumeChannelRequest, ResumeChannelResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ResumeChannelRequest, ResumeChannelResponse>,
+                        java.util.concurrent.Future<ResumeChannelResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ResumeChannelRequest, ResumeChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateChannelResponse> updateChannel(
+            UpdateChannelRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateChannelRequest, UpdateChannelResponse>
+                    handler) {
+        LOG.trace("Called async updateChannel");
+        final UpdateChannelRequest interceptedRequest =
+                UpdateChannelConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateChannelConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateChannelResponse>
+                transformer = UpdateChannelConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateChannelRequest, UpdateChannelResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateChannelRequest, UpdateChannelResponse>,
+                        java.util.concurrent.Future<UpdateChannelResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateChannelRequest, UpdateChannelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsClient.java
@@ -1,0 +1,662 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.internal.http.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ChannelsClient implements Channels {
+    /**
+     * Service instance for Channels.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("CHANNELS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://mysql.{region}.ocp.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final ChannelsWaiters waiters;
+
+    private final ChannelsPaginators paginators;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                executorService,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected ChannelsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("Channels-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new ChannelsWaiters(executorService, this);
+
+        this.paginators = new ChannelsPaginators(this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, ChannelsClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ChannelsClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ChannelsClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public CreateChannelResponse createChannel(CreateChannelRequest request) {
+        LOG.trace("Called createChannel");
+        final CreateChannelRequest interceptedRequest =
+                CreateChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateChannelResponse>
+                transformer = CreateChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateChannelDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteChannelResponse deleteChannel(DeleteChannelRequest request) {
+        LOG.trace("Called deleteChannel");
+        final DeleteChannelRequest interceptedRequest =
+                DeleteChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteChannelResponse>
+                transformer = DeleteChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetChannelResponse getChannel(GetChannelRequest request) {
+        LOG.trace("Called getChannel");
+        final GetChannelRequest interceptedRequest = GetChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetChannelResponse> transformer =
+                GetChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListChannelsResponse listChannels(ListChannelsRequest request) {
+        LOG.trace("Called listChannels");
+        final ListChannelsRequest interceptedRequest =
+                ListChannelsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListChannelsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListChannelsResponse>
+                transformer = ListChannelsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ResetChannelResponse resetChannel(ResetChannelRequest request) {
+        LOG.trace("Called resetChannel");
+        final ResetChannelRequest interceptedRequest =
+                ResetChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResetChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ResetChannelResponse>
+                transformer = ResetChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ResumeChannelResponse resumeChannel(ResumeChannelRequest request) {
+        LOG.trace("Called resumeChannel");
+        final ResumeChannelRequest interceptedRequest =
+                ResumeChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResumeChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ResumeChannelResponse>
+                transformer = ResumeChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateChannelResponse updateChannel(UpdateChannelRequest request) {
+        LOG.trace("Called updateChannel");
+        final UpdateChannelRequest interceptedRequest =
+                UpdateChannelConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateChannelConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateChannelResponse>
+                transformer = UpdateChannelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateChannelDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChannelsWaiters getWaiters() {
+        return waiters;
+    }
+
+    @Override
+    public ChannelsPaginators getPaginators() {
+        return paginators;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsPaginators.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsPaginators.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+/**
+ * Collection of helper methods that can be used to provide an {@link java.lang.Iterable} interface
+ * to any list operations of Channels where multiple pages of data may be fetched.
+ * Two styles of iteration are supported:
+ *
+ * <ul>
+ *   <li>Iterating over the Response objects returned by the list operation. These are referred to as ResponseIterators, and the methods are suffixed with ResponseIterator. For example: <i>listUsersResponseIterator</i></li>
+ *   <li>Iterating over the resources/records being listed. These are referred to as RecordIterators, and the methods are suffixed with RecordIterator. For example: <i>listUsersRecordIterator</i></li>
+ * </ul>
+ *
+ * These iterables abstract away the need to write code to manually handle pagination via looping and using the page tokens.
+ * They will automatically fetch more data from the service when required.
+ *
+ * As an example, if we were using the ListUsers operation in IdentityService, then the {@link java.lang.Iterable} returned by calling a
+ * ResponseIterator method would iterate over the ListUsersResponse objects returned by each ListUsers call, whereas the {@link java.lang.Iterable}
+ * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
+ * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.RequiredArgsConstructor
+public class ChannelsPaginators {
+    private final Channels client;
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listChannels operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListChannelsResponse> listChannelsResponseIterator(
+            final ListChannelsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListChannelsRequest.Builder, ListChannelsRequest, ListChannelsResponse>(
+                new com.google.common.base.Supplier<ListChannelsRequest.Builder>() {
+                    @Override
+                    public ListChannelsRequest.Builder get() {
+                        return ListChannelsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListChannelsResponse, String>() {
+                    @Override
+                    public String apply(ListChannelsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListChannelsRequest.Builder>,
+                        ListChannelsRequest>() {
+                    @Override
+                    public ListChannelsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListChannelsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListChannelsRequest, ListChannelsResponse>() {
+                    @Override
+                    public ListChannelsResponse apply(ListChannelsRequest request) {
+                        return client.listChannels(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.mysql.model.ChannelSummary} objects
+     * contained in responses from the listChannels operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.mysql.model.ChannelSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.mysql.model.ChannelSummary> listChannelsRecordIterator(
+            final ListChannelsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListChannelsRequest.Builder, ListChannelsRequest, ListChannelsResponse,
+                com.oracle.bmc.mysql.model.ChannelSummary>(
+                new com.google.common.base.Supplier<ListChannelsRequest.Builder>() {
+                    @Override
+                    public ListChannelsRequest.Builder get() {
+                        return ListChannelsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListChannelsResponse, String>() {
+                    @Override
+                    public String apply(ListChannelsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListChannelsRequest.Builder>,
+                        ListChannelsRequest>() {
+                    @Override
+                    public ListChannelsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListChannelsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListChannelsRequest, ListChannelsResponse>() {
+                    @Override
+                    public ListChannelsResponse apply(ListChannelsRequest request) {
+                        return client.listChannels(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListChannelsResponse,
+                        java.util.List<com.oracle.bmc.mysql.model.ChannelSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.mysql.model.ChannelSummary> apply(
+                            ListChannelsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsWaiters.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/ChannelsWaiters.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql;
+
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of Channels.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.RequiredArgsConstructor
+public class ChannelsWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final Channels client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetChannelRequest, GetChannelResponse> forChannel(
+            GetChannelRequest request,
+            com.oracle.bmc.mysql.model.Channel.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forChannel(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetChannelRequest, GetChannelResponse> forChannel(
+            GetChannelRequest request,
+            com.oracle.bmc.mysql.model.Channel.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forChannel(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetChannelRequest, GetChannelResponse> forChannel(
+            GetChannelRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.mysql.model.Channel.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forChannel(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Channel.
+    private com.oracle.bmc.waiter.Waiter<GetChannelRequest, GetChannelResponse> forChannel(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetChannelRequest request,
+            final com.oracle.bmc.mysql.model.Channel.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.mysql.model.Channel.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetChannelRequest, GetChannelResponse>() {
+                            @Override
+                            public GetChannelResponse apply(GetChannelRequest request) {
+                                return client.getChannel(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetChannelResponse>() {
+                            @Override
+                            public boolean apply(GetChannelResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getChannel().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.mysql.model.Channel.LifecycleState.Deleted)),
+                request);
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/CreateChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/CreateChannelConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class CreateChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.CreateChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.CreateChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.CreateChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateChannelDetails(), "createChannelDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190415").path("channels");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.CreateChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.CreateChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.CreateChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.CreateChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.CreateChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Channel>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Channel.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Channel> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.CreateChannelResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.CreateChannelResponse
+                                                        .builder();
+
+                                builder.channel(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.CreateChannelResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/DeleteChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/DeleteChannelConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class DeleteChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.DeleteChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.DeleteChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.DeleteChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getChannelId(), "channelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("channels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getChannelId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.DeleteChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.DeleteChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.DeleteChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.DeleteChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.DeleteChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.DeleteChannelResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.DeleteChannelResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.DeleteChannelResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/GetChannelConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class GetChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.GetChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.GetChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.GetChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getChannelId(), "channelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("channels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getChannelId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfNoneMatch() != null) {
+            ib.header("if-none-match", request.getIfNoneMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.GetChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.GetChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.GetChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.GetChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.GetChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Channel>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Channel.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Channel> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.GetChannelResponse.Builder builder =
+                                        com.oracle.bmc.mysql.responses.GetChannelResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.channel(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.GetChannelResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListBackupsConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListBackupsConverter.java
@@ -70,6 +70,14 @@ public class ListBackupsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getCreationType() != null) {
+            target =
+                    target.queryParam(
+                            "creationType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCreationType().getValue()));
+        }
+
         if (request.getSortBy() != null) {
             target =
                     target.queryParam(

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListChannelsConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ListChannelsConverter.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ListChannelsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.ListChannelsRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.ListChannelsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.ListChannelsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190415").path("channels");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDbSystemId() != null) {
+            target =
+                    target.queryParam(
+                            "dbSystemId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDbSystemId()));
+        }
+
+        if (request.getChannelId() != null) {
+            target =
+                    target.queryParam(
+                            "channelId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getChannelId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getIsEnabled() != null) {
+            target =
+                    target.queryParam(
+                            "isEnabled",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsEnabled()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.ListChannelsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.ListChannelsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.ListChannelsResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.ListChannelsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.ListChannelsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<ChannelSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ChannelSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ChannelSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.ListChannelsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.ListChannelsResponse
+                                                        .builder();
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.ListChannelsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ResetChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ResetChannelConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ResetChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.ResetChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.ResetChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.ResetChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getChannelId(), "channelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("channels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getChannelId()))
+                        .path("actions")
+                        .path("reset");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.ResetChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.ResetChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.ResetChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.ResetChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.ResetChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.ResetChannelResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.ResetChannelResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.ResetChannelResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ResumeChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ResumeChannelConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ResumeChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.ResumeChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.ResumeChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.ResumeChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getChannelId(), "channelId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("channels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getChannelId()))
+                        .path("actions")
+                        .path("resume");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.ResumeChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.ResumeChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.ResumeChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.ResumeChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.ResumeChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.ResumeChannelResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.ResumeChannelResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.ResumeChannelResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/UpdateChannelConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/UpdateChannelConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class UpdateChannelConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.UpdateChannelRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.UpdateChannelRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.UpdateChannelRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getChannelId(), "channelId must not be blank");
+        Validate.notNull(request.getUpdateChannelDetails(), "updateChannelDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("channels")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getChannelId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.mysql.responses.UpdateChannelResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.UpdateChannelResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.UpdateChannelResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.UpdateChannelResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.UpdateChannelResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.UpdateChannelResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses.UpdateChannelResponse
+                                                        .builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.UpdateChannelResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Backup.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Backup.java
@@ -131,6 +131,15 @@ public class Backup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemSnapshot")
+        private DbSystemSnapshot dbSystemSnapshot;
+
+        public Builder dbSystemSnapshot(DbSystemSnapshot dbSystemSnapshot) {
+            this.dbSystemSnapshot = dbSystemSnapshot;
+            this.__explicitlySet__.add("dbSystemSnapshot");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("backupSizeInGBs")
         private Integer backupSizeInGBs;
 
@@ -212,6 +221,7 @@ public class Backup {
                             backupType,
                             creationType,
                             dbSystemId,
+                            dbSystemSnapshot,
                             backupSizeInGBs,
                             retentionInDays,
                             dataStorageSizeInGBs,
@@ -237,6 +247,7 @@ public class Backup {
                             .backupType(o.getBackupType())
                             .creationType(o.getCreationType())
                             .dbSystemId(o.getDbSystemId())
+                            .dbSystemSnapshot(o.getDbSystemSnapshot())
                             .backupSizeInGBs(o.getBackupSizeInGBs())
                             .retentionInDays(o.getRetentionInDays())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
@@ -463,6 +474,9 @@ public class Backup {
     @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
     String dbSystemId;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemSnapshot")
+    DbSystemSnapshot dbSystemSnapshot;
+
     /**
      * The size of the backup in base-2 (IEC) gibibytes. (GiB).
      **/
@@ -495,7 +509,7 @@ public class Backup {
     String shapeName;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -503,7 +517,7 @@ public class Backup {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/BackupSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/BackupSummary.java
@@ -84,6 +84,15 @@ public class BackupSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("creationType")
+        private Backup.CreationType creationType;
+
+        public Builder creationType(Backup.CreationType creationType) {
+            this.creationType = creationType;
+            this.__explicitlySet__.add("creationType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
         private String dbSystemId;
 
@@ -169,6 +178,7 @@ public class BackupSummary {
                             timeCreated,
                             lifecycleState,
                             backupType,
+                            creationType,
                             dbSystemId,
                             dataStorageSizeInGBs,
                             backupSizeInGBs,
@@ -190,6 +200,7 @@ public class BackupSummary {
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState())
                             .backupType(o.getBackupType())
+                            .creationType(o.getCreationType())
                             .dbSystemId(o.getDbSystemId())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
                             .backupSizeInGBs(o.getBackupSizeInGBs())
@@ -248,6 +259,12 @@ public class BackupSummary {
     Backup.BackupType backupType;
 
     /**
+     * If the backup was created automatically, or by a manual request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("creationType")
+    Backup.CreationType creationType;
+
+    /**
      * The OCID of the DB System the Backup is associated with.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
@@ -284,7 +301,7 @@ public class BackupSummary {
     String shapeName;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -292,7 +309,7 @@ public class BackupSummary {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CaCertificate.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CaCertificate.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * The CA certificate of the server used for VERIFY_IDENTITY and VERIFY_CA ssl modes.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "certificateType",
+    defaultImpl = CaCertificate.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PemCaCertificate.class,
+        name = "PEM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CaCertificate {
+
+    /**
+     * The type of CA certificate.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum CertificateType {
+        Pem("PEM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, CertificateType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (CertificateType v : CertificateType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        CertificateType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static CertificateType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'CertificateType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Channel.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Channel.java
@@ -1,0 +1,328 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * A Channel connecting a DB System to an external entity.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Channel.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Channel {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private ChannelSource source;
+
+        public Builder source(ChannelSource source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private ChannelTarget target;
+
+        public Builder target(ChannelTarget target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Channel build() {
+            Channel __instance__ =
+                    new Channel(
+                            id,
+                            compartmentId,
+                            displayName,
+                            isEnabled,
+                            source,
+                            target,
+                            description,
+                            lifecycleState,
+                            lifecycleDetails,
+                            timeCreated,
+                            timeUpdated,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Channel o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .source(o.getSource())
+                            .target(o.getTarget())
+                            .description(o.getDescription())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the Channel. It does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Whether the Channel has been enabled by the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    ChannelSource source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    ChannelTarget target;
+
+    /**
+     * User provided description of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+    /**
+     * The state of the Channel.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Active("ACTIVE"),
+        NeedsAttention("NEEDS_ATTENTION"),
+        Inactive("INACTIVE"),
+        Updating("UPDATING"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The state of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A message describing the state of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The date and time the Channel was created, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the Channel was last updated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSource.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSource.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the source for the given Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType",
+    defaultImpl = ChannelSource.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ChannelSourceMysql.class,
+        name = "MYSQL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChannelSource {
+
+    /**
+     * The specific source identifier.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum SourceType {
+        Mysql("MYSQL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, SourceType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SourceType v : SourceType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        SourceType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SourceType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'SourceType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSourceMysql.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSourceMysql.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Core properties of a Mysql Channel source.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChannelSourceMysql.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChannelSourceMysql extends ChannelSource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+        private SslMode sslMode;
+
+        public Builder sslMode(SslMode sslMode) {
+            this.sslMode = sslMode;
+            this.__explicitlySet__.add("sslMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+        private CaCertificate sslCaCertificate;
+
+        public Builder sslCaCertificate(CaCertificate sslCaCertificate) {
+            this.sslCaCertificate = sslCaCertificate;
+            this.__explicitlySet__.add("sslCaCertificate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChannelSourceMysql build() {
+            ChannelSourceMysql __instance__ =
+                    new ChannelSourceMysql(hostname, port, username, sslMode, sslCaCertificate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChannelSourceMysql o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname())
+                            .port(o.getPort())
+                            .username(o.getUsername())
+                            .sslMode(o.getSslMode())
+                            .sslCaCertificate(o.getSslCaCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ChannelSourceMysql(
+            String hostname,
+            Integer port,
+            String username,
+            SslMode sslMode,
+            CaCertificate sslCaCertificate) {
+        super();
+        this.hostname = hostname;
+        this.port = port;
+        this.username = username;
+        this.sslMode = sslMode;
+        this.sslCaCertificate = sslCaCertificate;
+    }
+
+    /**
+     * The network address of the MySQL instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * The port the source MySQL instance listens on.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    /**
+     * The name of the replication user on the source MySQL instance.
+     * The username has a maximum length of 96 characters. For more information,
+     * please see the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+    /**
+     * The SSL mode of the Channel.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum SslMode {
+        VerifyIdentity("VERIFY_IDENTITY"),
+        VerifyCa("VERIFY_CA"),
+        Required("REQUIRED"),
+        Disabled("DISABLED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, SslMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SslMode v : SslMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        SslMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SslMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'SslMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The SSL mode of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+    SslMode sslMode;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+    CaCertificate sslCaCertificate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelSummary.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Summary of a Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ChannelSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChannelSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private ChannelSource source;
+
+        public Builder source(ChannelSource source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private ChannelTarget target;
+
+        public Builder target(ChannelTarget target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Channel.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Channel.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChannelSummary build() {
+            ChannelSummary __instance__ =
+                    new ChannelSummary(
+                            id,
+                            compartmentId,
+                            isEnabled,
+                            source,
+                            target,
+                            lifecycleState,
+                            lifecycleDetails,
+                            displayName,
+                            timeCreated,
+                            timeUpdated,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChannelSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .isEnabled(o.getIsEnabled())
+                            .source(o.getSource())
+                            .target(o.getTarget())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .displayName(o.getDisplayName())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The OCID of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Whether the Channel has been enabled by the user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    ChannelSource source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    ChannelTarget target;
+
+    /**
+     * The state of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    Channel.LifecycleState lifecycleState;
+
+    /**
+     * A message describing the state of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The user-friendly name for the Channel. It does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The date and time the Channel was created, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the Channel was last updated, as described by [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelTarget.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelTarget.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Details about the Channel target.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = ChannelTarget.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ChannelTargetDbSystem.class,
+        name = "DBSYSTEM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ChannelTarget {
+
+    /**
+     * The specific target identifier.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TargetType {
+        Dbsystem("DBSYSTEM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TargetType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TargetType v : TargetType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TargetType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TargetType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TargetType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelTargetDbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChannelTargetDbSystem.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Core properties of a DB System Channel target.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChannelTargetDbSystem.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChannelTargetDbSystem extends ChannelTarget {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+        private String channelName;
+
+        public Builder channelName(String channelName) {
+            this.channelName = channelName;
+            this.__explicitlySet__.add("channelName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+        private String applierUsername;
+
+        public Builder applierUsername(String applierUsername) {
+            this.applierUsername = applierUsername;
+            this.__explicitlySet__.add("applierUsername");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChannelTargetDbSystem build() {
+            ChannelTargetDbSystem __instance__ =
+                    new ChannelTargetDbSystem(dbSystemId, channelName, applierUsername);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChannelTargetDbSystem o) {
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .channelName(o.getChannelName())
+                            .applierUsername(o.getApplierUsername());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ChannelTargetDbSystem(String dbSystemId, String channelName, String applierUsername) {
+        super();
+        this.dbSystemId = dbSystemId;
+        this.channelName = channelName;
+        this.applierUsername = applierUsername;
+    }
+
+    /**
+     * The OCID of the source DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    /**
+     * The case-insensitive name that identifies the replication channel. Channel names
+     * must follow the rules defined for [MySQL identifiers](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html).
+     * The names of non-Deleted Channels must be unique for each DB System.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+    String channelName;
+
+    /**
+     * The username for the replication applier of the target MySQL DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+    String applierUsername;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Configuration.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Configuration.java
@@ -351,7 +351,7 @@ public class Configuration {
     String parentConfigurationId;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -359,7 +359,7 @@ public class Configuration {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationSummary.java
@@ -230,7 +230,7 @@ public class ConfigurationSummary {
     java.util.Date timeUpdated;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -238,7 +238,7 @@ public class ConfigurationSummary {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationVariables.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationVariables.java
@@ -463,6 +463,16 @@ public class ConfigurationVariables {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("mysqlxZstdDefaultCompressionLevel")
+        private Integer mysqlxZstdDefaultCompressionLevel;
+
+        public Builder mysqlxZstdDefaultCompressionLevel(
+                Integer mysqlxZstdDefaultCompressionLevel) {
+            this.mysqlxZstdDefaultCompressionLevel = mysqlxZstdDefaultCompressionLevel;
+            this.__explicitlySet__.add("mysqlxZstdDefaultCompressionLevel");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("mysqlZstdDefaultCompressionLevel")
         private Integer mysqlZstdDefaultCompressionLevel;
 
@@ -526,6 +536,7 @@ public class ConfigurationVariables {
                             mysqlxLz4MaxClientCompressionLevel,
                             mysqlxLz4DefaultCompressionLevel,
                             mysqlxZstdMaxClientCompressionLevel,
+                            mysqlxZstdDefaultCompressionLevel,
                             mysqlZstdDefaultCompressionLevel);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -587,6 +598,8 @@ public class ConfigurationVariables {
                                     o.getMysqlxLz4DefaultCompressionLevel())
                             .mysqlxZstdMaxClientCompressionLevel(
                                     o.getMysqlxZstdMaxClientCompressionLevel())
+                            .mysqlxZstdDefaultCompressionLevel(
+                                    o.getMysqlxZstdDefaultCompressionLevel())
                             .mysqlZstdDefaultCompressionLevel(
                                     o.getMysqlZstdDefaultCompressionLevel());
 
@@ -713,6 +726,7 @@ public class ConfigurationVariables {
     public enum TransactionIsolation {
         ReadUncommitted("READ-UNCOMMITTED"),
         ReadCommited("READ-COMMITED"),
+        ReadCommitted("READ-COMMITTED"),
         RepeatableRead("REPEATABLE-READ"),
         Serializable("SERIALIZABLE"),
 
@@ -803,7 +817,7 @@ public class ConfigurationVariables {
     Boolean mysqlFirewallMode;
 
     /**
-     * (\"mysqlx_enable_hello_notice\")
+     * (\"mysqlx_enable_hello_notice\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxEnableHelloNotice")
     Boolean mysqlxEnableHelloNotice;
@@ -821,7 +835,7 @@ public class ConfigurationVariables {
     Boolean sqlWarnings;
 
     /**
-     * (\"binlog_expire_logs_seconds\")
+     * (\"binlog_expire_logs_seconds\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("binlogExpireLogsSeconds")
     Integer binlogExpireLogsSeconds;
@@ -863,7 +877,7 @@ public class ConfigurationVariables {
     Integer cteMaxRecursionDepth;
 
     /**
-     * (\"generated_random_password_length\")
+     * (\"generated_random_password_length\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("generatedRandomPasswordLength")
     Integer generatedRandomPasswordLength;
@@ -923,55 +937,55 @@ public class ConfigurationVariables {
     Integer maxExecutionTime;
 
     /**
-     * (\"mysqlx_connect_timeout\")
+     * (\"mysqlx_connect_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxConnectTimeout")
     Integer mysqlxConnectTimeout;
 
     /**
-     * (\"mysqlx_document_id_unique_prefix\")
+     * (\"mysqlx_document_id_unique_prefix\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxDocumentIdUniquePrefix")
     Integer mysqlxDocumentIdUniquePrefix;
 
     /**
-     * (\"mysqlx_idle_worker_thread_timeout\")
+     * (\"mysqlx_idle_worker_thread_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxIdleWorkerThreadTimeout")
     Integer mysqlxIdleWorkerThreadTimeout;
 
     /**
-     * (\"mysqlx_interactive_timeout\")
+     * (\"mysqlx_interactive_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxInteractiveTimeout")
     Integer mysqlxInteractiveTimeout;
 
     /**
-     * (\"mysqlx_max_allowed_packet\")
+     * (\"mysqlx_max_allowed_packet\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxMaxAllowedPacket")
     Integer mysqlxMaxAllowedPacket;
 
     /**
-     * (\"mysqlx_min_worker_threads\")
+     * (\"mysqlx_min_worker_threads\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxMinWorkerThreads")
     Integer mysqlxMinWorkerThreads;
 
     /**
-     * (\"mysqlx_read_timeout\")
+     * (\"mysqlx_read_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxReadTimeout")
     Integer mysqlxReadTimeout;
 
     /**
-     * (\"mysqlx_wait_timeout\")
+     * (\"mysqlx_wait_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxWaitTimeout")
     Integer mysqlxWaitTimeout;
 
     /**
-     * (\"mysqlx_write_timeout\")
+     * (\"mysqlx_write_timeout\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlxWriteTimeout")
     Integer mysqlxWriteTimeout;
@@ -983,13 +997,13 @@ public class ConfigurationVariables {
     Integer parserMaxMemSize;
 
     /**
-     * (\"query_alloc_block_size\")
+     * (\"query_alloc_block_size\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("queryAllocBlockSize")
     Integer queryAllocBlockSize;
 
     /**
-     * (\"query_prealloc_size\")
+     * (\"query_prealloc_size\") DEPRECATED -- variable should not be settable and will be ignored
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("queryPreallocSize")
     Integer queryPreallocSize;
@@ -1032,6 +1046,12 @@ public class ConfigurationVariables {
 
     /**
      * Set the default compression level for the zstd algorithm. (\"mysqlx_zstd_default_compression_level\")
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("mysqlxZstdDefaultCompressionLevel")
+    Integer mysqlxZstdDefaultCompressionLevel;
+
+    /**
+     * DEPRECATED -- typo of mysqlx_zstd_default_compression_level. variable will be ignored.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("mysqlZstdDefaultCompressionLevel")
     Integer mysqlZstdDefaultCompressionLevel;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateBackupDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateBackupDetails.java
@@ -195,7 +195,7 @@ public class CreateBackupDetails {
     Integer retentionInDays;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -203,7 +203,7 @@ public class CreateBackupDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateBackupPolicyDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateBackupPolicyDetails.java
@@ -131,6 +131,9 @@ public class CreateBackupPolicyDetails {
 
     /**
      * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * <p>
+     * Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+     * <p>
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelDetails.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Details required to create a Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateChannelDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateChannelDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private CreateChannelSourceDetails source;
+
+        public Builder source(CreateChannelSourceDetails source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private CreateChannelTargetDetails target;
+
+        public Builder target(CreateChannelTargetDetails target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateChannelDetails build() {
+            CreateChannelDetails __instance__ =
+                    new CreateChannelDetails(
+                            compartmentId,
+                            displayName,
+                            isEnabled,
+                            source,
+                            target,
+                            description,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateChannelDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .source(o.getSource())
+                            .target(o.getTarget())
+                            .description(o.getDescription())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The user-friendly name for the Channel. It does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Whether the Channel should be enabled upon creation. If set to true, the Channel
+     * will be asynchronously started as a result of the create Channel operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    CreateChannelSourceDetails source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    CreateChannelTargetDetails target;
+
+    /**
+     * User provided information about the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelSourceDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelSourceDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the source for the given Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType",
+    defaultImpl = CreateChannelSourceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateChannelSourceFromMysqlDetails.class,
+        name = "MYSQL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateChannelSourceDetails {}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelSourceFromMysqlDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelSourceFromMysqlDetails.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the source endpoint that is a MySQL Server.
+ * Typically a MySQL Server that is not managed by the MySQL Database Service.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateChannelSourceFromMysqlDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateChannelSourceFromMysqlDetails extends CreateChannelSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("password")
+        private String password;
+
+        public Builder password(String password) {
+            this.password = password;
+            this.__explicitlySet__.add("password");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+        private ChannelSourceMysql.SslMode sslMode;
+
+        public Builder sslMode(ChannelSourceMysql.SslMode sslMode) {
+            this.sslMode = sslMode;
+            this.__explicitlySet__.add("sslMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+        private CaCertificate sslCaCertificate;
+
+        public Builder sslCaCertificate(CaCertificate sslCaCertificate) {
+            this.sslCaCertificate = sslCaCertificate;
+            this.__explicitlySet__.add("sslCaCertificate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateChannelSourceFromMysqlDetails build() {
+            CreateChannelSourceFromMysqlDetails __instance__ =
+                    new CreateChannelSourceFromMysqlDetails(
+                            hostname, port, username, password, sslMode, sslCaCertificate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateChannelSourceFromMysqlDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname())
+                            .port(o.getPort())
+                            .username(o.getUsername())
+                            .password(o.getPassword())
+                            .sslMode(o.getSslMode())
+                            .sslCaCertificate(o.getSslCaCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateChannelSourceFromMysqlDetails(
+            String hostname,
+            Integer port,
+            String username,
+            String password,
+            ChannelSourceMysql.SslMode sslMode,
+            CaCertificate sslCaCertificate) {
+        super();
+        this.hostname = hostname;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.sslMode = sslMode;
+        this.sslCaCertificate = sslCaCertificate;
+    }
+
+    /**
+     * The network address of the MySQL instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * The port the source MySQL instance listens on.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    /**
+     * The name of the replication user on the source MySQL instance.
+     * The username has a maximum length of 96 characters. For more information,
+     * please see the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * The password for the replication user. The password must be
+     * between 8 and 32 characters long, and must contain at least 1
+     * numeric character, 1 lowercase character, 1 uppercase character,
+     * and 1 special (nonalphanumeric) character.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("password")
+    String password;
+
+    /**
+     * The SSL mode of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+    ChannelSourceMysql.SslMode sslMode;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+    CaCertificate sslCaCertificate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelTargetDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelTargetDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the target for the given Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = CreateChannelTargetDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateChannelTargetFromDbSystemDetails.class,
+        name = "DBSYSTEM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateChannelTargetDetails {}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelTargetFromDbSystemDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateChannelTargetFromDbSystemDetails.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the target endpoint that is a DB System.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateChannelTargetFromDbSystemDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateChannelTargetFromDbSystemDetails extends CreateChannelTargetDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+        private String dbSystemId;
+
+        public Builder dbSystemId(String dbSystemId) {
+            this.dbSystemId = dbSystemId;
+            this.__explicitlySet__.add("dbSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+        private String channelName;
+
+        public Builder channelName(String channelName) {
+            this.channelName = channelName;
+            this.__explicitlySet__.add("channelName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+        private String applierUsername;
+
+        public Builder applierUsername(String applierUsername) {
+            this.applierUsername = applierUsername;
+            this.__explicitlySet__.add("applierUsername");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateChannelTargetFromDbSystemDetails build() {
+            CreateChannelTargetFromDbSystemDetails __instance__ =
+                    new CreateChannelTargetFromDbSystemDetails(
+                            dbSystemId, channelName, applierUsername);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateChannelTargetFromDbSystemDetails o) {
+            Builder copiedBuilder =
+                    dbSystemId(o.getDbSystemId())
+                            .channelName(o.getChannelName())
+                            .applierUsername(o.getApplierUsername());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateChannelTargetFromDbSystemDetails(
+            String dbSystemId, String channelName, String applierUsername) {
+        super();
+        this.dbSystemId = dbSystemId;
+        this.channelName = channelName;
+        this.applierUsername = applierUsername;
+    }
+
+    /**
+     * The OCID of the target DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbSystemId")
+    String dbSystemId;
+
+    /**
+     * The case-insensitive name that identifies the replication channel. Channel names
+     * must follow the rules defined for [MySQL identifiers](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html).
+     * The names of non-Deleted Channels must be unique for each DB System.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+    String channelName;
+
+    /**
+     * The username for the replication applier of the target MySQL DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+    String applierUsername;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateConfigurationDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateConfigurationDetails.java
@@ -177,7 +177,7 @@ public class CreateConfigurationDetails {
     String parentConfigurationId;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -185,7 +185,7 @@ public class CreateConfigurationDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemSourceDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemSourceDetails.java
@@ -34,6 +34,10 @@ package com.oracle.bmc.mysql.model;
         name = "BACKUP"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateDbSystemSourceFromNoneDetails.class,
+        name = "NONE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateDbSystemSourceImportFromUrlDetails.class,
         name = "IMPORTURL"
     )

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemSourceFromNoneDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/CreateDbSystemSourceFromNoneDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Creation of a DbSystem from no particular source.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDbSystemSourceFromNoneDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateDbSystemSourceFromNoneDetails extends CreateDbSystemSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDbSystemSourceFromNoneDetails build() {
+            CreateDbSystemSourceFromNoneDetails __instance__ =
+                    new CreateDbSystemSourceFromNoneDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDbSystemSourceFromNoneDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateDbSystemSourceFromNoneDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystem.java
@@ -6,6 +6,8 @@ package com.oracle.bmc.mysql.model;
 
 /**
  * A DB System is the core logical unit of MySQL Database Service.
+ * # NOTE: definitions/DbSystemSnapshot is a snapshot version of DbSystem which is stored during backup. Any
+ * # addition/deletion of properties should also consider snapshot's definition
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -205,6 +207,15 @@ public class DbSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("channels")
+        private java.util.List<ChannelSummary> channels;
+
+        public Builder channels(java.util.List<ChannelSummary> channels) {
+            this.channels = channels;
+            this.__explicitlySet__.add("channels");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -295,6 +306,7 @@ public class DbSystem {
                             port,
                             portX,
                             endpoints,
+                            channels,
                             lifecycleState,
                             lifecycleDetails,
                             maintenance,
@@ -329,6 +341,7 @@ public class DbSystem {
                             .port(o.getPort())
                             .portX(o.getPortX())
                             .endpoints(o.getEndpoints())
+                            .channels(o.getChannels())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .maintenance(o.getMaintenance())
@@ -479,6 +492,12 @@ public class DbSystem {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("endpoints")
     java.util.List<DbSystemEndpoint> endpoints;
+
+    /**
+     * A list with a summary of all the Channels attached to the DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("channels")
+    java.util.List<ChannelSummary> channels;
     /**
      * The current state of the DB System.
      **/
@@ -558,7 +577,7 @@ public class DbSystem {
     java.util.Date timeUpdated;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -566,7 +585,7 @@ public class DbSystem {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSnapshot.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Snapshot of the DbSystem details at the time of the backup
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DbSystemSnapshot.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbSystemSnapshot {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("faultDomain")
+        private String faultDomain;
+
+        public Builder faultDomain(String faultDomain) {
+            this.faultDomain = faultDomain;
+            this.__explicitlySet__.add("faultDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("mysqlVersion")
+        private String mysqlVersion;
+
+        public Builder mysqlVersion(String mysqlVersion) {
+            this.mysqlVersion = mysqlVersion;
+            this.__explicitlySet__.add("mysqlVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminUsername")
+        private String adminUsername;
+
+        public Builder adminUsername(String adminUsername) {
+            this.adminUsername = adminUsername;
+            this.__explicitlySet__.add("adminUsername");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupPolicy")
+        private BackupPolicy backupPolicy;
+
+        public Builder backupPolicy(BackupPolicy backupPolicy) {
+            this.backupPolicy = backupPolicy;
+            this.__explicitlySet__.add("backupPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configurationId")
+        private String configurationId;
+
+        public Builder configurationId(String configurationId) {
+            this.configurationId = configurationId;
+            this.__explicitlySet__.add("configurationId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInGBs")
+        private Integer dataStorageSizeInGBs;
+
+        public Builder dataStorageSizeInGBs(Integer dataStorageSizeInGBs) {
+            this.dataStorageSizeInGBs = dataStorageSizeInGBs;
+            this.__explicitlySet__.add("dataStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hostnameLabel")
+        private String hostnameLabel;
+
+        public Builder hostnameLabel(String hostnameLabel) {
+            this.hostnameLabel = hostnameLabel;
+            this.__explicitlySet__.add("hostnameLabel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ipAddress")
+        private String ipAddress;
+
+        public Builder ipAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            this.__explicitlySet__.add("ipAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("portX")
+        private Integer portX;
+
+        public Builder portX(Integer portX) {
+            this.portX = portX;
+            this.__explicitlySet__.add("portX");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("endpoints")
+        private java.util.List<DbSystemEndpoint> endpoints;
+
+        public Builder endpoints(java.util.List<DbSystemEndpoint> endpoints) {
+            this.endpoints = endpoints;
+            this.__explicitlySet__.add("endpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maintenance")
+        private MaintenanceDetails maintenance;
+
+        public Builder maintenance(MaintenanceDetails maintenance) {
+            this.maintenance = maintenance;
+            this.__explicitlySet__.add("maintenance");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbSystemSnapshot build() {
+            DbSystemSnapshot __instance__ =
+                    new DbSystemSnapshot(
+                            id,
+                            displayName,
+                            description,
+                            compartmentId,
+                            subnetId,
+                            availabilityDomain,
+                            faultDomain,
+                            shapeName,
+                            mysqlVersion,
+                            adminUsername,
+                            backupPolicy,
+                            configurationId,
+                            dataStorageSizeInGBs,
+                            hostnameLabel,
+                            ipAddress,
+                            port,
+                            portX,
+                            endpoints,
+                            maintenance,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbSystemSnapshot o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .compartmentId(o.getCompartmentId())
+                            .subnetId(o.getSubnetId())
+                            .availabilityDomain(o.getAvailabilityDomain())
+                            .faultDomain(o.getFaultDomain())
+                            .shapeName(o.getShapeName())
+                            .mysqlVersion(o.getMysqlVersion())
+                            .adminUsername(o.getAdminUsername())
+                            .backupPolicy(o.getBackupPolicy())
+                            .configurationId(o.getConfigurationId())
+                            .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
+                            .hostnameLabel(o.getHostnameLabel())
+                            .ipAddress(o.getIpAddress())
+                            .port(o.getPort())
+                            .portX(o.getPortX())
+                            .endpoints(o.getEndpoints())
+                            .maintenance(o.getMaintenance())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The user-friendly name for the DB System. It does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * User-provided data about the DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The OCID of the compartment the DB System belongs in.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The OCID of the subnet the DB System is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * The Availability Domain where the primary DB System should be located.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    /**
+     * The name of the Fault Domain the DB System is located in.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("faultDomain")
+    String faultDomain;
+
+    /**
+     * The shape of the primary instances of the DB System. The shape
+     * determines resources allocated to a DB System - CPU cores
+     * and memory for VM shapes; CPU cores, memory and storage for non-VM
+     * (or bare metal) shapes. To get a list of shapes, use (the
+     * {@link #listShapes(ListShapesRequest) listShapes} operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * Name of the MySQL Version in use for the DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("mysqlVersion")
+    String mysqlVersion;
+
+    /**
+     * The username for the administrative user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminUsername")
+    String adminUsername;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("backupPolicy")
+    BackupPolicy backupPolicy;
+
+    /**
+     * The OCID of the Configuration to be used for Instances in this DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("configurationId")
+    String configurationId;
+
+    /**
+     * Initial size of the data volume in GiBs that will be created and attached.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInGBs")
+    Integer dataStorageSizeInGBs;
+
+    /**
+     * The hostname for the primary endpoint of the DB System. Used for DNS.
+     * The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN)
+     * (for example, \"dbsystem-1\" in FQDN \"dbsystem-1.subnet123.vcn1.oraclevcn.com\").
+     * Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostnameLabel")
+    String hostnameLabel;
+
+    /**
+     * The IP address the DB System is configured to listen on. A private
+     * IP address of the primary endpoint of the DB System. Must be an
+     * available IP address within the subnet's CIDR. This will be a
+     * \"dotted-quad\" style IPv4 address.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ipAddress")
+    String ipAddress;
+
+    /**
+     * The port for primary endpoint of the DB System to listen on.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    /**
+     * The network port on which X Plugin listens for TCP/IP connections. This is the X Plugin equivalent of port.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("portX")
+    Integer portX;
+
+    /**
+     * The network endpoints available for this DB System.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpoints")
+    java.util.List<DbSystemEndpoint> endpoints;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("maintenance")
+    MaintenanceDetails maintenance;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSource.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSource.java
@@ -34,6 +34,10 @@ package com.oracle.bmc.mysql.model;
         name = "BACKUP"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DbSystemSourceFromNone.class,
+        name = "NONE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DbSystemSourceImportFromUrl.class,
         name = "IMPORTURL"
     )

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSourceFromNone.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSourceFromNone.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * A DB System created from no particular external source.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DbSystemSourceFromNone.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbSystemSourceFromNone extends DbSystemSource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbSystemSourceFromNone build() {
+            DbSystemSourceFromNone __instance__ = new DbSystemSourceFromNone();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbSystemSourceFromNone o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DbSystemSourceFromNone() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/DbSystemSummary.java
@@ -297,7 +297,7 @@ public class DbSystemSummary {
     java.util.Date timeUpdated;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -305,7 +305,7 @@ public class DbSystemSummary {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/PemCaCertificate.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/PemCaCertificate.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * The CA certificate in PEM format.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PemCaCertificate.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "certificateType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PemCaCertificate extends CaCertificate {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("contents")
+        private String contents;
+
+        public Builder contents(String contents) {
+            this.contents = contents;
+            this.__explicitlySet__.add("contents");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PemCaCertificate build() {
+            PemCaCertificate __instance__ = new PemCaCertificate(contents);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PemCaCertificate o) {
+            Builder copiedBuilder = contents(o.getContents());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PemCaCertificate(String contents) {
+        super();
+        this.contents = contents;
+    }
+
+    /**
+     * The string containing the CA certificate in PEM format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("contents")
+    String contents;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateBackupDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateBackupDetails.java
@@ -125,7 +125,7 @@ public class UpdateBackupDetails {
     Integer retentionInDays;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -133,7 +133,7 @@ public class UpdateBackupDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateBackupPolicyDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateBackupPolicyDetails.java
@@ -131,6 +131,9 @@ public class UpdateBackupPolicyDetails {
 
     /**
      * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * <p>
+     * Tags defined here will be copied verbatim as tags on the Backup resource created by this BackupPolicy.
+     * <p>
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelDetails.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Details required to update a Channel
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateChannelDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateChannelDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private UpdateChannelSourceDetails source;
+
+        public Builder source(UpdateChannelSourceDetails source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private UpdateChannelTargetDetails target;
+
+        public Builder target(UpdateChannelTargetDetails target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateChannelDetails build() {
+            UpdateChannelDetails __instance__ =
+                    new UpdateChannelDetails(
+                            source,
+                            target,
+                            displayName,
+                            isEnabled,
+                            description,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateChannelDetails o) {
+            Builder copiedBuilder =
+                    source(o.getSource())
+                            .target(o.getTarget())
+                            .displayName(o.getDisplayName())
+                            .isEnabled(o.getIsEnabled())
+                            .description(o.getDescription())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    UpdateChannelSourceDetails source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    UpdateChannelTargetDetails target;
+
+    /**
+     * The user-friendly name for the Channel. It does not have to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Whether the Channel should be enabled or disabled. Enabling a previously
+     * disabled Channel will cause the Channel to be started. Conversely, disabling
+     * a previously enabled Channel will stop the Channel. Both operations are
+     * executed asynchronously.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    /**
+     * User provided description of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelSourceDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelSourceDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the source for the given Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType",
+    defaultImpl = UpdateChannelSourceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateChannelSourceFromMysqlDetails.class,
+        name = "MYSQL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateChannelSourceDetails {}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelSourceFromMysqlDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelSourceFromMysqlDetails.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the source endpoint that is a MySQL Server.
+ * Typically a MySQL Server that is not managed by the MySQL Database Service.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateChannelSourceFromMysqlDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sourceType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateChannelSourceFromMysqlDetails extends UpdateChannelSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("port")
+        private Integer port;
+
+        public Builder port(Integer port) {
+            this.port = port;
+            this.__explicitlySet__.add("port");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("password")
+        private String password;
+
+        public Builder password(String password) {
+            this.password = password;
+            this.__explicitlySet__.add("password");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+        private ChannelSourceMysql.SslMode sslMode;
+
+        public Builder sslMode(ChannelSourceMysql.SslMode sslMode) {
+            this.sslMode = sslMode;
+            this.__explicitlySet__.add("sslMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+        private CaCertificate sslCaCertificate;
+
+        public Builder sslCaCertificate(CaCertificate sslCaCertificate) {
+            this.sslCaCertificate = sslCaCertificate;
+            this.__explicitlySet__.add("sslCaCertificate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateChannelSourceFromMysqlDetails build() {
+            UpdateChannelSourceFromMysqlDetails __instance__ =
+                    new UpdateChannelSourceFromMysqlDetails(
+                            hostname, port, username, password, sslMode, sslCaCertificate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateChannelSourceFromMysqlDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname())
+                            .port(o.getPort())
+                            .username(o.getUsername())
+                            .password(o.getPassword())
+                            .sslMode(o.getSslMode())
+                            .sslCaCertificate(o.getSslCaCertificate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateChannelSourceFromMysqlDetails(
+            String hostname,
+            Integer port,
+            String username,
+            String password,
+            ChannelSourceMysql.SslMode sslMode,
+            CaCertificate sslCaCertificate) {
+        super();
+        this.hostname = hostname;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.sslMode = sslMode;
+        this.sslCaCertificate = sslCaCertificate;
+    }
+
+    /**
+     * The network address of the MySQL instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * The port the source MySQL instance listens on.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("port")
+    Integer port;
+
+    /**
+     * The name of the replication user on the source MySQL instance.
+     * The username has a maximum length of 96 characters. For more information,
+     * please see the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/change-master-to.html)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * The password for the replication user. The password must be
+     * between 8 and 32 characters long, and must contain at least 1
+     * numeric character, 1 lowercase character, 1 uppercase character,
+     * and 1 special (nonalphanumeric) character.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("password")
+    String password;
+
+    /**
+     * The SSL mode of the Channel.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sslMode")
+    ChannelSourceMysql.SslMode sslMode;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sslCaCertificate")
+    CaCertificate sslCaCertificate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelTargetDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelTargetDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the target for the given Channel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = UpdateChannelTargetDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateChannelTargetFromDbSystemDetails.class,
+        name = "DBSYSTEM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateChannelTargetDetails {}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelTargetFromDbSystemDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateChannelTargetFromDbSystemDetails.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * Parameters detailing how to provision the target endpoint that is a DB System.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateChannelTargetFromDbSystemDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateChannelTargetFromDbSystemDetails extends UpdateChannelTargetDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+        private String channelName;
+
+        public Builder channelName(String channelName) {
+            this.channelName = channelName;
+            this.__explicitlySet__.add("channelName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+        private String applierUsername;
+
+        public Builder applierUsername(String applierUsername) {
+            this.applierUsername = applierUsername;
+            this.__explicitlySet__.add("applierUsername");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateChannelTargetFromDbSystemDetails build() {
+            UpdateChannelTargetFromDbSystemDetails __instance__ =
+                    new UpdateChannelTargetFromDbSystemDetails(channelName, applierUsername);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateChannelTargetFromDbSystemDetails o) {
+            Builder copiedBuilder =
+                    channelName(o.getChannelName()).applierUsername(o.getApplierUsername());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateChannelTargetFromDbSystemDetails(String channelName, String applierUsername) {
+        super();
+        this.channelName = channelName;
+        this.applierUsername = applierUsername;
+    }
+
+    /**
+     * The case-insensitive name that identifies the replication channel. Channel names
+     * must follow the rules defined for [MySQL identifiers](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html).
+     * The names of non-Deleted Channels must be unique for each DB System.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("channelName")
+    String channelName;
+
+    /**
+     * The username for the replication applier of the target MySQL DB System.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("applierUsername")
+    String applierUsername;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateConfigurationDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/UpdateConfigurationDetails.java
@@ -108,7 +108,7 @@ public class UpdateConfigurationDetails {
     String displayName;
 
     /**
-     * Simple key-value pair applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
      * Example: `{\"bar-key\": \"value\"}`
      *
      **/
@@ -116,7 +116,7 @@ public class UpdateConfigurationDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
      * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
      *
      **/

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/CreateChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/CreateChannelRequest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateChannelRequest extends com.oracle.bmc.requests.BmcRequest<CreateChannelDetails> {
+
+    /**
+     * The parameters of the request to create the Channel.
+     */
+    private CreateChannelDetails createChannelDetails;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateChannelDetails getBody$() {
+        return createChannelDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateChannelRequest, CreateChannelDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateChannelRequest o) {
+            createChannelDetails(o.getCreateChannelDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateChannelRequest
+         */
+        public CreateChannelRequest build() {
+            CreateChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateChannelDetails body) {
+            createChannelDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/DeleteChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/DeleteChannelRequest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteChannelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Channel [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String channelId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteChannelRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteChannelRequest o) {
+            channelId(o.getChannelId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteChannelRequest
+         */
+        public DeleteChannelRequest build() {
+            DeleteChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/GetChannelRequest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetChannelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Channel [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String channelId;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For conditional requests. In the GET call for a resource, set the
+     * `If-None-Match` header to the value of the ETag from a previous GET (or
+     * POST or PUT) response for that resource. The server will return with
+     * either a 304 Not Modified response if the resource has not changed, or a
+     * 200 OK response with the updated representation.
+     *
+     */
+    private String ifNoneMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetChannelRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetChannelRequest o) {
+            channelId(o.getChannelId());
+            opcRequestId(o.getOpcRequestId());
+            ifNoneMatch(o.getIfNoneMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetChannelRequest
+         */
+        public GetChannelRequest build() {
+            GetChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListBackupsRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListBackupsRequest.java
@@ -45,6 +45,11 @@ public class ListBackupsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String displayName;
 
     /**
+     * Backup creationType
+     */
+    private Backup.CreationType creationType;
+
+    /**
      * The field to sort by. Only one sort order may be provided. Time fields are default ordered as descending.
      *
      */
@@ -183,6 +188,7 @@ public class ListBackupsRequest extends com.oracle.bmc.requests.BmcRequest<java.
             lifecycleState(o.getLifecycleState());
             dbSystemId(o.getDbSystemId());
             displayName(o.getDisplayName());
+            creationType(o.getCreationType());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             limit(o.getLimit());

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListChannelsRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ListChannelsRequest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListChannelsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The DB System [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbSystemId;
+
+    /**
+     * The OCID of the Channel.
+     */
+    private String channelId;
+
+    /**
+     * A filter to return only the resource matching the given display name exactly.
+     */
+    private String displayName;
+
+    /**
+     * The LifecycleState of the Channel.
+     */
+    private Channel.LifecycleState lifecycleState;
+
+    /**
+     * If true, returns only Channels that are enabled. If false, returns only
+     * Channels that are disabled.
+     *
+     */
+    private Boolean isEnabled;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Time fields are default ordered as descending. Display name is default ordered as ascending.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Time fields are default ordered as descending. Display name is default ordered as ascending.
+     *
+     **/
+    public enum SortBy {
+        DisplayName("displayName"),
+        TimeCreated("timeCreated"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use (ASC or DESC).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use (ASC or DESC).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return in a paginated list call. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The value of the `opc-next-page` or `opc-prev-page` response header from
+     * the previous list call. For information about pagination, see [List
+     * Pagination](https://docs.cloud.oracle.com/#API/Concepts/usingapi.htm#List_Pagination).
+     *
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListChannelsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListChannelsRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            dbSystemId(o.getDbSystemId());
+            channelId(o.getChannelId());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
+            isEnabled(o.getIsEnabled());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListChannelsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListChannelsRequest
+         */
+        public ListChannelsRequest build() {
+            ListChannelsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ResetChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ResetChannelRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ResetChannelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Channel [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String channelId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ResetChannelRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResetChannelRequest o) {
+            channelId(o.getChannelId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ResetChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ResetChannelRequest
+         */
+        public ResetChannelRequest build() {
+            ResetChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ResumeChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ResumeChannelRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ResumeChannelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Channel [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String channelId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ResumeChannelRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResumeChannelRequest o) {
+            channelId(o.getChannelId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ResumeChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ResumeChannelRequest
+         */
+        public ResumeChannelRequest build() {
+            ResumeChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/UpdateChannelRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/UpdateChannelRequest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateChannelRequest extends com.oracle.bmc.requests.BmcRequest<UpdateChannelDetails> {
+
+    /**
+     * The Channel [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String channelId;
+
+    /**
+     * The parameters of the request to update the Channel.
+     */
+    private UpdateChannelDetails updateChannelDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the `If-Match` header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateChannelDetails getBody$() {
+        return updateChannelDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateChannelRequest, UpdateChannelDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateChannelRequest o) {
+            channelId(o.getChannelId());
+            updateChannelDetails(o.getUpdateChannelDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateChannelRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateChannelRequest
+         */
+        public UpdateChannelRequest build() {
+            UpdateChannelRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateChannelDetails body) {
+            updateChannelDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/AddAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/AddAnalyticsClusterResponse.java
@@ -13,18 +13,20 @@ public class AddAnalyticsClusterResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateBackupResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateBackupResponse.java
@@ -13,18 +13,20 @@ public class CreateBackupResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateChannelResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateChannelResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned Channel instance.
+     */
+    private Channel channel;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateChannelResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            channel(o.getChannel());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateConfigurationResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateConfigurationResponse.java
@@ -18,18 +18,20 @@ public class CreateConfigurationResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/CreateDbSystemResponse.java
@@ -13,6 +13,7 @@ public class CreateDbSystemResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
@@ -22,14 +23,15 @@ public class CreateDbSystemResponse {
     private String location;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteAnalyticsClusterResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class DeleteAnalyticsClusterResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteBackupResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteBackupResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class DeleteBackupResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteChannelResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteChannelResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteChannelResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteConfigurationResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteConfigurationResponse.java
@@ -12,8 +12,8 @@ import com.oracle.bmc.mysql.model.*;
 public class DeleteConfigurationResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/DeleteDbSystemResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class DeleteDbSystemResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GenerateAnalyticsClusterMemoryEstimateResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GenerateAnalyticsClusterMemoryEstimateResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class GenerateAnalyticsClusterMemoryEstimateResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterMemoryEstimateResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterMemoryEstimateResponse.java
@@ -12,8 +12,8 @@ import com.oracle.bmc.mysql.model.*;
 public class GetAnalyticsClusterMemoryEstimateResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetAnalyticsClusterResponse.java
@@ -13,12 +13,13 @@ public class GetAnalyticsClusterResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetBackupResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetBackupResponse.java
@@ -13,12 +13,13 @@ public class GetBackupResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetChannelResponse.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetChannelResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Channel instance, or null if {@link #isNotModified()} is true.
+     */
+    private Channel channel;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetChannelResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            channel(o.getChannel());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetConfigurationResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetConfigurationResponse.java
@@ -13,12 +13,13 @@ public class GetConfigurationResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetDbSystemResponse.java
@@ -13,12 +13,13 @@ public class GetDbSystemResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetWorkRequestResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/GetWorkRequestResponse.java
@@ -12,18 +12,19 @@ import com.oracle.bmc.mysql.model.*;
 public class GetWorkRequestResponse {
 
     /**
-     * For optimistic concurrency control. See `If-None-Match`.
+     * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Retry the request after the specified number of seconds.
+     * A decimal number representing the number of seconds the client should wait before polling this endpoint again.
      */
     private Integer retryAfter;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListBackupsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListBackupsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListBackupsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListChannelsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListChannelsResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListChannelsResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of ChannelSummary instances.
+     */
+    private java.util.List<ChannelSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListChannelsResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListConfigurationsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListConfigurationsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListConfigurationsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListDbSystemsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListDbSystemsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListDbSystemsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListShapesResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListShapesResponse.java
@@ -12,8 +12,8 @@ import com.oracle.bmc.mysql.model.*;
 public class ListShapesResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListVersionsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListVersionsResponse.java
@@ -12,8 +12,8 @@ import com.oracle.bmc.mysql.model.*;
 public class ListVersionsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestErrorsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListWorkRequestErrorsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestLogsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListWorkRequestLogsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestsResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ListWorkRequestsResponse.java
@@ -12,14 +12,17 @@ import com.oracle.bmc.mysql.model.*;
 public class ListWorkRequestsResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * Opaque token representing the next page of results.
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
      */
     private String opcNextPage;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ResetChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ResetChannelResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ResetChannelResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResetChannelResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartAnalyticsClusterResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class RestartAnalyticsClusterResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/RestartDbSystemResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class RestartDbSystemResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ResumeChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ResumeChannelResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ResumeChannelResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResumeChannelResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartAnalyticsClusterResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class StartAnalyticsClusterResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StartDbSystemResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class StartDbSystemResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopAnalyticsClusterResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class StopAnalyticsClusterResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/StopDbSystemResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class StopDbSystemResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateAnalyticsClusterResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateAnalyticsClusterResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class UpdateAnalyticsClusterResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateBackupResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateBackupResponse.java
@@ -12,8 +12,8 @@ import com.oracle.bmc.mysql.model.*;
 public class UpdateBackupResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateChannelResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateChannelResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateChannelResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateChannelResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateConfigurationResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateConfigurationResponse.java
@@ -13,12 +13,13 @@ public class UpdateConfigurationResponse {
 
     /**
      * For optimistic concurrency control. See `if-match`.
+     *
      */
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateDbSystemResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/UpdateDbSystemResponse.java
@@ -12,14 +12,15 @@ import com.oracle.bmc.mysql.model.*;
 public class UpdateDbSystemResponse {
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
-     * a specific request, please provide the request ID.
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * OCID of the WorkRequest associated with this operation.
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
      */
     private String opcWorkRequestId;
 

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ObjectLifecycleRule.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/ObjectLifecycleRule.java
@@ -140,21 +140,23 @@ public class ObjectLifecycleRule {
 
     /**
      * The target of the object lifecycle policy rule. The values of target can be either \"objects\",
-     * \"multipart-uploads\" or \"previous-object-versions\". This field when declared as \"objects\" is used to specify
-     * archive or delete rule for objects. This field when declared as \"multipart-uploads\" is used to specify
-     * the abort (only) rule for uncommitted multipart-uploads. This field when declared as \"previous-object-versions\"
-     * is used to specify archive or delete rule for previous versions of existing objects.
+     * \"multipart-uploads\" or \"previous-object-versions\".
+     * This field when declared as \"objects\" is used to specify ARCHIVE or DELETE rule for objects.
+     * This field when declared as \"previous-object-versions\" is used to specify ARCHIVE or DELETE
+     * rule for previous versions of existing objects.
+     * This field when declared as \"multipart-uploads\" is used to specify the ABORT (only) rule for
+     * uncommitted multipart-uploads.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("target")
     String target;
 
     /**
-     * The action of the object lifecycle policy rule. Rules using the action 'ARCHIVE' move objects into the
-     * [Archive Storage tier](https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm). Rules using the action
-     * 'DELETE' permanently delete objects from buckets. Rules using 'ABORT' abort the uncommitted multipart-uploads
-     * and permanently delete their parts from buckets. 'ARCHIVE', 'DELETE' and 'ABORT' are the only three supported
-     * actions at this time.
+     * The action of the object lifecycle policy rule.
+     * Rules using the action 'ARCHIVE' move objects from Standard storage tier into the
+     * [Archive Storage tier] (https://docs.cloud.oracle.com/Content/Archive/Concepts/archivestorageoverview.htm).
+     * Rules using the action 'DELETE' permanently delete objects from buckets.
+     * Rules using 'ABORT' abort the uncommitted multipart-uploads and permanently delete their parts from buckets.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("action")

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetObjectRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetObjectRequest.java
@@ -86,32 +86,32 @@ public class GetObjectRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     private String opcSseCustomerKeySha256;
 
     /**
-     * This value will be used in Content-Disposition header of the response.
+     * Specify this query parameter to override the value of the Content-Disposition response header in the GetObject response.
      */
     private String httpResponseContentDisposition;
 
     /**
-     * This value will be used in Cache-Control header of the response.
+     * Specify this query parameter to override the Cache-Control response header in the GetObject response.
      */
     private String httpResponseCacheControl;
 
     /**
-     * This value will be used in Content-Type header of the response.
+     * Specify this query parameter to override the Content-Type response header in the GetObject response.
      */
     private String httpResponseContentType;
 
     /**
-     * This value will be used in Content-Language header of the response.
+     * Specify this query parameter to override the Content-Language response header in the GetObject response.
      */
     private String httpResponseContentLanguage;
 
     /**
-     * This value will be used in Content-Encoding header of the response
+     * Specify this query parameter to override the Content-Encoding response header in the GetObject response.
      */
     private String httpResponseContentEncoding;
 
     /**
-     * This value will be used in Expires header of the response
+     * Specify this query parameter to override the Expires response header in the GetObject response.
      */
     private String httpResponseExpires;
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/GetObjectResponse.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/GetObjectResponse.java
@@ -96,6 +96,44 @@ public class GetObjectResponse {
     private String archivalState;
 
     /**
+     * The current state of the object.
+     **/
+    public enum ArchivalState {
+        Available("AVAILABLE"),
+        Archived("ARCHIVED"),
+        Restoring("RESTORING"),
+        Restored("RESTORED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ArchivalState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ArchivalState v : ArchivalState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ArchivalState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ArchivalState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ArchivalState: " + key);
+        }
+    };
+
+    /**
      * Time that the object is returned to the archived state. This field is only present for restored objects.
      */
     private java.util.Date timeOfArchival;
@@ -106,7 +144,9 @@ public class GetObjectResponse {
     private String versionId;
 
     /**
-     * Time after which object is no longer cacheable, as described in [RFC 2616](https://tools.ietf.org/rfc/rfc2616#section-14.21).
+     * The date and time after which the object is no longer cached by a browser, proxy, or other caching entity. See
+     * [RFC 2616](https://tools.ietf.org/rfc/rfc2616#section-14.21).
+     *
      */
     private java.util.Date expires;
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/HeadObjectResponse.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/responses/HeadObjectResponse.java
@@ -91,6 +91,44 @@ public class HeadObjectResponse {
     private String archivalState;
 
     /**
+     * The current state of the object.
+     **/
+    public enum ArchivalState {
+        Available("AVAILABLE"),
+        Archived("ARCHIVED"),
+        Restoring("RESTORING"),
+        Restored("RESTORED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ArchivalState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ArchivalState v : ArchivalState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ArchivalState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ArchivalState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ArchivalState: " + key);
+        }
+    };
+
+    /**
      * Time that the object is returned to the archived state. This field is only present for restored objects.
      */
     private java.util.Date timeOfArchival;

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.26.0</version>
+    <version>1.27.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.26.0</version>
+  <version>1.27.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for calling Oracle Cloud Infrastructure services in the sa-santiago-1 region

- Support for peer and OSN resources, as well as retry tokens, in the Blockchain Platform service

- Support for getting the availability status of management agents in the Management Agent service

- Support for the on-prem-connector resource type in the Data Safe service

- Support for service channels in the MySQL Database service

- Support for getting the creation type of backups, and for filtering backups by creation type in the MySQL Database service



### Breaking Changes

- Method `public java.util.Map getDefinedTags()` has been removed from EnableDataSafeConfigurationDetails in the Data Safe service

- Method `public java.util.Map getFreeformTags()` has been removed from EnableDataSafeConfigurationDetails in the Data Safe service